### PR TITLE
More ruby files

### DIFF
--- a/rubyfmt.rb
+++ b/rubyfmt.rb
@@ -210,24 +210,29 @@ def parse_file(fn)
   [file_data, Parser.new(file_data).parse]
 end
 
+RUBY_PATHS_PATTERN = "**/{*.rb,*.builder,*.jbuilder,*.ru,*.rake,*.gemspec,Gemfile,Capfile,capfile,Guardfile,.Guardfile,rakefile,Rakefile,Rake,.irbrc,irb.rc,_irbrc,$irbrc,pryrc,.pryrc,.simplecov}"
 def rubyfmt_dir(dn)
-  files = Dir[File.join(dn, "**/*.rb")]
-  files.each do |glob_fn|
-    file_data, parsed = parse_file(glob_fn)
-    Rubyfmt::format_to_file(glob_fn, file_data, parsed)
+  Dir.glob(File.join(dn, RUBY_PATHS_PATTERN), File::FNM_DOTMATCH).each do |glob_fn|
+    rubyfmt_file(glob_fn)
   end
 end
 
+def rubyfmt_file(fn)
+  file_data, parsed = parse_file(fn)
+  Rubyfmt::format_to_file(fn, file_data, parsed)
+end
+
 first = ARGV.shift
+
 if first == "-i"
   ARGV.each do |fn|
     if File.directory?(fn)
       rubyfmt_dir(fn)
     else
-      file_data, parsed = parse_file(fn)
-      Rubyfmt::format_to_file(fn, file_data, parsed)
+      rubyfmt_file(fn)
     end
   end
+
 elsif String === first
   if File.directory?(first)
     rubyfmt_dir(first)

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -22,6 +22,7 @@ diff_files() {
     if ! diff -u "$ACTUAL" "$EXPECTED"
     then
         echo "got diff between formated formatted actual and expected"
+        echo "files are here: $PWD"
         exit 1
     fi
 }

--- a/script/tests/test_cli_interface.sh
+++ b/script/tests/test_cli_interface.sh
@@ -33,6 +33,23 @@ test_dir_no_i_flag() {
     )
 }
 
+test_dir_no_i_flag_no_trailing_slash() {
+    (
+    cd "$(mktemp -d)"
+
+    mkdir bees/
+    echo "a 1,2,3" > bees/a_ruby_file_1.rb
+    echo "a 1,2,5" > bees/a_ruby_file_2.rb
+    echo "a(1, 2, 3)" > expected_1.rb
+    echo "a(1, 2, 5)" > expected_2.rb
+
+    f_rubyfmt bees
+
+    diff_files bees/a_ruby_file_1.rb expected_1.rb
+    diff_files bees/a_ruby_file_2.rb expected_2.rb
+    )
+}
+
 test_i_flag() {
     (
     cd "$(mktemp -d)"
@@ -55,6 +72,21 @@ test_i_flag() {
     diff_files bees/a_ruby_file_2.rb expected_2.rb
     diff_files bees/sub/a_ruby_file_3.rb expected_3.rb
     diff_files cows.rb expected_4.rb
+    )
+}
+
+test_i_flag_no_trailing_slash() {
+    (
+    cd "$(mktemp -d)"
+
+    mkdir bees/
+    echo "a 1,2,3" > bees/a_ruby_file_1.rb
+
+    echo "a(1, 2, 3)" > expected_1.rb
+
+    f_rubyfmt -i bees
+
+    diff_files bees/a_ruby_file_1.rb expected_1.rb
     )
 }
 
@@ -81,7 +113,35 @@ test_dir_non_rb_ruby_files() {
     diff_files cows.ru expected_4.rb
 }
 
+test_dir_non_extension_ruby_files() {
+    cd "$(mktemp -d)"
+
+    mkdir bees/
+
+    echo "a 1,2,3" > bees/Gemfile
+    echo -e '#!/usr/bin/env bash\n\nset -ex\nif [[ -z ruby ]]; then\n  true;\nfi' > bees/bash
+    echo -e '#!/usr/bin/env ruby\n\na 1,2,6' > bees/ruby_script
+    echo -e '#!/usr/bin/ruby -w\n\na 1,2,7' > bees/ruby_script_with_warnings
+    echo "a 1,2,9" > ruby_script_called_directly
+    echo "a(1, 2, 3)" > expected_1.rb
+    echo -e '#!/usr/bin/env bash\n\nset -ex\nif [[ -z ruby ]]; then\n  true;\nfi' > expected_2.rb # unchanged, no error
+    echo -e '#!/usr/bin/env ruby\n\na(1, 2, 6)' > expected_3.rb
+    echo -e '#!/usr/bin/ruby -w\n\na(1, 2, 7)' > expected_4.rb
+    echo "a(1, 2, 9)" > expected_5.rb
+
+    f_rubyfmt -i bees/ ruby_script_called_directly
+
+    diff_files bees/Gemfile expected_1.rb
+    diff_files bees/bash expected_2.rb
+    diff_files bees/ruby_script expected_3.rb
+    diff_files bees/ruby_script_with_warnings expected_4.rb
+    diff_files ruby_script_called_directly expected_5.rb
+}
+
 test_single_file_stdout
 test_dir_no_i_flag
+test_dir_no_i_flag_no_trailing_slash
 test_i_flag
+test_i_flag_no_trailing_slash
 test_dir_non_rb_ruby_files
+test_dir_non_extension_ruby_files

--- a/script/tests/test_cli_interface.sh
+++ b/script/tests/test_cli_interface.sh
@@ -58,6 +58,30 @@ test_i_flag() {
     )
 }
 
+test_dir_non_rb_ruby_files() {
+    cd "$(mktemp -d)"
+
+    mkdir bees/
+    mkdir bees/.sub
+
+    echo "a 1,2,3" > bees/Gemfile
+    echo "a 1,2,5" > bees/.pryrc
+    echo "a 1,2,6" > bees/.sub/a_ruby_file_3.rake
+    echo "a 1,2,7" > cows.ru
+    echo "a(1, 2, 3)" > expected_1.rb
+    echo "a(1, 2, 5)" > expected_2.rb
+    echo "a(1, 2, 6)" > expected_3.rb
+    echo "a(1, 2, 7)" > expected_4.rb
+
+    f_rubyfmt -i bees/ cows.ru
+
+    diff_files bees/Gemfile expected_1.rb
+    diff_files bees/.pryrc expected_2.rb
+    diff_files bees/.sub/a_ruby_file_3.rake expected_3.rb
+    diff_files cows.ru expected_4.rb
+}
+
 test_single_file_stdout
 test_dir_no_i_flag
 test_i_flag
+test_dir_non_rb_ruby_files


### PR DESCRIPTION
From this comment: https://github.com/penelopezone/rubyfmt/pull/179#discussion_r407064119

More files use ruby than just .rb. This is as exhaustive as i could make
it with a little bit of research (all the files i've come across as a
ruby developer, plus whatever documented variations there are).

*.builder is from rails (https://guides.rubyonrails.org/action_view_overview.html#builder)
*.jbuilder is from rails (https://guides.rubyonrails.org/action_view_overview.html#jbuilder)
Gemfile is from bundler (https://bundler.io/man/gemfile.5.html)
Capfile, capfile is from capistrano (https://github.com/capistrano/capistrano/blob/master/lib/capistrano/application.rb#L5)
Guardfile, .Guardfile is from guard (https://github.com/guard/guard/blob/master/README.md#start)
*.ru is from rack (https://github.com/rack/rack/wiki/(tutorial)-rackup-howto)
Rakefile, rakefile, Rake, *.rake is from rake (https://github.com/ruby/rake/blob/master/doc/command_line_usage.rdoc)
.irbrc, irb.rc, _irbrc, $irbrc is from irb (https://docs.ruby-lang.org/en/2.7.0/IRB.html#module-IRB-label-Configuration)
.pryrc, pryrc is from pry (https://github.com/pry/pry/wiki/Pry-rc#overview)

Also checks ruby files with no extension, but with a ruby shebang

This is largely based on code from
https://github.com/robotdana/fast_ignore which in turn is based on code
from stdlib find but with fewer system calls so it's very slightly faster.

You may want just the first commit, as that's significantly less ruby.