### PR TITLE
Add support for string_dvar.

### DIFF
--- a/fixtures/string_dvar_actual.rb
+++ b/fixtures/string_dvar_actual.rb
@@ -1,0 +1,2 @@
+"pre #@foo post"
+%{pre #@foo post}

--- a/fixtures/string_dvar_expected.rb
+++ b/fixtures/string_dvar_expected.rb
@@ -1,0 +1,2 @@
+"pre #{@foo} post"
+"pre #{@foo} post"

--- a/src/rubyfmt.rb
+++ b/src/rubyfmt.rb
@@ -895,6 +895,12 @@ def format_inner_string(ps, parts, type)
       if on_line_skip
         ps.render_heredocs(true)
       end
+    when :string_dvar
+      ps.emit_ident("\#{")
+      ps.with_start_of_line(false) do
+        format_expression(ps, part[1])
+      end
+      ps.emit_ident("}")
     else
       raise "dont't know how to do this #{part[0].inspect}"
     end
@@ -2588,9 +2594,9 @@ class Parser < Ripper::SexpBuilderPP
           case part[0]
           when :@tstring_content
             part[1] = eval("#{start_delim}#{part[1]}#{end_delim}").inspect[1..-2]
-          when :string_embexpr
+          when :string_embexpr, :string_dvar
             if reject_embexpr
-              raise "got string_embexpr in a #{start_delim}...#{end_delim} string"
+              raise "got #{part[0]} in a #{start_delim}...#{end_delim} string"
             end
           else
             raise "got #{part[0]} in a #{start_delim}...#{end_delim} string"


### PR DESCRIPTION
This commit adds support for interpolated ivars without braces (e.g. `"#@foo"`), and makes the formatting decision that we should always use braces (e.g. `"#{@foo}"`).

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
