### PR TITLE
Test idempotence

### DIFF
--- a/scripts/test_fixtures.sh
+++ b/scripts/test_fixtures.sh
@@ -9,7 +9,15 @@ test_folder() {
 
         if ! diff -u /tmp/out.rb "$file"
         then
-            echo "got diff"
+            echo "got diff between formated actual and expected"
+            exit 1
+        fi
+
+        time ruby --disable=gems src/rubyfmt.rb "$file" > /tmp/out.rb
+
+        if ! diff -u /tmp/out.rb "$file"
+        then
+            echo "got diff between formatted expected and expected (not idempotent)"
             exit 1
         fi
     done

--- a/src/rubyfmt.rb
+++ b/src/rubyfmt.rb
@@ -1973,9 +1973,19 @@ def format_while_mod(ps, rest, type)
 
   ps.emit_indent if ps.start_of_line.last
 
+  # Unwrap parens, so that we can consistently decide if we need them
+  # or not when doing the final formatting.
+  if while_expr[0] == :paren
+    while_exprs = while_expr[1]
+  else
+    while_exprs = [while_expr]
+  end
+
   buf = StringIO.new
   render = ParserState.with_depth_stack(buf, from: ps)
-  format_expression(render, while_expr)
+  while_exprs.each do |while_expr|
+    format_expression(render, while_expr)
+  end
   render.write
   buf.rewind
   data = buf.read
@@ -1985,7 +1995,9 @@ def format_while_mod(ps, rest, type)
       ps.emit_open_paren
       ps.emit_newline
       ps.new_block do
-        format_expression(ps, while_expr)
+        while_exprs.each do |while_expr|
+          format_expression(ps, while_expr)
+        end
       end
       ps.emit_indent
       ps.emit_close_paren


### PR DESCRIPTION
This PR updates the test script to run the expected fixtures through `rubyfmt` and compare the output to the original file. The intention is to catch idempotence bugs, i.e. situations where running a file through `rubyfmt` a second time would change the file.

The failures seem to be around whether or not we include parens on a method call. I started looking at fixing them, but Ruby apparently has many, _many_ ways of representing the same call, and it's more than I'll have time to fix today.

Current failures are:

- ~~`fixtures/command_call_raise_expected.rb`~~ (fixed by #117)
- ~~`fixtures/nested_command_expected.rb`~~ (fixed by #117)
- ~~`fixtures/until_while_mod_expected.rb`~~ (fixed on this branch)

Related to #107 

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
