### PR TITLE
Partial audit of unsafe code, refactor to reduce its usage

### DIFF
--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -32,7 +32,7 @@ impl FileComments {
                 .trim()
                 .to_owned();
             fc.push_comment(lineno as _, comment);
-        };
+        }
         fc
     }
 

--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -14,31 +14,24 @@ pub struct FileComments {
 impl FileComments {
     pub fn from_ruby_hash(h: VALUE) -> Self {
         let mut fc = FileComments::default();
+        let keys;
+        let values;
         unsafe {
-            let keys = rb_funcall(h, intern!("keys"), 0);
-            let values = rb_funcall(h, intern!("values"), 0);
-            if rubyfmt_rb_ary_len(keys) != rubyfmt_rb_ary_len(values) {
-                raise("expected keys and values to have same length, indicates error");
+            keys = ruby_array_to_slice(rb_funcall(h, intern!("keys"), 0));
+            values = ruby_array_to_slice(rb_funcall(h, intern!("values"), 0));
+        }
+        if keys.len() != values.len() {
+            raise("expected keys and values to have same length, indicates error");
+        }
+        for (ruby_lineno, ruby_comment) in keys.iter().zip(values) {
+            let lineno = unsafe { rubyfmt_rb_num2ll(*ruby_lineno) };
+            if lineno < 0 {
+                raise("line number negative");
             }
-            for i in 0..rubyfmt_rb_ary_len(keys) {
-                let ruby_lineno = rb_ary_entry(keys, i);
-                let ruby_comment = rb_ary_entry(values, i);
-                let lineno = rubyfmt_rb_num2ll(ruby_lineno);
-                if lineno < 0 {
-                    raise("line number negative");
-                }
-                let lineno = lineno as u64;
-
-                let comment_slice = std::slice::from_raw_parts(
-                    rubyfmt_rstring_ptr(ruby_comment) as *const u8,
-                    rubyfmt_rstring_len(ruby_comment) as usize,
-                );
-
-                let comment = std::str::from_utf8_unchecked(comment_slice)
-                    .trim()
-                    .to_string();
-                fc.push_comment(lineno, comment);
-            }
+            let comment = unsafe { ruby_string_to_str(*ruby_comment) }
+                .trim()
+                .to_owned();
+            fc.push_comment(lineno as _, comment);
         };
         fc
     }

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -494,6 +494,9 @@ impl ParserState {
         // valid utf8 and also we're only using this to newline match
         // which should be very hard to break. The unsafe conversion
         // here skips a utf8 check which is faster.
+        // FIXME: Is the overhead of utf8 checking actually a bottleneck here?
+        // The comment above even admits there are circumstances where it will
+        // not be UTF-8
         unsafe {
             let s = str::from_utf8_unchecked(&data).to_string();
             s.trim().chars().any(|v| v == '\n')

--- a/librubyfmt/src/rubyfmt.c
+++ b/librubyfmt/src/rubyfmt.c
@@ -20,6 +20,10 @@ long rubyfmt_rb_ary_len(VALUE v) {
   return rb_array_len(v);
 }
 
+VALUE *rubyfmt_rb_ary_ptr(VALUE v) {
+  return RARRAY_PTR(v);
+}
+
 int rubyfmt_rb_nil_p(VALUE v) {
   return RB_NIL_P(v);
 }


### PR DESCRIPTION
This is the result of a partial audit of all unsafe code in rubyfmt. I
found one double free, and many instances where unsafe was used more
than it was needed. In some cases this was caused by omitting extremely
cheap safety checks like UTF-8 validation, and in some cases it was
redundant code converting arrays and strings to Rust versions. I've
added UTF-8 checking where it's clearly not going to cause a performance
problem, commented where it's not clear, and moved array and string
conversion to a common function that's easier to audit.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
