### PR TITLE
Fix nested commands.

### DIFF
--- a/fixtures/nested_command_actual.rb
+++ b/fixtures/nested_command_actual.rb
@@ -1,0 +1,1 @@
+should eq 1

--- a/fixtures/nested_command_expected.rb
+++ b/fixtures/nested_command_expected.rb
@@ -1,0 +1,1 @@
+should eq(1)

--- a/src/rubyfmt.rb
+++ b/src/rubyfmt.rb
@@ -850,7 +850,7 @@ def format_command(ps, rest)
   end
 
   ps.with_start_of_line(false) do
-    if !args_list.nil? && args_list[0] == :command_call
+    if !args_list.nil? && [:command, :command_call].include?(args_list[0])
       ps.emit_space
     end
 


### PR DESCRIPTION
There was already code to account for a `command` with a single
`command_call` argument. This commit generalises that to handle a `command`
with a single `command` argument too.

Fixes #104 

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
