### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,31 @@ Rubyfmt is a standalone script that only loads the standard library of Ruby,
 as such it is not packaged as a gem. It is intended to be in your editor's save
 hook and run really fast.
 
-I suggest:
+```sh
+# Clone the repo
+git clone https://github.com/samphippen/rubyfmt.git
 
-* Download `src/rubyfmt.rb` to `~/bin`
-* Add `~/bin` to your PATH (e.g. `echo "$HOME/bin:$PATH" >> ~/.bash_profile`)
-* Set your editor to run `rubyfmt file_name > file_name` on save.
+# cd into the project
+cd rubyfmt
 
+# add src/rubyfmt.rb to your ~/bin folder
+mv src/rubyfmt.rb ~/bin/
+
+# make the file executable
+chmod +x ~/bin/rubyfmt.rb
+```
+
+Add `~/bin` to your PATH if it is not already there:
+
+```sh
+# Bash
+echo "$HOME/bin:$PATH" >> ~/.bash_profile
+
+# ZSH
+echo "$HOME/bin:$PATH" >> ~/.zshrc
+```
+
+Now you can tell your editor to run `rubyfmt.rb file_name > file_name` on save.
 
 ## Contributing
 


### PR DESCRIPTION
I had several issues while trying to use rubyfmt when working on the vscode extension. I eventually figured it out after putting it down for a few days and wanted to help mitigate this issue for future users by updating the installation instructions.

I also wanted to add a little bit more info about running the formatter against your ruby files but came across something that I thought might be a bug, but wasn't sure. I figured opening this PR would help get that conversation going.

1. If I run `rubyfmt.rb my_ugly_code.rb > my_ugly_code.rb`, the file is erased and not updated with the formatted version.
2. If I run `rubyfmt.rb my_ugly_code.rb > my_prettier_code.rb`, a new file is created with the new name, and it is formatted like I would expect.
3. If I run `rubyfmt.rb my_ugly_code.rb`, the formatted version of the file is output to the terminal.

I feel the first scenario is a bug but wanted to confirm. If it is not, I would like to update this PR to document that behavior. The other two scenarios did what I would expect, and feel like it might be beneficial to document that in the README as well - but wanted your thoughts first.  Happy to open a bug report if any of these three scenarios are not behaving like you would expect.

Thanks!