### PR TITLE
Use eval for string escaping.

### DIFF
--- a/benchmarks/Gemfile
+++ b/benchmarks/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# gem "rails"
+gem "benchmark-ips"

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    benchmark-ips (2.7.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  benchmark-ips
+
+BUNDLED WITH
+   2.0.1

--- a/benchmarks/string_escaping/bench.rb
+++ b/benchmarks/string_escaping/bench.rb
@@ -1,0 +1,33 @@
+require 'benchmark/ips'
+require 'ripper'
+
+$: << File.dirname(__FILE__)
+
+require 'parser_eval'
+require 'parser_munging'
+
+f1 = File.read("#{File.dirname(__FILE__)}/string_literals_stress_test.rb")
+f2 = File.read("#{File.dirname(__FILE__)}/rspec_core_notifications_actual.rb")
+
+Benchmark.ips do |x|
+  # Configure the number of seconds used during
+  # the warmup phase (default 2) and calculation phase (default 5)
+  x.config(:time => 10, :warmup => 4)
+
+  # Typical mode, runs the block as many times as it can
+  x.report("munging") {
+    ParserMunging.new(f1).parse
+  }
+
+  x.report("eval") {
+    ParserEval.new(f1).parse
+  }
+
+  x.report("munging 2") {
+    ParserMunging.new(f2).parse
+  }
+
+  x.report("eval 2") {
+    ParserEval.new(f2).parse
+  }
+end

--- a/benchmarks/string_escaping/parser_eval.rb
+++ b/benchmarks/string_escaping/parser_eval.rb
@@ -1,0 +1,125 @@
+class ParserEval < Ripper::SexpBuilderPP
+  ARRAY_SYMBOLS = {
+    qsymbols: '%i',
+    qwords: '%w',
+    symbols: '%I',
+    words: '%W'
+  }.freeze
+
+  def self.is_percent_array?(rest)
+    return false if rest.nil?
+    return false if rest[0].nil?
+    ARRAY_SYMBOLS.include?(rest[0][0])
+  end
+
+  def self.percent_symbol_for(rest)
+    ARRAY_SYMBOLS[rest[0][0]]
+  end
+
+  def initialize(file_data)
+    super(file_data)
+    @file_lines = file_data.split("\n")
+    # heredoc stack is the stack of identified heredocs
+    @heredoc_stack = []
+
+    # next_heredoc_stack is the type identifiers of the next heredocs, that
+    # we haven't emitted yet
+    @next_heredoc_stack = []
+    @heredoc_regex = /(<<[-~]?)(.*$)/
+    @next_comment_delete = []
+    @comments_delete = []
+    @regexp_stack = []
+    @string_stack = []
+  end
+
+  attr_reader :comments_delete
+
+  private
+
+  ARRAY_SYMBOLS.each do |event, symbol|
+    define_method(:"on_#{event}_new") do
+      [event, [], [lineno, column]]
+    end
+
+    define_method(:"on_#{event}_add") do |parts, part|
+      parts.tap do |node|
+        node[1] << part
+      end
+    end
+  end
+
+  def on_heredoc_beg(*args, &blk)
+    heredoc_parts = @heredoc_regex.match(args[0]).captures
+    raise "bad heredoc" unless heredoc_parts.select { |x| x != nil }.count == 2
+    @next_heredoc_stack.push(heredoc_parts)
+    @next_comment_delete.push(lineno)
+    super
+  end
+
+  def on_heredoc_end(*args, &blk)
+    @heredoc_stack.push(@next_heredoc_stack.pop)
+    start_com = @next_comment_delete.pop
+    end_com = lineno
+    @comments_delete.push([start_com, end_com])
+    super
+  end
+
+  def on_string_literal(*args, &blk)
+    if @heredoc_stack.last
+      heredoc_parts = @heredoc_stack.pop
+      args.insert(0, [:heredoc_string_literal, heredoc_parts])
+    else
+      end_delim = @string_stack.pop
+      start_delim = @string_stack.pop
+
+      if start_delim != "\""
+        reject_embexpr = start_delim == "'" || start_delim.start_with?("%q")
+
+        (args[0][1..-1] || []).each do |part|
+          next if part.nil?
+          case part[0]
+          when :@tstring_content
+            part[1] = eval("#{start_delim}#{part[1]}#{end_delim}").inspect[1..-2]
+          when :string_embexpr
+            if reject_embexpr
+              raise "got string_embexpr in a #{start_delim}...#{end_delim} string"
+            end
+          else
+            raise "got #{part[0]} in a #{start_delim}...#{end_delim} string"
+          end
+        end
+      end
+    end
+    super
+  end
+
+  def on_lambda(*args, &blk)
+    terminator = @file_lines[lineno-1]
+    if terminator.include?("}")
+      args.insert(1, :curly)
+    else
+      args.insert(1, :do)
+    end
+
+    super
+  end
+
+  def on_tstring_beg(*args, &blk)
+    @string_stack << args[0]
+    super
+  end
+
+  def on_tstring_end(*args, &blk)
+    @string_stack << args[0]
+    super
+  end
+
+  def on_regexp_beg(re_part)
+    @regexp_stack << re_part
+  end
+
+  def on_regexp_literal(*args)
+    args[1] << @regexp_stack.pop
+    super(*args)
+  end
+end

--- a/benchmarks/string_escaping/parser_munging.rb
+++ b/benchmarks/string_escaping/parser_munging.rb
@@ -1,0 +1,219 @@
+class ParserMunging < Ripper::SexpBuilderPP
+  ARRAY_SYMBOLS = {
+    qsymbols: '%i',
+    qwords: '%w',
+    symbols: '%I',
+    words: '%W'
+  }.freeze
+
+  def self.is_percent_array?(rest)
+    return false if rest.nil?
+    return false if rest[0].nil?
+    ARRAY_SYMBOLS.include?(rest[0][0])
+  end
+
+  def self.percent_symbol_for(rest)
+    ARRAY_SYMBOLS[rest[0][0]]
+  end
+
+  def initialize(file_data)
+    super(file_data)
+    @file_lines = file_data.split("\n")
+    # heredoc stack is the stack of identified heredocs
+    @heredoc_stack = []
+
+    # next_heredoc_stack is the type identifiers of the next heredocs, that
+    # we haven't emitted yet
+    @next_heredoc_stack = []
+    @heredoc_regex = /(<<[-~]?)(.*$)/
+    @next_comment_delete = []
+    @comments_delete = []
+    @regexp_stack = []
+    @string_stack = []
+  end
+
+  attr_reader :comments_delete
+
+  private
+
+  ARRAY_SYMBOLS.each do |event, symbol|
+    define_method(:"on_#{event}_new") do
+      [event, [], [lineno, column]]
+    end
+
+    define_method(:"on_#{event}_add") do |parts, part|
+      parts.tap do |node|
+        node[1] << part
+      end
+    end
+  end
+
+  def on_heredoc_beg(*args, &blk)
+    heredoc_parts = @heredoc_regex.match(args[0]).captures
+    raise "bad heredoc" unless heredoc_parts.select { |x| x != nil }.count == 2
+    @next_heredoc_stack.push(heredoc_parts)
+    @next_comment_delete.push(lineno)
+    super
+  end
+
+  def on_heredoc_end(*args, &blk)
+    @heredoc_stack.push(@next_heredoc_stack.pop)
+    start_com = @next_comment_delete.pop
+    end_com = lineno
+    @comments_delete.push([start_com, end_com])
+    super
+  end
+
+
+  FOUR_SLASHES_IN_TSTRING = "\\\\\\\\"
+  LITERAL_DOUBLE_QUOTE_IN_TSTRING = "\""
+  TWO_SLASHES_IN_TSTRING = "\\\\"
+  ONE_SLASH_IN_TSTRING = "\\"
+
+  # Rubyfmt renders all string literals as double quotes for consistency's sake
+  # this method fixes up individual tstring content items to ensure that they
+  # represent the same string literal once reformatted. This method is not
+  # called on string literals that were already surrounded by double quotes,
+  # and so this formatting only applies to tstring_contents from strings that
+  # need to be manipulated to correctly reform as a double quoted string
+  #
+  def fixup_tstring_content_for_double_quotes(string, is_single_quote:, delimiter:)
+    # cleanup escaped delimiters
+    string.gsub!("#{ONE_SLASH_IN_TSTRING}#{delimiter}", "#{delimiter}")
+
+    # Given '\\a' we get a tstring content with "\\\\a", and we need to keep
+    # it the same. However, the next substitution line will replace "\\\\a"
+    # with "\\\\\\\\\\a", so we insert "__RUBYFMT_SAFE_QUAD" as a placeholder
+    # to sub back with quad slashes.
+    string.gsub!(TWO_SLASHES_IN_TSTRING, "__RUBYFMT_SAFE_QUAD")
+
+    # Given '\a' we get a tstring content with "\\a", and we need to replace it
+    # with literally "\\\\a", which needs four escaped slashes
+    string.gsub!(
+      ONE_SLASH_IN_TSTRING,
+      FOUR_SLASHES_IN_TSTRING,
+    )
+
+    if is_single_quote
+      # Given '"', we get a tstring content with "\"", however we need to
+      # literally serialize that slash back out, so we replace it with "\\\""
+      string.gsub!(
+        LITERAL_DOUBLE_QUOTE_IN_TSTRING,
+        "#{ONE_SLASH_IN_TSTRING}#{LITERAL_DOUBLE_QUOTE_IN_TSTRING}",
+      )
+    else
+      # deals with e.g. %^\"^ which should format to "\"" (that is, a
+      # literal quote)
+      string.gsub!(
+        "#{TWO_SLASHES_IN_TSTRING}#{LITERAL_DOUBLE_QUOTE_IN_TSTRING}",
+        "__RUBYFMT_PLEASE_SERIALIZE_THIS_TO_A_LITERAL_DOUBLE_QUOTE",
+      )
+
+      # deals with e.g. %^\\"^ which should format to "\\\"" (that is, an
+      # escaped double quote)
+      string.gsub!(
+        "__RUBYFMT_SAFE_QUAD\"",
+        "__RUBYFMT_PLEASE_SERIALIZE_THIS_TO_AN_ESACPED_DOUBLE_QUOTE"
+      )
+
+      # deals with bare double quotes, replacing them with \"
+      string.gsub!(
+        LITERAL_DOUBLE_QUOTE_IN_TSTRING,
+        "#{ONE_SLASH_IN_TSTRING}#{LITERAL_DOUBLE_QUOTE_IN_TSTRING}",
+      )
+
+      # undoes the literal double quote replacement
+      string.gsub!(
+        "__RUBYFMT_PLEASE_SERIALIZE_THIS_TO_A_LITERAL_DOUBLE_QUOTE",
+        "#{ONE_SLASH_IN_TSTRING}#{LITERAL_DOUBLE_QUOTE_IN_TSTRING}",
+      )
+
+      # undoes the escaped double quote replacement
+      string.gsub!(
+        "__RUBYFMT_PLEASE_SERIALIZE_THIS_TO_AN_ESACPED_DOUBLE_QUOTE",
+        "#{FOUR_SLASHES_IN_TSTRING}#{ONE_SLASH_IN_TSTRING}#{LITERAL_DOUBLE_QUOTE_IN_TSTRING}",
+      )
+    end
+
+    # Fixup the quad safes
+    string.gsub!(
+      "__RUBYFMT_SAFE_QUAD",
+      FOUR_SLASHES_IN_TSTRING,
+    )
+
+    # protect against escaped interpolation
+    string.gsub!("\#{", "\\\#{")
+    string.gsub!("\#@", "\\\#@")
+  end
+
+  def on_string_literal(*args, &blk)
+    if @heredoc_stack.last
+      heredoc_parts = @heredoc_stack.pop
+      args.insert(0, [:heredoc_string_literal, heredoc_parts])
+    else
+      next_string_end_delim = [@file_lines[lineno-1].bytes[column-1]].pack("c*")
+      if next_string_end_delim == "'"
+        (args || []).each do |part|
+          next if part[1].nil?
+          case part[1][0]
+          when :@tstring_content
+            fixup_tstring_content_for_double_quotes(
+              part[1][1],
+              is_single_quote: true,
+              delimiter: next_string_end_delim,
+            )
+          else
+            raise "got non tstring content in single string"
+          end
+        end
+      elsif /[^a-zA-Z0-9]/ === next_string_end_delim && next_string_end_delim != "\""
+        next_string_start_delim = @string_stack.pop
+        is_single_q_string = next_string_start_delim.start_with?("%q")
+        (args[0][1..-1] || []).each do |part|
+          next if part.nil?
+          case part[0]
+          when :@tstring_content
+            fixup_tstring_content_for_double_quotes(
+              part[1],
+              is_single_quote: is_single_q_string,
+              delimiter: next_string_end_delim,
+            )
+          when :string_embexpr
+            # this is fine
+          else
+            raise "got something bad in %q string"
+          end
+        end
+      elsif next_string_end_delim == "\""
+      else
+        raise "what even is this string type #{next_string_end_delim}"
+      end
+    end
+    super
+  end
+
+  def on_lambda(*args, &blk)
+    terminator = @file_lines[lineno-1]
+    if terminator.include?("}")
+      args.insert(1, :curly)
+    else
+      args.insert(1, :do)
+    end
+
+    super
+  end
+
+  def on_tstring_beg(*args, &blk)
+    @string_stack << args[0]
+    super
+  end
+
+  def on_regexp_beg(re_part)
+    @regexp_stack << re_part
+  end
+
+  def on_regexp_literal(*args)
+    args[1] << @regexp_stack.pop
+    super(*args)
+  end
+end

--- a/benchmarks/string_escaping/rspec_core_notifications_actual.rb
+++ b/benchmarks/string_escaping/rspec_core_notifications_actual.rb
@@ -1,0 +1,521 @@
+RSpec::Support.require_rspec_core "formatters/console_codes"
+RSpec::Support.require_rspec_core "formatters/exception_presenter"
+RSpec::Support.require_rspec_core "formatters/helpers"
+RSpec::Support.require_rspec_core "shell_escape"
+
+module RSpec::Core
+  # Notifications are value objects passed to formatters to provide them
+  # with information about a particular event of interest.
+  module Notifications
+    # @private
+    module NullColorizer
+      module_function
+
+      def wrap(line, _code_or_symbol)
+        line
+      end
+    end
+
+    # The `StartNotification` represents a notification sent by the reporter
+    # when the suite is started. It contains the expected amount of examples
+    # to be executed, and the load time of RSpec.
+    #
+    # @attr count [Fixnum] the number counted
+    # @attr load_time [Float] the number of seconds taken to boot RSpec
+    #                         and load the spec files
+    StartNotification = Struct.new(:count, :load_time)
+
+    # The `ExampleNotification` represents notifications sent by the reporter
+    # which contain information about the current (or soon to be) example.
+    # It is used by formatters to access information about that example.
+    #
+    # @example
+    #   def example_started(notification)
+    #     puts "Hey I started #{notification.example.description}"
+    #   end
+    #
+    # @attr example [RSpec::Core::Example] the current example
+    ExampleNotification = Struct.new(:example)
+    class ExampleNotification
+      # @private
+      def self.for(example)
+        execution_result = example.execution_result
+
+        return SkippedExampleNotification.new(example) if execution_result.example_skipped?
+        return new(example) unless execution_result.status == :pending || execution_result.status == :failed
+
+        klass = if execution_result.pending_fixed?
+                  PendingExampleFixedNotification
+                elsif execution_result.status == :pending
+                  PendingExampleFailedAsExpectedNotification
+                else
+                  FailedExampleNotification
+                end
+
+        klass.new(example)
+      end
+
+      private_class_method :new
+    end
+
+    # The `ExamplesNotification` represents notifications sent by the reporter
+    # which contain information about the suites examples.
+    #
+    # @example
+    #   def stop(notification)
+    #     puts "Hey I ran #{notification.examples.size}"
+    #   end
+    #
+    class ExamplesNotification
+      def initialize(reporter)
+        @reporter = reporter
+      end
+
+      # @return [Array<RSpec::Core::Example>] list of examples
+      def examples
+        @reporter.examples
+      end
+
+      # @return [Array<RSpec::Core::Example>] list of failed examples
+      def failed_examples
+        @reporter.failed_examples
+      end
+
+      # @return [Array<RSpec::Core::Example>] list of pending examples
+      def pending_examples
+        @reporter.pending_examples
+      end
+
+      # @return [Array<RSpec::Core::Notifications::ExampleNotification>]
+      #         returns examples as notifications
+      def notifications
+        @notifications ||= format_examples(examples)
+      end
+
+      # @return [Array<RSpec::Core::Notifications::FailedExampleNotification>]
+      #         returns failed examples as notifications
+      def failure_notifications
+        @failed_notifications ||= format_examples(failed_examples)
+      end
+
+      # @return [Array<RSpec::Core::Notifications::SkippedExampleNotification,
+      #                 RSpec::Core::Notifications::PendingExampleFailedAsExpectedNotification>]
+      #         returns pending examples as notifications
+      def pending_notifications
+        @pending_notifications ||= format_examples(pending_examples)
+      end
+
+      # @return [String] The list of failed examples, fully formatted in the way
+      #   that RSpec's built-in formatters emit.
+      def fully_formatted_failed_examples(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        formatted = "\nFailures:\n"
+
+        failure_notifications.each_with_index do |failure, index|
+          formatted += failure.fully_formatted(index.next, colorizer)
+        end
+
+        formatted
+      end
+
+      # @return [String] The list of pending examples, fully formatted in the
+      #   way that RSpec's built-in formatters emit.
+      def fully_formatted_pending_examples(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        formatted = "\nPending: (Failures listed here are expected and do not affect your suite's status)\n".dup
+
+        pending_notifications.each_with_index do |notification, index|
+          formatted << notification.fully_formatted(index.next, colorizer)
+        end
+
+        formatted
+      end
+
+    private
+
+      def format_examples(examples)
+        examples.map do |example|
+          ExampleNotification.for(example)
+        end
+      end
+    end
+
+    # The `FailedExampleNotification` extends `ExampleNotification` with
+    # things useful for examples that have failure info -- typically a
+    # failed or pending spec.
+    #
+    # @example
+    #   def example_failed(notification)
+    #     puts "Hey I failed :("
+    #     puts "Here's my stack trace"
+    #     puts notification.exception.backtrace.join("\n")
+    #   end
+    #
+    # @attr [RSpec::Core::Example] example the current example
+    # @see ExampleNotification
+    class FailedExampleNotification < ExampleNotification
+      public_class_method :new
+
+      # @return [Exception] The example failure
+      def exception
+        @exception_presenter.exception
+      end
+
+      # @return [String] The example description
+      def description
+        @exception_presenter.description
+      end
+
+      # Returns the message generated for this failure line by line.
+      #
+      # @return [Array<String>] The example failure message
+      def message_lines
+        @exception_presenter.message_lines
+      end
+
+      # Returns the message generated for this failure colorized line by line.
+      #
+      # @param colorizer [#wrap] An object to colorize the message_lines by
+      # @return [Array<String>] The example failure message colorized
+      def colorized_message_lines(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        @exception_presenter.colorized_message_lines(colorizer)
+      end
+
+      # Returns the failures formatted backtrace.
+      #
+      # @return [Array<String>] the examples backtrace lines
+      def formatted_backtrace
+        @exception_presenter.formatted_backtrace
+      end
+
+      # Returns the failures colorized formatted backtrace.
+      #
+      # @param colorizer [#wrap] An object to colorize the message_lines by
+      # @return [Array<String>] the examples colorized backtrace lines
+      def colorized_formatted_backtrace(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        @exception_presenter.colorized_formatted_backtrace(colorizer)
+      end
+
+      # @return [String] The failure information fully formatted in the way that
+      #   RSpec's built-in formatters emit.
+      def fully_formatted(failure_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        @exception_presenter.fully_formatted(failure_number, colorizer)
+      end
+
+      # @return [Array<string>] The failure information fully formatted in the way that
+      #   RSpec's built-in formatters emit, split by line.
+      def fully_formatted_lines(failure_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        @exception_presenter.fully_formatted_lines(failure_number, colorizer)
+      end
+
+    private
+
+      def initialize(example, exception_presenter=Formatters::ExceptionPresenter::Factory.new(example).build)
+        @exception_presenter = exception_presenter
+        super(example)
+      end
+    end
+
+    # @deprecated Use {FailedExampleNotification} instead.
+    class PendingExampleFixedNotification < FailedExampleNotification; end
+
+    # @deprecated Use {FailedExampleNotification} instead.
+    class PendingExampleFailedAsExpectedNotification < FailedExampleNotification; end
+
+    # The `SkippedExampleNotification` extends `ExampleNotification` with
+    # things useful for specs that are skipped.
+    #
+    # @attr [RSpec::Core::Example] example the current example
+    # @see ExampleNotification
+    class SkippedExampleNotification < ExampleNotification
+      public_class_method :new
+
+      # @return [String] The pending detail fully formatted in the way that
+      #   RSpec's built-in formatters emit.
+      def fully_formatted(pending_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        formatted_caller = RSpec.configuration.backtrace_formatter.backtrace_line(example.location)
+
+        [
+          colorizer.wrap("\n  #{pending_number}) #{example.full_description}", :pending),
+          "\n     ",
+          Formatters::ExceptionPresenter::PENDING_DETAIL_FORMATTER.call(example, colorizer),
+          "\n",
+          colorizer.wrap("     # #{formatted_caller}\n", :detail)
+        ].join("")
+      end
+    end
+
+    # The `GroupNotification` represents notifications sent by the reporter
+    # which contain information about the currently running (or soon to be)
+    # example group. It is used by formatters to access information about that
+    # group.
+    #
+    # @example
+    #   def example_group_started(notification)
+    #     puts "Hey I started #{notification.group.description}"
+    #   end
+    # @attr group [RSpec::Core::ExampleGroup] the current group
+    GroupNotification = Struct.new(:group)
+
+    # The `MessageNotification` encapsulates generic messages that the reporter
+    # sends to formatters.
+    #
+    # @attr message [String] the message
+    MessageNotification = Struct.new(:message)
+
+    # The `SeedNotification` holds the seed used to randomize examples and
+    # whether that seed has been used or not.
+    #
+    # @attr seed [Fixnum] the seed used to randomize ordering
+    # @attr used [Boolean] whether the seed has been used or not
+    SeedNotification = Struct.new(:seed, :used)
+    class SeedNotification
+      # @api
+      # @return [Boolean] has the seed been used?
+      def seed_used?
+        !!used
+      end
+      private :used
+
+      # @return [String] The seed information fully formatted in the way that
+      #   RSpec's built-in formatters emit.
+      def fully_formatted
+        "\nRandomized with seed #{seed}\n"
+      end
+    end
+
+    # The `SummaryNotification` holds information about the results of running
+    # a test suite. It is used by formatters to provide information at the end
+    # of the test run.
+    #
+    # @attr duration [Float] the time taken (in seconds) to run the suite
+    # @attr examples [Array<RSpec::Core::Example>] the examples run
+    # @attr failed_examples [Array<RSpec::Core::Example>] the failed examples
+    # @attr pending_examples [Array<RSpec::Core::Example>] the pending examples
+    # @attr load_time [Float] the number of seconds taken to boot RSpec
+    #                         and load the spec files
+    # @attr errors_outside_of_examples_count [Integer] the number of errors that
+    #                                                  have occurred processing
+    #                                                  the spec suite
+    SummaryNotification = Struct.new(:duration, :examples, :failed_examples,
+                                     :pending_examples, :load_time,
+                                     :errors_outside_of_examples_count)
+    class SummaryNotification
+      # @api
+      # @return [Fixnum] the number of examples run
+      def example_count
+        @example_count ||= examples.size
+      end
+
+      # @api
+      # @return [Fixnum] the number of failed examples
+      def failure_count
+        @failure_count ||= failed_examples.size
+      end
+
+      # @api
+      # @return [Fixnum] the number of pending examples
+      def pending_count
+        @pending_count ||= pending_examples.size
+      end
+
+      # @api
+      # @return [String] A line summarising the result totals of the spec run.
+      def totals_line
+        summary = Formatters::Helpers.pluralize(example_count, "example") +
+          ", " + Formatters::Helpers.pluralize(failure_count, "failure")
+        summary += ", #{pending_count} pending" if pending_count > 0
+        if errors_outside_of_examples_count > 0
+          summary += (
+            ", " +
+            Formatters::Helpers.pluralize(errors_outside_of_examples_count, "error") +
+            " occurred outside of examples"
+          )
+        end
+        summary
+      end
+
+      # @api public
+      #
+      # Wraps the results line with colors based on the configured
+      # colors for failure, pending, and success. Defaults to red,
+      # yellow, green accordingly.
+      #
+      # @param colorizer [#wrap] An object which supports wrapping text with
+      #                          specific colors.
+      # @return [String] A colorized results line.
+      def colorized_totals_line(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        if failure_count > 0 || errors_outside_of_examples_count > 0
+          colorizer.wrap(totals_line, RSpec.configuration.failure_color)
+        elsif pending_count > 0
+          colorizer.wrap(totals_line, RSpec.configuration.pending_color)
+        else
+          colorizer.wrap(totals_line, RSpec.configuration.success_color)
+        end
+      end
+
+      # @api public
+      #
+      # Formats failures into a rerunable command format.
+      #
+      # @param colorizer [#wrap] An object which supports wrapping text with
+      #                          specific colors.
+      # @return [String] A colorized summary line.
+      def colorized_rerun_commands(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        "\nFailed examples:\n\n" +
+        failed_examples.map do |example|
+          colorizer.wrap("rspec #{rerun_argument_for(example)}", RSpec.configuration.failure_color) + " " +
+          colorizer.wrap("# #{example.full_description}",   RSpec.configuration.detail_color)
+        end.join("\n")
+      end
+
+      # @return [String] a formatted version of the time it took to run the
+      #   suite
+      def formatted_duration
+        Formatters::Helpers.format_duration(duration)
+      end
+
+      # @return [String] a formatted version of the time it took to boot RSpec
+      #   and load the spec files
+      def formatted_load_time
+        Formatters::Helpers.format_duration(load_time)
+      end
+
+      # @return [String] The summary information fully formatted in the way that
+      #   RSpec's built-in formatters emit.
+      def fully_formatted(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        formatted = "\nFinished in #{formatted_duration} " \
+                    "(files took #{formatted_load_time} to load)\n" \
+                    "#{colorized_totals_line(colorizer)}\n"
+
+        unless failed_examples.empty?
+          formatted += (colorized_rerun_commands(colorizer) + "\n")
+        end
+
+        formatted
+      end
+
+    private
+
+      include RSpec::Core::ShellEscape
+
+      def rerun_argument_for(example)
+        location = example.location_rerun_argument
+        return location unless duplicate_rerun_locations.include?(location)
+        conditionally_quote(example.id)
+      end
+
+      def duplicate_rerun_locations
+        @duplicate_rerun_locations ||= begin
+          locations = RSpec.world.all_examples.map(&:location_rerun_argument)
+
+          Set.new.tap do |s|
+            locations.group_by { |l| l }.each do |l, ls|
+              s << l if ls.count > 1
+            end
+          end
+        end
+      end
+    end
+
+    # The `ProfileNotification` holds information about the results of running a
+    # test suite when profiling is enabled. It is used by formatters to provide
+    # information at the end of the test run for profiling information.
+    #
+    # @attr duration [Float] the time taken (in seconds) to run the suite
+    # @attr examples [Array<RSpec::Core::Example>] the examples run
+    # @attr number_of_examples [Fixnum] the number of examples to profile
+    # @attr example_groups [Array<RSpec::Core::Profiler>] example groups run
+    class ProfileNotification
+      def initialize(duration, examples, number_of_examples, example_groups)
+        @duration = duration
+        @examples = examples
+        @number_of_examples = number_of_examples
+        @example_groups = example_groups
+      end
+      attr_reader :duration, :examples, :number_of_examples
+
+      # @return [Array<RSpec::Core::Example>] the slowest examples
+      def slowest_examples
+        @slowest_examples ||=
+          examples.sort_by do |example|
+            -example.execution_result.run_time
+          end.first(number_of_examples)
+      end
+
+      # @return [Float] the time taken (in seconds) to run the slowest examples
+      def slow_duration
+        @slow_duration ||=
+          slowest_examples.inject(0.0) do |i, e|
+            i + e.execution_result.run_time
+          end
+      end
+
+      # @return [String] the percentage of total time taken
+      def percentage
+        @percentage ||=
+          begin
+            time_taken = slow_duration / duration
+            '%.1f' % ((time_taken.nan? ? 0.0 : time_taken) * 100)
+          end
+      end
+
+      # @return [Array<RSpec::Core::Example>] the slowest example groups
+      def slowest_groups
+        @slowest_groups ||= calculate_slowest_groups
+      end
+
+    private
+
+      def calculate_slowest_groups
+        # stop if we've only one example group
+        return {} if @example_groups.keys.length <= 1
+
+        @example_groups.each_value do |hash|
+          hash[:average] = hash[:total_time].to_f / hash[:count]
+        end
+
+        groups = @example_groups.sort_by { |_, hash| -hash[:average] }.first(number_of_examples)
+        groups.map { |group, data| [group.location, data] }
+      end
+    end
+
+    # The `DeprecationNotification` is issued by the reporter when a deprecated
+    # part of RSpec is encountered. It represents information about the
+    # deprecated call site.
+    #
+    # @attr message [String] A custom message about the deprecation
+    # @attr deprecated [String] A custom message about the deprecation (alias of
+    #   message)
+    # @attr replacement [String] An optional replacement for the deprecation
+    # @attr call_site [String] An optional call site from which the deprecation
+    #   was issued
+    DeprecationNotification = Struct.new(:deprecated, :message, :replacement, :call_site)
+    class DeprecationNotification
+      private_class_method :new
+
+      # @api
+      # Convenience way to initialize the notification
+      def self.from_hash(data)
+        new data[:deprecated], data[:message], data[:replacement], data[:call_site]
+      end
+    end
+
+    # `NullNotification` represents a placeholder value for notifications that
+    # currently require no information, but we may wish to extend in future.
+    class NullNotification
+    end
+
+    # `CustomNotification` is used when sending custom events to formatters /
+    # other registered listeners, it creates attributes based on supplied hash
+    # of options.
+    class CustomNotification < Struct
+      # @param options [Hash] A hash of method / value pairs to create on this notification
+      # @return [CustomNotification]
+      #
+      # Build a custom notification based on the supplied option key / values.
+      def self.for(options={})
+        return NullNotification if options.keys.empty?
+        new(*options.keys).new(*options.values)
+      end
+    end
+  end
+end

--- a/benchmarks/string_escaping/string_literals_stress_test.rb
+++ b/benchmarks/string_escaping/string_literals_stress_test.rb
@@ -1,0 +1,1073 @@
+puts %Q("")
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %Q("")
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>
+puts %^_^
+puts %^\"^
+puts %^\\"^
+puts %(\\"\))
+puts '\\"'
+puts '\"'
+puts '\''
+puts '\\"'
+puts '\\\\"'
+puts '"'
+puts '\"'
+puts "\""
+puts "\\3\3"
+puts %^\\"#{'\a^'}\^^
+puts <<EOD
+"abc"\"
+EOD
+@foo = 3
+puts '#@foo'
+puts '#{3}'
+puts %q("")
+puts %q(\"\")
+puts %Q(\"\")
+puts '\"\"'
+puts %q(\\"\\")
+puts %q(\))
+puts %Q(\))
+puts %<foo\>>

--- a/src/rubyfmt.rb
+++ b/src/rubyfmt.rb
@@ -2571,129 +2571,30 @@ class Parser < Ripper::SexpBuilderPP
     super
   end
 
-
-  FOUR_SLASHES_IN_TSTRING = "\\\\\\\\"
-  LITERAL_DOUBLE_QUOTE_IN_TSTRING = "\""
-  TWO_SLASHES_IN_TSTRING = "\\\\"
-  ONE_SLASH_IN_TSTRING = "\\"
-
-  # Rubyfmt renders all string literals as double quotes for consistency's sake
-  # this method fixes up individual tstring content items to ensure that they
-  # represent the same string literal once reformatted. This method is not
-  # called on string literals that were already surrounded by double quotes,
-  # and so this formatting only applies to tstring_contents from strings that
-  # need to be manipulated to correctly reform as a double quoted string
-  #
-  def fixup_tstring_content_for_double_quotes(string, is_single_quote:, delimiter:)
-    # cleanup escaped delimiters
-    string.gsub!("#{ONE_SLASH_IN_TSTRING}#{delimiter}", "#{delimiter}")
-
-    # Given '\\a' we get a tstring content with "\\\\a", and we need to keep
-    # it the same. However, the next substitution line will replace "\\\\a"
-    # with "\\\\\\\\\\a", so we insert "__RUBYFMT_SAFE_QUAD" as a placeholder
-    # to sub back with quad slashes.
-    string.gsub!(TWO_SLASHES_IN_TSTRING, "__RUBYFMT_SAFE_QUAD")
-
-    # Given '\a' we get a tstring content with "\\a", and we need to replace it
-    # with literally "\\\\a", which needs four escaped slashes
-    string.gsub!(
-      ONE_SLASH_IN_TSTRING,
-      FOUR_SLASHES_IN_TSTRING,
-    )
-
-    if is_single_quote
-      # Given '"', we get a tstring content with "\"", however we need to
-      # literally serialize that slash back out, so we replace it with "\\\""
-      string.gsub!(
-        LITERAL_DOUBLE_QUOTE_IN_TSTRING,
-        "#{ONE_SLASH_IN_TSTRING}#{LITERAL_DOUBLE_QUOTE_IN_TSTRING}",
-      )
-    else
-      # deals with e.g. %^\"^ which should format to "\"" (that is, a
-      # literal quote)
-      string.gsub!(
-        "#{TWO_SLASHES_IN_TSTRING}#{LITERAL_DOUBLE_QUOTE_IN_TSTRING}",
-        "__RUBYFMT_PLEASE_SERIALIZE_THIS_TO_A_LITERAL_DOUBLE_QUOTE",
-      )
-
-      # deals with e.g. %^\\"^ which should format to "\\\"" (that is, an
-      # escaped double quote)
-      string.gsub!(
-        "__RUBYFMT_SAFE_QUAD\"",
-        "__RUBYFMT_PLEASE_SERIALIZE_THIS_TO_AN_ESACPED_DOUBLE_QUOTE"
-      )
-
-      # deals with bare double quotes, replacing them with \"
-      string.gsub!(
-        LITERAL_DOUBLE_QUOTE_IN_TSTRING,
-        "#{ONE_SLASH_IN_TSTRING}#{LITERAL_DOUBLE_QUOTE_IN_TSTRING}",
-      )
-
-      # undoes the literal double quote replacement
-      string.gsub!(
-        "__RUBYFMT_PLEASE_SERIALIZE_THIS_TO_A_LITERAL_DOUBLE_QUOTE",
-        "#{ONE_SLASH_IN_TSTRING}#{LITERAL_DOUBLE_QUOTE_IN_TSTRING}",
-      )
-
-      # undoes the escaped double quote replacement
-      string.gsub!(
-        "__RUBYFMT_PLEASE_SERIALIZE_THIS_TO_AN_ESACPED_DOUBLE_QUOTE",
-        "#{FOUR_SLASHES_IN_TSTRING}#{ONE_SLASH_IN_TSTRING}#{LITERAL_DOUBLE_QUOTE_IN_TSTRING}",
-      )
-    end
-
-    # Fixup the quad safes
-    string.gsub!(
-      "__RUBYFMT_SAFE_QUAD",
-      FOUR_SLASHES_IN_TSTRING,
-    )
-
-    # protect against escaped interpolation
-    string.gsub!("\#{", "\\\#{")
-    string.gsub!("\#@", "\\\#@")
-  end
-
   def on_string_literal(*args, &blk)
     if @heredoc_stack.last
       heredoc_parts = @heredoc_stack.pop
       args.insert(0, [:heredoc_string_literal, heredoc_parts])
     else
-      next_string_end_delim = [@file_lines[lineno-1].bytes[column-1]].pack("c*")
-      if next_string_end_delim == "'"
-        (args || []).each do |part|
-          next if part[1].nil?
-          case part[1][0]
-          when :@tstring_content
-            fixup_tstring_content_for_double_quotes(
-              part[1][1],
-              is_single_quote: true,
-              delimiter: next_string_end_delim,
-            )
-          else
-            raise "got non tstring content in single string"
-          end
-        end
-      elsif /[^a-zA-Z0-9]/ === next_string_end_delim && next_string_end_delim != "\""
-        next_string_start_delim = @string_stack.pop
-        is_single_q_string = next_string_start_delim.start_with?("%q")
+      end_delim = @string_stack.pop
+      start_delim = @string_stack.pop
+
+      if start_delim != "\""
+        reject_embexpr = start_delim == "'" || start_delim.start_with?("%q")
+
         (args[0][1..-1] || []).each do |part|
           next if part.nil?
           case part[0]
           when :@tstring_content
-            fixup_tstring_content_for_double_quotes(
-              part[1],
-              is_single_quote: is_single_q_string,
-              delimiter: next_string_end_delim,
-            )
+            part[1] = eval("#{start_delim}#{part[1]}#{end_delim}").inspect[1..-2]
           when :string_embexpr
-            # this is fine
+            if reject_embexpr
+              raise "got string_embexpr in a #{start_delim}...#{end_delim} string"
+            end
           else
-            raise "got something bad in %q string"
+            raise "got #{part[0]} in a #{start_delim}...#{end_delim} string"
           end
         end
-      elsif next_string_end_delim == "\""
-      else
-        raise "what even is this string type #{next_string_end_delim}"
       end
     end
     super
@@ -2711,6 +2612,11 @@ class Parser < Ripper::SexpBuilderPP
   end
 
   def on_tstring_beg(*args, &blk)
+    @string_stack << args[0]
+    super
+  end
+
+  def on_tstring_end(*args, &blk)
     @string_stack << args[0]
     super
   end


### PR DESCRIPTION
Even after Sam's serious improvements to string handling in #87, it still kinda bothered me that we had to do a bunch of work that Ruby must already know how to do.

I spent too much time crawling around in `parse.y` figuring out how Ruby handles character escaping with different string delimiters and, long story short, there doesn't seem to be a way of getting at that information from Ripper without making changes to `parse.y`. Maybe that's worth doing sometime, but since we want to support old Rubies too it wouldn't help immediately.

Still, the Ruby interpreter knows how to properly unescape the content of string literals. So here's a wildly different approach: Instead of trying to parse and re-escape all possible strings ourselves, or coax the information out of Ripper, let's delegate the responsibility to Ruby by using `#eval` and `#inspect` to get a correctly escaped double-quoted string for any input string. Effectively this is doing what @jcoglan suggested and tokenising the string first, it's just cheating by using Ruby's implementation of that code instead of writing it ourselves.

I think this code is easier to understand, and less likely to be hiding surprising bugs. If nothing else, it's a lot shorter.

Couple of things that still bother me:

1. **Performance** might take a hit, which is important. I ran `time ./scripts/test.sh` and `time ./scripts/test_repo.sh ../gitsh` a few times against this branch and against master and didn't see a clear winner, but more thorough benchmarking might be needed.
1. **Security** is always a worry with `#eval`, although there's no immediately obvious attack that I can see here. Given the input data is escaped strings from Ripper, there would have to be a bug in Ruby string parsing to exploit this, and even then an attacker would already need sufficient access to a machine to get that malicious string into a developer's code so that their editor would `rubyfmt` over it.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
