### PR TITLE
Use `git diff --no-index` over `diff(1)`

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,4 +6,9 @@ for file in `ls fixtures/*_expected.rb` `ls fixtures/$(ruby -v | grep -o '\d\.\d
 do
     time ruby --disable=gems src/rubyfmt.rb `echo $file | sed s/expected/actual/` > /tmp/out.rb
     diff -u /tmp/out.rb $file
+    if [[ $? -ne 0 ]]
+    then
+        echo "got diff"
+        exit 1
+    fi
 done

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,5 +5,5 @@ cp -r fixtures/2.5 fixtures/2.6
 for file in `ls fixtures/*_expected.rb` `ls fixtures/$(ruby -v | grep -o '\d\.\d')/*_expected.rb`
 do
     time ruby --disable=gems src/rubyfmt.rb `echo $file | sed s/expected/actual/` > /tmp/out.rb
-    git diff --no-index /tmp/out.rb $file
+    diff -u /tmp/out.rb $file
 done

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,10 +5,5 @@ cp -r fixtures/2.5 fixtures/2.6
 for file in `ls fixtures/*_expected.rb` `ls fixtures/$(ruby -v | grep -o '\d\.\d')/*_expected.rb`
 do
     time ruby --disable=gems src/rubyfmt.rb `echo $file | sed s/expected/actual/` > /tmp/out.rb
-    diff /tmp/out.rb $file
-    if [[ $? -ne 0 ]]
-    then
-        echo "got diff"
-        exit 1
-    fi
+    git diff --no-index /tmp/out.rb $file
 done


### PR DESCRIPTION
It gives contributors a more familiar interface with the diffs the test
produce.