### PR TITLE
Failing test for multiline comment in empty method

### DIFF
--- a/fixtures/small/class_comment_actual.rb
+++ b/fixtures/small/class_comment_actual.rb
@@ -11,9 +11,26 @@ class Bees
   # this one gets a proceeding newline because it's prefixed by a statement
   class Bar
   end
+  # this one gets a proceeding newline because it's prefixed by a statement
 
   def bees
     # no proceeding newline here
     a
   end
+
+  def empty_method
+    # comment inside empty method
+    # second line of comment
+    # third line of comment
+    # fourth line of comment
+  end
+  # comment after empty method
+
+  def empty_method_end_of_file
+    # comment inside empty method
+    # second line of comment
+    # third line of comment
+    # fourth line of comment
+  end
+  # comment after empty method
 end

--- a/fixtures/small/class_comment_expected.rb
+++ b/fixtures/small/class_comment_expected.rb
@@ -11,9 +11,26 @@ class Bees
   # this one gets a proceeding newline because it's prefixed by a statement
   class Bar
   end
+  # this one gets a proceeding newline because it's prefixed by a statement
 
   def bees
     # no proceeding newline here
     a
   end
+
+  def empty_method
+    # comment inside empty method
+    # second line of comment
+    # third line of comment
+    # fourth line of comment
+  end
+  # comment after empty method
+
+  def empty_method_end_of_file
+    # comment inside empty method
+    # second line of comment
+    # third line of comment
+    # fourth line of comment
+  end
+  # comment after empty method
 end


### PR DESCRIPTION
This test demonstrates a formatting error when there are multiline
comments inside an empty method. When formatting, the first line of the
comment remains in the method, while all other lines get pulled out to
just after the method. Additionally, if the method is the last method in
the file, only the second line gets pulled after `end`. Everything else
in the comment, as well as a comment following the method, gets dropped
entirely.

The output of the `class_comment_actual` fixture in trunk at the time of this PR is:

``` ruby
#adsf
class Foo
  #but this one doesn't get a proceeding newline
  a
end

# this one gets a proceeding newline because it is prefixed by an end
class Bees
  foo

  # this one gets a proceeding newline because it's prefixed by a statement
  class Bar
  end

  # this one gets a proceeding newline because it's prefixed by a statement
  def bees
    # no proceeding newline here
    a
  end

  def empty_method
    # comment inside empty method
  end

    # second line of comment
    # third line of comment
    # fourth line of comment
  # comment after empty method
  def empty_method_end_of_file
    # comment inside empty method
  end
    # second line of comment
end
```