### PR TITLE
Add script to test rubyfmt against any Git repo.

### DIFF
--- a/scripts/test_repo.sh
+++ b/scripts/test_repo.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ "$#" -ne 1 ]]
+then
+  >&2 echo "usage: test_repo.sh path_to_repo"
+  exit 64
+fi
+
+repo_path="$1"
+
+for file in $(git --work-tree="$repo_path" --git-dir="$repo_path/.git" ls-files | grep '\.rb$')
+do
+  full_path="$repo_path/$file"
+  errors=$(ruby --disable=gems src/rubyfmt.rb "$full_path" 2>&1)
+  if [[ "$?" -ne 0 ]]
+  then
+    echo "$full_path"
+    echo "$errors"
+  fi
+done


### PR DESCRIPTION
This commit adds a script to run all of the Ruby files in some external Git repo through rubyfmt, only outputting errors and the paths to the files where they were encountered.

The purpose of the script is to make it easier to throw a whole bunch of code at rubyfmt, so that we can more easily find bugs and uncovered edge-cases.

The issues and PRs I've opened so far were found by running a bunch of thoughtbot repos through rubyfmt (so far: gitsh, factory_bot, and an internal Rails app called Hub), and I've found enough stuff that it seemed useful to turn the awful shell one-liner I was using into a properly reusable script.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
