### PR TITLE
Fix balanced string delims around interpolation

### DIFF
--- a/ci/string_literals_stress_test.rb
+++ b/ci/string_literals_stress_test.rb
@@ -1,3 +1,5 @@
+puts ''
+puts ""
 puts %Q("")
 puts %^_^
 puts %^\"^
@@ -12,7 +14,13 @@ puts '"'
 puts '\"'
 puts "\""
 puts "\\3\3"
+puts %^\\"\^^
+puts '\a^'
 puts %^\\"#{'\a^'}\^^
+puts %{{a#{1}}}
+puts %{{a}#{1}}
+puts %{\\\{#{1}}
+puts %{\\{#{1}}}
 puts <<EOD
 "abc"\"
 EOD


### PR DESCRIPTION
Fixes: #211

The previous way of doing this with eval was very clever, but resulted
in trying to eval strings like `%{{}` which is just doesn't work. I
tried to think of ways we could continue to use this eval pattern
somehow but everything i could think of was more fragile than regular
expressions, so lets use regular expressions.

Because (I assume, please don't tell me this is incorrect) single quoted
and %q strings don't have interpolations we continue to use the original
eval pattern (i tried processing these with regular expressions as well
and they have completely different handling of escapes, so since this
works and is less fragile it can stay.

So we find the characters we need to escape after counting the
backslashes and either insert or remove a backslash as necessary.

Sorry i had to ruin strings again.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
