### PR TITLE
Fix lonely operator in Ruby 2.6

### DIFF
--- a/src/rubyfmt.rb
+++ b/src/rubyfmt.rb
@@ -989,7 +989,7 @@ def format_dot(ps, dot)
     ps.emit_dot
   when dot == :"::"
     ps.emit_ident("::")
-  when dot == :"&."
+  when is_lonely_operator(dot)
     ps.emit_lonely_operator
   else
     raise "got unrecognised dot"
@@ -1042,6 +1042,11 @@ end
 
 def is_normal_dot(candidate)
   candidate == :"." || (candidate.is_a?(Array) && candidate[0] == :@period)
+end
+
+def is_lonely_operator(candidate)
+  candidate == :"&." ||
+    (candidate.is_a?(Array) && candidate[0] == :@op && candidate[1] == "&.")
 end
 
 def format_command_call(ps, expression)

--- a/src/rubyfmt.rb
+++ b/src/rubyfmt.rb
@@ -1045,8 +1045,11 @@ def is_normal_dot(candidate)
 end
 
 def is_lonely_operator(candidate)
-  candidate == :"&." ||
-    (candidate.is_a?(Array) && candidate[0] == :@op && candidate[1] == "&.")
+  candidate == :"&." || [
+    candidate.is_a?(Array),
+    candidate[0] == :@op,
+    candidate[1] == "&.",
+  ].all?
 end
 
 def format_command_call(ps, expression)


### PR DESCRIPTION
This commit updates the lonely operator (&.) handling code to recognise both
the Ruby 2.6 representation (`[:@op, "&.", ...]`) and the earlier
representation (`:"&."`).

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
