### PR TITLE
Fix double free in `debug_inspect`

### DIFF
--- a/librubyfmt/src/ruby.rs
+++ b/librubyfmt/src/ruby.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types, dead_code)]
 use log::debug;
-use std::ffi::CString;
+use std::ffi::{CString, CStr};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(transparent)]
@@ -127,7 +127,7 @@ extern "C" fn real_debug_inspect(v: VALUE) -> VALUE {
     unsafe {
         let inspect = rb_funcall(v, intern!("inspect"), 0, std::ptr::null() as *const VALUE);
         let char_pointer = rb_string_value_cstr(&inspect) as *mut i8;
-        let cstr = CString::from_raw(char_pointer);
+        let cstr = CStr::from_ptr(char_pointer);
         let s = cstr.to_str().expect("it's utf8");
         debug!("{}", s);
         Qnil


### PR DESCRIPTION
This was the cause of the segfault that earlier commits in this branch
tried to fix. They actually fixed it by not calling `debug_inspect`, the
way it was performing iteration was fine (other than the signature of
the callback missing an argument, which could fuck things up depending
on the ABI of the target).

The source of this bug is that `CString` is being constructed with a
pointer we don't own. `CString` is an owned string, which frees its
memory on drop. This results in a double free at best.

The reason this manifested as it did was because we're not just freeing
a pointer we don't own, we're freeing a pointer that was allocated by a
different allocator. Since we didn't build ruby with jemalloc, and we
aren't compiling our jemalloc with unprefixed symbols (we should totally
do that), jemalloc would end up corrupting its own book keeping when we
freed it.

This is also why the segfault disappeared if we used the system
allocator in Rust, or unprefixed symbols in jemalloc. When we do either
of those, it becomes "just" a double free, since the string is never
read again. Even the double free was unlikely to manifest since GC
almost certainly never runs again after Ripper finishes parsing.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
