### PR TITLE
Lint `.sh` files using `shellcheck(1)`

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -5,4 +5,5 @@ if [ $RES != "puts(\"a\")"]
 then
     exit 1
 fi
+./scripts/lint.sh
 ./scripts/test.sh

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -ex
-RES=`echo "puts 'a'" | ruby src/rubyfmt.rb`
-if [ $RES != "puts(\"a\")"]
+
+RES=$(echo "puts 'a'" | ruby src/rubyfmt.rb)
+
+if [ "$RES" != "puts(\"a\")" ]
 then
     exit 1
 fi

--- a/dockerfiles/2.3/Dockerfile
+++ b/dockerfiles/2.3/Dockerfile
@@ -1,6 +1,10 @@
 FROM ruby:2.3
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales bc
+RUN apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        bc \
+        locales \
+        shellcheck
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     locale-gen

--- a/dockerfiles/2.5/Dockerfile
+++ b/dockerfiles/2.5/Dockerfile
@@ -1,6 +1,10 @@
 FROM ruby:2.5
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales bc
+RUN apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        bc \
+        locales \
+        shellcheck
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     locale-gen

--- a/dockerfiles/2.6/Dockerfile
+++ b/dockerfiles/2.6/Dockerfile
@@ -1,6 +1,10 @@
 FROM ruby:2.6
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales bc
+RUN apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        bc \
+        locales \
+        shellcheck
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     locale-gen

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git grep -l "bin\/bash" | xargs shellcheck
+git grep -l "bin\/bash" | xargs shellcheck -f gcc

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+git grep -l "bin\/bash" | xargs shellcheck

--- a/scripts/regen_example.sh
+++ b/scripts/regen_example.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+
 set -ex
-EXPECTED_FILENAME=`echo $1 | sed s/_actual/_expected/`
-bundle exec ruby src/rubyfmt.rb $1 $EXPECTED_FILENAME > $EXPECTED_FILENAME
-git diff $EXPECTED_FILENAME
+
+temp=$(mktemp -q)
+EXPECTED_FILENAME="${1//_actual_/_expected}"
+
+bundle exec ruby src/rubyfmt.rb "$1" "$EXPECTED_FILENAME" > "$temp" && mv "$temp" "$EXPECTED_FILENAME"
+git diff "$EXPECTED_FILENAME"
 echo "do you want to commit [Y/n]"
-read -n1 ans
+read -rn1 ans
 if [ "$ans" == "y" ]
 then
-  git add $EXPECTED_FILENAME
+  git add "$EXPECTED_FILENAME"
 else
-  git checkout $EXPECTED_FILENAME
+  git checkout "$EXPECTED_FILENAME"
 fi

--- a/scripts/regen_example.sh
+++ b/scripts/regen_example.sh
@@ -3,7 +3,8 @@
 set -ex
 
 temp=$(mktemp -q)
-EXPECTED_FILENAME="${1//_actual_/_expected}"
+# shellcheck disable=SC2001
+EXPECTED_FILENAME=$(echo "$1" | sed s/expected/actual/)
 
 bundle exec ruby src/rubyfmt.rb "$1" "$EXPECTED_FILENAME" > "$temp" && mv "$temp" "$EXPECTED_FILENAME"
 git diff "$EXPECTED_FILENAME"

--- a/scripts/rspec_stress_test.sh
+++ b/scripts/rspec_stress_test.sh
@@ -2,9 +2,9 @@
 set -ex
 
 mkdir -p tmp
-if [ -z ${GITHUB_REF+x} ]
+if [ -z "${GITHUB_REF+x}" ]
 then
-echo "not on github"
+    echo "not on github"
 else
     rm -rf tmp/rspec-core
 fi
@@ -15,12 +15,12 @@ git reset --hard
 bundle
 cd ../..
 
-FILES=`find tmp/rspec-core/lib -type f | grep -i '\.rb$'`
+FILES=$(find tmp/rspec-core/lib -type f | grep -i '\.rb$')
 for FN in $FILES
 do
     echo "running rubyfmt on $FN"
-    ruby --disable=gems src/rubyfmt.rb $FN > /tmp/this_one.rb
-    ruby --disable=gems src/rubyfmt.rb /tmp/this_one.rb > $FN
+    ruby --disable=gems src/rubyfmt.rb "$FN" > /tmp/this_one.rb
+    ruby --disable=gems src/rubyfmt.rb /tmp/this_one.rb > "$FN"
 done
 cd tmp/rspec-core
 bundle exec rspec
@@ -30,12 +30,12 @@ cd ../../
 # refmt.rb replaces rubyfmt.rb
 ruby --disable=gems src/rubyfmt.rb src/rubyfmt.rb > tmp/refmt.rb
 
-FILES=`find tmp/rspec-core/lib -type f | grep -i '\.rb$'`
+FILES=$(find tmp/rspec-core/lib -type f | grep -i '\.rb$')
 for FN in $FILES
 do
     echo "running rubyfmt on $FN"
-    ruby --disable=gems tmp/refmt.rb $FN > /tmp/this_one.rb
-    ruby --disable=gems tmp/refmt.rb /tmp/this_one.rb > $FN
+    ruby --disable=gems tmp/refmt.rb "$FN" > /tmp/this_one.rb
+    ruby --disable=gems tmp/refmt.rb /tmp/this_one.rb > "$FN"
 done
 cd tmp/rspec-core
 bundle exec rspec

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,11 +2,12 @@
 set -ex
 
 test_folder() {
-    for file in `ls $1/*_expected.rb`
+    find "$1" -name "*_expected.rb" -type f | while read -r file
     do
-        time ruby --disable=gems src/rubyfmt.rb `echo $file | sed s/expected/actual/` > /tmp/out.rb
-        diff -u /tmp/out.rb $file
-        if [[ $? -ne 0 ]]
+        # shellcheck disable=SC2001
+        time ruby --disable=gems src/rubyfmt.rb "$(echo "$file" | sed s/expected/actual/)" > /tmp/out.rb
+
+        if ! diff -u /tmp/out.rb "$file"
         then
             echo "got diff"
             exit 1
@@ -15,17 +16,17 @@ test_folder() {
 }
 
 f_md5() {
-    if [[ -z `which md5sum` ]]
+    if command -v md5sum >/dev/null
     then
-        md5
-    else
         md5sum
+    else
+        md5
     fi
 }
 
-STRING_LITERALS_EXPECTED=`ruby string_literals_stress_test.rb | f_md5`
-STRING_LITERALS_ACTUAL=`ruby --disable=gems src/rubyfmt.rb string_literals_stress_test.rb | ruby | f_md5`
-if [[ $STRING_LITERALS_EXPECTED != $STRING_LITERALS_ACTUAL ]]
+STRING_LITERALS_EXPECTED=$(ruby string_literals_stress_test.rb | f_md5)
+STRING_LITERALS_ACTUAL=$(ruby --disable=gems src/rubyfmt.rb string_literals_stress_test.rb | ruby | f_md5)
+if [[ "$STRING_LITERALS_EXPECTED" != "$STRING_LITERALS_ACTUAL" ]]
 then
     echo "string literals are broken"
     exit 1
@@ -34,13 +35,13 @@ fi
 test_folder fixtures/
 
 RUBY_VERSION=$(ruby -v | grep -o "[0-9].[0-9]" | head -n 1)
-echo $RUBY_VERSION
+echo "$RUBY_VERSION"
 
-for dir in $(find fixtures -type d -name '2.*')
+find fixtures -type d -name '2.*' | while read -r dir
 do
     fixture_version=$(basename "$dir")
     if [[ $(echo "$fixture_version<=$RUBY_VERSION" | bc -l) -ne 0 ]]
     then
-        test_folder $dir
+        test_folder "$dir"
     fi
 done

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,7 +2,7 @@
 set -ex
 
 test_folder() {
-    find "$1" -name "*_expected.rb" -type f | while read -r file
+    find "$1" -name "*_expected.rb" -maxdepth 1 | while read -r file
     do
         # shellcheck disable=SC2001
         time ruby --disable=gems src/rubyfmt.rb "$(echo "$file" | sed s/expected/actual/)" > /tmp/out.rb
@@ -37,7 +37,7 @@ test_folder fixtures/
 RUBY_VERSION=$(ruby -v | grep -o "[0-9].[0-9]" | head -n 1)
 echo "$RUBY_VERSION"
 
-find fixtures -type d -name '2.*' | while read -r dir
+find fixtures/ -type d -name "2.*" | while read -r dir
 do
     fixture_version=$(basename "$dir")
     if [[ $(echo "$fixture_version<=$RUBY_VERSION" | bc -l) -ne 0 ]]

--- a/scripts/test_repo.sh
+++ b/scripts/test_repo.sh
@@ -12,6 +12,7 @@ for file in $(git --work-tree="$repo_path" --git-dir="$repo_path/.git" ls-files 
 do
   full_path="$repo_path/$file"
   errors=$(ruby --disable=gems src/rubyfmt.rb "$full_path" 2>&1)
+  # shellcheck disable=SC2181
   if [[ "$?" -ne 0 ]]
   then
     echo "$full_path"


### PR DESCRIPTION
References #88

Changes:
- Add `shellcheck(1)` linting to Docker images.
- Fix linter warnings from `shellcheck(1)`. The following warnings were
  fixed:

  https://shellcheck.com/wiki/SC1009
  https://shellcheck.com/wiki/SC1020 
  https://shellcheck.com/wiki/SC1072
  https://shellcheck.com/wiki/SC1073 
  https://shellcheck.com/wiki/SC2001
  https://shellcheck.com/wiki/SC2006 
  https://shellcheck.com/wiki/SC2044
  https://shellcheck.com/wiki/SC2045 
  https://shellcheck.com/wiki/SC2046
  https://shellcheck.com/wiki/SC2053 
  https://shellcheck.com/wiki/SC2086
  https://shellcheck.com/wiki/SC2094 
  https://shellcheck.com/wiki/SC2162
  https://shellcheck.com/wiki/SC2181 
  https://shellcheck.com/wiki/SC2230