### PR TITLE
Update readme to use a tmp file instead of attempting to change inplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ mv path/to/ruby/file.rb.tmp path/to/ruby/file.rb
 To run over an entire project run the following from the project root:
 
 ```
-find ./ -type f -name "*.rb" -exec sh -c 'rubyfmt {} > {}.tmp' \; -exec sh -c 'mv {}.tmp {}' \;
+find ./ -type f -name "*.rb" -exec sh -c 'rubyfmt $1 > "$1.tmp"' _ {} \; -exec sh -c 'mv "$1.tmp" $1' _ {} \;
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -23,8 +23,18 @@ I suggest:
 
 * Download `src/rubyfmt.rb` to `~/bin` as `rubyfmt`
 * Add `~/bin` to your PATH (e.g. `echo "$HOME/bin:$PATH" >> ~/.bash_profile`)
-* Set your editor to run `echo "$(rubyfmt file_name)" > file_name` on save.
+* Set your editor to run the following on save.
 
+```
+rubyfmt path/to/ruby/file.rb > path/to/ruby/file.rb.tmp
+mv path/to/ruby/file.rb.tmp path/to/ruby/file.rb
+```
+
+To run over an entire project run the following from the project root:
+
+```
+find ./ -type f -name "*.rb" -exec sh -c 'rubyfmt {} > {}.tmp' \; -exec sh -c 'mv {}.tmp {}' \;
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ hook and run really fast.
 
 I suggest:
 
-* Download `src/rubyfmt.rb` to `~/bin`
+* Download `src/rubyfmt.rb` to `~/bin` as `rubyfmt`
 * Add `~/bin` to your PATH (e.g. `echo "$HOME/bin:$PATH" >> ~/.bash_profile`)
-* Set your editor to run `rubyfmt file_name > file_name` on save.
+* Set your editor to run `echo "$(rubyfmt file_name)" > file_name` on save.
 
 
 ## Contributing


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

This updates the README to create a `tmp` file and then move that to replace the original file. This is instead of attempting to do an inplace change. The original version from the README does not work as the file is deleted before it has a change to be processed.

I tested this method against a sub-shell approach and found they both ran in about the same amount of time and this seemed like less of a hack. I flip-flopped on this as you can see in my original commit, but I think the `tmp` file approach is more straightforward. Here is both the current tmp file version and the subshell version.

This assumes `$file` is a BASH variable containing the file path
```
rubyfmt "$file" > "${file}.tmp"
mv "${file}.tmp" "$file"
```
vs this subshell method
```
echo "$(rubyfmt $file)" > "$file"
```

This also includes a `find` command to run this against an entire project, which I found useful but am happy to remove aswell!