### PR TITLE
Shim script generator and vscode instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ Rubyfmt supports the following CLI invocations:
 * `ruby --disable=all path/to/rubyfmt/rubyfmt.rb -i many file or directory names`
   to format many file and directory names in place
 
+## Command line support
+There are two ways to add a terminal command to your environment to make running
+rubyfmt easier.
 
+### Shell Alias
 If you'd like, you can set up an alias (if you are an RBenv user please read
 the section below):
 
@@ -33,7 +37,7 @@ the section below):
 alias rubyfmt="ruby --disable=all /absolute/path/to/rubyfmt/rubyfmt.rb"
 ```
 
-## On RBenv:
+#### On RBenv:
 
 RBenv runs what it calls ["shims"](https://github.com/rbenv/rbenv#understanding-shims),
 all ruby commands, but most importantly the `ruby` command itself. These
@@ -46,6 +50,16 @@ e.g.:
 ~/.rbenv/versions/<ruby-version>/bin/ruby --disable=all rubyfmt.rb
 ```
 
+### Executable shim script
+You can also run an included script to generate a small executable script which you can
+place anywhere in your environment's `$PATH`:
+
+```bash
+$ /<path-to-rubyfmt-dir>/script/install_shim.sh /usr/local/bin/rubyfmt
+```
+
+You can replace `/usr/bin/local` above with any directory in `$PATH`.
+
 ## Useful environment variables:
 
 * `RUBYFMT_USE_RELEASE=1`: use release rust compile, much faster + no logging
@@ -57,7 +71,11 @@ e.g.:
 
 ### Visual Studio Code
 
-Rubyfmt is a supported formatter in the popular [vscode ruby extension](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby).  After installing the extension and following the instructions above to ensure `rubyfmt` is available in your shell's `PATH`, add the following to vscode's `settings.json` file:
+Rubyfmt is a supported formatter in the popular
+[vscode ruby extension](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby).
+You should follow the above instructions for installing rubyfmt and ensuring an executable is
+available in your environment `PATH`. **Note**: You must use the "Executable shim script" method
+to get vscode-ruby to work. Once installed, add the following to vscode's `settings.json` file:
 
 ``` json
   "ruby.useLanguageServer": true,

--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ e.g.:
 * `RUBYFMT_DISABLE_SZUSH=1`: disables the backend render queue writer,
   very useful for debugging, literally useless if you're not developing rubyfmt
   itself.
+
+## Editor Support
+
+### Visual Studio Code
+
+Rubyfmt is a supported formatter in the popular [vscode ruby extension](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby).  After installing the extension and following the instructions above to ensure `rubyfmt` is available in your shell's `PATH`, add the following to vscode's `settings.json` file:
+
+``` json
+  "ruby.useLanguageServer": true,
+  "ruby.format": "rubyfmt",
+  "[ruby]": {
+      "editor.formatOnSave": true
+  },
+```

--- a/script/install_shim.sh
+++ b/script/install_shim.sh
@@ -6,7 +6,9 @@ if [ $# -eq 0 ]
     exit 1
 fi
 
+rubyfmt_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 && pwd )"
+
 echo "#!/usr/bin/env bash
 export RUBYFMT_USE_RELEASE=1
-$(which ruby) --disable=all $(pwd)/rubyfmt.rb \$@" > "$1"
+$(which ruby) --disable=all $rubyfmt_root/rubyfmt.rb \$@" > "$1"
 chmod +x "$1"

--- a/script/install_shim.sh
+++ b/script/install_shim.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+if [ $# -eq 0 ]
+  then
+    echo "Please pass a file location to install the shim script"
+    exit 1
+fi
+
+echo "#!/usr/bin/env bash
+export RUBYFMT_USE_RELEASE=1
+$(which ruby) --disable=all $(pwd)/rubyfmt.rb \$@" > "$1"
+chmod +x "$1"

--- a/script/tests/test_cli_interface.sh
+++ b/script/tests/test_cli_interface.sh
@@ -70,7 +70,24 @@ test_i_flag() {
     )
 }
 
+test_shim_script() {
+    (
+    cwd=$(pwd)
+    cd "$(mktemp -d)"
+
+    "$cwd"/script/install_shim.sh ./rubyfmt
+
+    echo "a 1,2,3" > a_ruby_file.rb
+    echo "a(1, 2, 3)" > expected.rb
+
+    ./rubyfmt a_ruby_file.rb > out.rb
+
+    diff_files out.rb expected.rb
+    )
+}
+
 test_single_file_stdout
 test_stdin_stdout
 test_dir_no_i_flag
 test_i_flag
+test_shim_script

--- a/script/tests/test_cli_interface.sh
+++ b/script/tests/test_cli_interface.sh
@@ -16,6 +16,18 @@ test_single_file_stdout() {
     )
 }
 
+test_stdin_stdout() {
+    (
+    cd "$(mktemp -d)"
+
+    echo "a(1, 2, 3)" > expected.rb
+
+    echo "a 1,2,3" | f_rubyfmt > out.rb
+
+    diff_files out.rb expected.rb
+    )
+}
+
 test_dir_no_i_flag() {
     (
     cd "$(mktemp -d)"
@@ -59,5 +71,6 @@ test_i_flag() {
 }
 
 test_single_file_stdout
+test_stdin_stdout
 test_dir_no_i_flag
 test_i_flag


### PR DESCRIPTION
Reopening from #201 after the rebase.  This adds a new script for generating an executable shim script as opposed to the currently recommended alias, as well as README instructions for setting up vscode. Does not include README update for the shim script, but glad to update with that if you want to make it the path going forward.