### PR TITLE
Fix unescaped square brackets and escaped delims in percent arrays

### DIFF
--- a/ci/array_literals_stress_test.rb
+++ b/ci/array_literals_stress_test.rb
@@ -29,5 +29,46 @@ puts %W^[#{1}]^.inspect
 puts %W^[]#{1}^.inspect
 puts %W^\[^.inspect
 puts %W^\^^.inspect
+puts %w^\^^.inspect
 puts %w[\]].inspect
+puts %w(()).inspect
+puts %w(\().inspect
+puts %w(\)).inspect
+puts %W(()).inspect
+puts %W(\().inspect
+puts %W(\)).inspect
+puts %W(#{}()).inspect
+puts %W(#{}\().inspect
+puts %W(#{}\)).inspect
+puts %W(()#{}).inspect
+puts %W(\(#{}).inspect
+puts %W(\)#{}).inspect
+puts %w<\<>.inspect
+puts %w<\>>.inspect
+puts %W<<>>.inspect
+puts %W<\<>.inspect
+puts %W<\>>.inspect
+puts %W<#{}<>>.inspect
+puts %W<#{}\<>.inspect
+puts %W<#{}\>>.inspect
+puts %W<<>#{}>.inspect
+puts %W<\<#{}>.inspect
+puts %W<\>#{}>.inspect
+puts %w{\{}.inspect
+puts %w{\}}.inspect
+puts %W{\}}.inspect
+puts %W{\{}.inspect
+puts %W{\}}.inspect
+puts %W{#{}{}}.inspect
+puts %W{#{}\{}.inspect
+puts %W{#{}\}}.inspect
+puts %W{{}#{}}.inspect
+puts %W{\{#{}}.inspect
+puts %W{\}#{}}.inspect
+puts %W{#{%w(this [that)} [other]}.inspect
+puts %W{#{%w[this \[that]} [other}.inspect
+puts %W[#{%w(this [that)} \[other].inspect
+puts %W{#{%w(this {that])} [other]}.inspect
+puts %W{#{%w[this \[that]} [other}.inspect
+puts %W[#{%w(this [that)} \[other].inspect
 puts %w[\[].inspect

--- a/ci/array_literals_stress_test.rb
+++ b/ci/array_literals_stress_test.rb
@@ -1,0 +1,33 @@
+puts [].inspect
+puts %w{1}.inspect
+puts %W[].inspect
+puts %i^^.inspect
+puts ["word"].inspect
+puts ['word'].inspect
+puts ["word", 'word'].inspect
+puts %w{word}.inspect
+puts %W[word].inspect
+puts %i{word}.inspect
+puts %w{word}.inspect
+puts %W[word].inspect
+puts %w[word word].inspect
+puts %W[word word].inspect
+puts %w{word word}.inspect
+puts %W{word word}.inspect
+puts %i^word^.inspect
+puts %I^[]^.inspect
+puts %i^[^.inspect
+puts %i^[#{1}]^.inspect
+puts %I^[#{1}]^.inspect
+puts %I^[]#{1}^.inspect
+puts %w^[]^.inspect
+puts %w^[^.inspect
+puts %w^]^.inspect
+puts %W^\^\[]^.inspect
+puts %w^[#{1}]^.inspect
+puts %W^[#{1}]^.inspect
+puts %W^[]#{1}^.inspect
+puts %W^\[^.inspect
+puts %W^\^^.inspect
+puts %w[\]].inspect
+puts %w[\[].inspect

--- a/librubyfmt/rubyfmt_lib.rb
+++ b/librubyfmt/rubyfmt_lib.rb
@@ -47,6 +47,7 @@ class Parser < Ripper::SexpBuilderPP
   private
 
 
+  UNESCAPED_SQUARE_BRACKET=/(?<!\\)((?:\\\\)*[\[\]])/.freeze # square bracket after even number of backslashes (including zero)
   ARRAY_SYMBOLS.each do |event, symbol|
     define_method(:"on_#{event}_new") do
       [event, [], [lineno, column]]
@@ -54,6 +55,13 @@ class Parser < Ripper::SexpBuilderPP
 
     define_method(:"on_#{event}_add") do |parts, part|
       parts.tap do |node|
+        if part[0].is_a?(Array)
+          part.each do |sub_part|
+            sub_part[1].gsub!(UNESCAPED_SQUARE_BRACKET, "\\\\\\1") if sub_part[0] == :@tstring_content
+          end
+        else
+          part[1].gsub!(UNESCAPED_SQUARE_BRACKET, "\\\\\\1") if part[0] == :@tstring_content
+        end
         node[1] << part
       end
     end

--- a/rubyfmt.rb
+++ b/rubyfmt.rb
@@ -33,6 +33,7 @@ class Parser < Ripper::SexpBuilderPP
     @comments_delete = []
     @regexp_stack = []
     @string_stack = []
+    @percent_array_stack = []
     @kw_stacks = {
       "return" => [],
       "when" => [],
@@ -50,24 +51,56 @@ class Parser < Ripper::SexpBuilderPP
 
   private
 
+  DELIM_CLOSE_PAREN={ '{' => '}', '[' => ']', '(' => ')', '<' => '>' }
 
-  UNESCAPED_SQUARE_BRACKET=/(?<!\\)((?:\\\\)*[\[\]])/.freeze # square bracket after even number of backslashes (including zero)
+  def escape_percent_array_paren_content(part, pattern)
+    return unless part[0] == :@tstring_content
+    part[1].gsub!(pattern) do |str|
+      str_last = str[-1]
+      if str_last == ']' || str_last == '['
+        # insert needed escape
+        "#{str[0..-2]}\\#{str_last}"
+      else
+        # drop unnecessary escape
+        "#{str[0..-3]}#{str_last}"
+      end
+    end
+  end
+
   ARRAY_SYMBOLS.each do |event, symbol|
     define_method(:"on_#{event}_new") do
-      [event, [], [lineno, column]]
+      # there doesn't seem to be an _end so _rubyfmt_delim is a hacky way
+      # to get the value from _beg into parts for _add.
+      # it's removed again in on_array.
+      [event, [[:_rubyfmt_delim, @percent_array_stack]], [lineno, column]]
+    end
+
+    define_method(:"on_#{event}_beg") do |delim|
+      @percent_array_stack = delim
     end
 
     define_method(:"on_#{event}_add") do |parts, part|
+      delim = parts[1][0][1]
       parts.tap do |node|
-        if part[0].is_a?(Array)
-          part.each do |sub_part|
-            sub_part[1].gsub!(UNESCAPED_SQUARE_BRACKET, "\\\\\\1") if sub_part[0] == :@tstring_content
+        unless delim.end_with?('[')
+          delim_start = delim[-1]
+          delim_close = DELIM_CLOSE_PAREN[delim_start]
+          pattern = if delim_close
+            /(?<!\\)(?:\\\\)*(?:\\[#{Regexp.escape(delim_start)}#{Regexp.escape(delim_close)}]|[\[\]])/
+          else
+            /(?<!\\)(?:\\\\)*(?:\\#{Regexp.escape(delim_start)}|[\[\]])/
           end
-        else
-          part[1].gsub!(UNESCAPED_SQUARE_BRACKET, "\\\\\\1") if part[0] == :@tstring_content
+          if part[0].is_a?(Array)
+            part.each do |sub_part|
+              escape_percent_array_paren_content(sub_part, pattern)
+            end
+          else
+            escape_percent_array_paren_content(part, pattern)
+          end
         end
         node[1] << part
       end
+      super(parts, part)
     end
   end
 
@@ -90,6 +123,7 @@ class Parser < Ripper::SexpBuilderPP
 
   def on_array(*args)
     res = super
+    res[1][1].shift if (ary = res.dig(1, 1, 0)) && ary.is_a?(Array) && ary[0] == :_rubyfmt_delim # it's done its job
     res << @array_location_stacks.pop
     res
   end

--- a/rubyfmt.rb
+++ b/rubyfmt.rb
@@ -51,6 +51,7 @@ class Parser < Ripper::SexpBuilderPP
   private
 
 
+  UNESCAPED_SQUARE_BRACKET=/(?<!\\)((?:\\\\)*[\[\]])/.freeze # square bracket after even number of backslashes (including zero)
   ARRAY_SYMBOLS.each do |event, symbol|
     define_method(:"on_#{event}_new") do
       [event, [], [lineno, column]]
@@ -58,6 +59,13 @@ class Parser < Ripper::SexpBuilderPP
 
     define_method(:"on_#{event}_add") do |parts, part|
       parts.tap do |node|
+        if part[0].is_a?(Array)
+          part.each do |sub_part|
+            sub_part[1].gsub!(UNESCAPED_SQUARE_BRACKET, "\\\\\\1") if sub_part[0] == :@tstring_content
+          end
+        else
+          part[1].gsub!(UNESCAPED_SQUARE_BRACKET, "\\\\\\1") if part[0] == :@tstring_content
+        end
         node[1] << part
       end
     end

--- a/script/test.sh
+++ b/script/test.sh
@@ -6,6 +6,7 @@ cargo build --release
 export RUBYFMT_USE_RELEASE=1
 uname -a
 ./script/tests/test_string_literals.sh
+./script/tests/test_array_literals.sh
 ./script/tests/test_methods.sh
 ./script/tests/test_cli_interface.sh
 ./script/tests/test_c_main.sh

--- a/script/tests/test_array_literals.sh
+++ b/script/tests/test_array_literals.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ex
+
+source ./script/functions.sh
+
+ARRAY_LITERALS_EXPECTED=$(ruby ci/array_literals_stress_test.rb | f_md5)
+ARRAY_LITERALS_ACTUAL=$(f_rubyfmt ci/array_literals_stress_test.rb | ruby | f_md5)
+if [[ "$ARRAY_LITERALS_EXPECTED" != "$ARRAY_LITERALS_ACTUAL" ]]
+then
+    echo "array literals are broken"
+    exit 1
+fi

--- a/test.rb
+++ b/test.rb
@@ -45,6 +45,7 @@ class Parser < Ripper::SexpBuilderPP
   private
 
 
+  UNESCAPED_SQUARE_BRACKET=/(?<!\\)((?:\\\\)*[\[\]])/.freeze # square bracket after even number of backslashes (including zero)
   ARRAY_SYMBOLS.each do |event, symbol|
     define_method(:"on_#{event}_new") do
       [event, [], [lineno, column]]
@@ -52,6 +53,13 @@ class Parser < Ripper::SexpBuilderPP
 
     define_method(:"on_#{event}_add") do |parts, part|
       parts.tap do |node|
+        if part[0].is_a?(Array)
+          part.each do |sub_part|
+            sub_part[1].gsub!(UNESCAPED_SQUARE_BRACKET, "\\\\\\1") if sub_part[0] == :@tstring_content
+          end
+        else
+          part[1].gsub!(UNESCAPED_SQUARE_BRACKET, "\\\\\\1") if part[0] == :@tstring_content
+        end
         node[1] << part
       end
     end

--- a/test.rb
+++ b/test.rb
@@ -44,24 +44,56 @@ class Parser < Ripper::SexpBuilderPP
 
   private
 
+  DELIM_CLOSE_PAREN={ '{' => '}', '[' => ']', '(' => ')', '<' => '>' }
 
-  UNESCAPED_SQUARE_BRACKET=/(?<!\\)((?:\\\\)*[\[\]])/.freeze # square bracket after even number of backslashes (including zero)
+  def escape_percent_array_paren_content(part, pattern)
+    return unless part[0] == :@tstring_content
+    part[1].gsub!(pattern) do |str|
+      str_last = str[-1]
+      if str_last == ']' || str_last == '['
+        # insert needed escape
+        "#{str[0..-2]}\\#{str_last}"
+      else
+        # drop unnecessary escape
+        "#{str[0..-3]}#{str_last}"
+      end
+    end
+  end
+
   ARRAY_SYMBOLS.each do |event, symbol|
     define_method(:"on_#{event}_new") do
-      [event, [], [lineno, column]]
+      # there doesn't seem to be an _end so _rubyfmt_delim is a hacky way
+      # to get the value from _beg into parts for _add.
+      # it's removed again in on_array.
+      [event, [[:_rubyfmt_delim, @percent_array_stack]], [lineno, column]]
+    end
+
+    define_method(:"on_#{event}_beg") do |delim|
+      @percent_array_stack = delim
     end
 
     define_method(:"on_#{event}_add") do |parts, part|
+      delim = parts[1][0][1]
       parts.tap do |node|
-        if part[0].is_a?(Array)
-          part.each do |sub_part|
-            sub_part[1].gsub!(UNESCAPED_SQUARE_BRACKET, "\\\\\\1") if sub_part[0] == :@tstring_content
+        unless delim.end_with?('[')
+          delim_start = delim[-1]
+          delim_close = DELIM_CLOSE_PAREN[delim_start]
+          pattern = if delim_close
+            /(?<!\\)(?:\\\\)*(?:\\[#{Regexp.escape(delim_start)}#{Regexp.escape(delim_close)}]|[\[\]])/
+          else
+            /(?<!\\)(?:\\\\)*(?:\\#{Regexp.escape(delim_start)}|[\[\]])/
           end
-        else
-          part[1].gsub!(UNESCAPED_SQUARE_BRACKET, "\\\\\\1") if part[0] == :@tstring_content
+          if part[0].is_a?(Array)
+            part.each do |sub_part|
+              escape_percent_array_paren_content(sub_part, pattern)
+            end
+          else
+            escape_percent_array_paren_content(part, pattern)
+          end
         end
         node[1] << part
       end
+      super(parts, part)
     end
   end
 
@@ -71,6 +103,7 @@ class Parser < Ripper::SexpBuilderPP
 
   def on_array(*args)
     res = super
+    res[1][1].shift if (ary = res.dig(1, 1, 0)) && ary.is_a?(Array) && ary[0] == :_rubyfmt_delim # it's done its job
     res << @array_location_stacks.pop
     res
   end


### PR DESCRIPTION
e.g. `%w{[ ]}` => `%w[\[ \]]` (which is equivalent to `["[", "]"]`)

fixes: #225

This does mean that this is possibly unnecessarily escaped, because
balanced pairs are fine in percent literals BUT this is easier, and
slightly more explicit.

i also added a hacky way to transform `%w{\{}`

before it would change the value from `['{']` to `['\\{']`. now it doesn't. 
but christ is it a hack

(also i'm unclear which ruby file i'm supposed to be modifying so i
modified them all)

**ALTERNATIVELY TO THIS PR**, we push the delim to the ast and don't change it
to another delim (might be cleaner in the end, but that sounds like a rust task and my
rust is weak at best)

**ALTERNATIVELY ALTERNATIVELY**, we transform things even more to regular array & string/symbol literals
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
