### PR TITLE
Run shellcheck with -x

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git grep -l "bin\/bash" | xargs shellcheck -f gcc
+git grep -l "bin\/bash" | xargs shellcheck -x -f gcc

--- a/scripts/test_string_literals.sh
+++ b/scripts/test_string_literals.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -ex
 
-# this one is safe because functions does in fact exist
-# shellcheck disable=SC1091
 source ./scripts/functions.sh
 
 STRING_LITERALS_EXPECTED=$(ruby string_literals_stress_test.rb | f_md5)


### PR DESCRIPTION
This should allow shellcheck to follow references to other files, and mean
we can remove an ignore directive.

Resolves https://github.com/samphippen/rubyfmt/commit/0c2d20eb2ec219d8c5352f260453084a1708f6c2#comments

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
