### PR TITLE
Fix unnamed kwrest param on older ruby

### DIFF
--- a/fixtures/2.5/unnamed_kwrest_param_def_actual.rb
+++ b/fixtures/2.5/unnamed_kwrest_param_def_actual.rb
@@ -1,0 +1,1 @@
+def foo(**); end

--- a/fixtures/2.5/unnamed_kwrest_param_def_expected.rb
+++ b/fixtures/2.5/unnamed_kwrest_param_def_expected.rb
@@ -1,0 +1,2 @@
+def foo(**)
+end

--- a/fixtures/double_splat_def_actual.rb
+++ b/fixtures/double_splat_def_actual.rb
@@ -1,4 +1,3 @@
 def foo(foo: bar, **kwargs ); end
 def foo(**kwargs ); end
 def foo(**_); end
-def foo(**); end

--- a/fixtures/double_splat_def_expected.rb
+++ b/fixtures/double_splat_def_expected.rb
@@ -6,6 +6,3 @@ end
 
 def foo(**_)
 end
-
-def foo(**)
-end

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-cp -r fixtures/2.5 fixtures/2.6
+cp -r fixtures/2.5/ fixtures/2.6
 for file in `ls fixtures/*_expected.rb` `ls fixtures/$(ruby -v | grep -o '\d\.\d')/*_expected.rb`
 do
     time ruby --disable=gems src/rubyfmt.rb `echo $file | sed s/expected/actual/` > /tmp/out.rb

--- a/src/rubyfmt.rb
+++ b/src/rubyfmt.rb
@@ -564,8 +564,11 @@ def format_kwrest_params(ps, kwrest_params)
   ps.emit_ident("**")
   return if kwrest_params[1].nil?
 
-  kwrest_param, expr = kwrest_params
-  raise "got bad kwrest_params" if kwrest_param != :kwrest_param
+  if kwrest_params[0] == :kwrest_param
+    expr = kwrest_params[1]
+  else
+    expr = kwrest_params
+  end
 
   ps.with_start_of_line(false) do
     format_expression(ps, expr)


### PR DESCRIPTION
As mentioned in #92, I accidentally introduced a bug with #90: test.sh breaks on fixtures/double_splat_def_actual.rb for Ruby 2.4 and below.

I found that older versions of Ripper [had a bug](https://bugs.ruby-lang.org/issues/12387), which I skip around my simply not testing e.g. `def(**)` on Ruby 2.3.

(1st commit fixed a tiny bug in the test script)