### PR TITLE
Refactor `FileComments` to better demonstrate intent

### DIFF
--- a/librubyfmt/src/comment_block.rs
+++ b/librubyfmt/src/comment_block.rs
@@ -1,14 +1,26 @@
+use std::ops::{AddAssign, Range};
+
 use crate::line_tokens::LineToken;
-use crate::types::ColNumber;
+use crate::types::{ColNumber, LineNumber};
 
 #[derive(Debug)]
 pub struct CommentBlock {
+    span: Range<LineNumber>,
     comments: Vec<String>,
 }
 
 impl CommentBlock {
-    pub fn new(comments: Vec<String>) -> Self {
-        CommentBlock { comments }
+    pub fn new(span: Range<LineNumber>, comments: Vec<String>) -> Self {
+        CommentBlock { span, comments }
+    }
+
+    pub fn following_line_number(&self) -> LineNumber {
+        self.span.end
+    }
+
+    pub fn add_line(&mut self, line: String) {
+        self.span.end += 1;
+        self.comments.push(line);
     }
 
     pub fn into_line_tokens(self) -> Vec<LineToken> {
@@ -18,19 +30,12 @@ impl CommentBlock {
             .collect()
     }
 
-    pub fn apply_spaces(self, indent_depth: ColNumber) -> Self {
-        let new_strings = self
-            .comments
-            .into_iter()
-            .map(|c| {
-                let spaces = (0..indent_depth)
-                    .map(|_| " ".to_string())
-                    .collect::<Vec<String>>()
-                    .join("");
-                format!("{}{}", spaces, c)
-            })
-            .collect();
-        Self::new(new_strings)
+    // FIXME: This should be the responsibility of the formatter
+    pub fn apply_spaces(mut self, indent_depth: ColNumber) -> Self {
+        for comment in &mut self.comments {
+            *comment = str::repeat(" ", indent_depth as _) + comment;
+        }
+        self
     }
 
     pub fn has_comments(&self) -> bool {
@@ -40,8 +45,20 @@ impl CommentBlock {
     pub fn len(&self) -> usize {
         self.comments.len()
     }
+}
 
-    pub fn merge(&mut self, mut other: CommentBlock) {
-        self.comments.append(&mut other.comments);
+impl AddAssign for CommentBlock {
+    fn add_assign(&mut self, mut rhs: CommentBlock) {
+        self.comments.append(&mut rhs.comments);
+    }
+}
+
+impl AddAssign<CommentBlock> for Option<CommentBlock> {
+    fn add_assign(&mut self, rhs: CommentBlock) {
+        if let Some(this) = self {
+            *this += rhs
+        } else {
+            *self = Some(rhs)
+        }
     }
 }


### PR DESCRIPTION
I'm not particularly happy with how this came out, but I do think it's a
clear improvement over what was there before. Previously this has three
obviously interacting fields, with a lot of subtle, undocumented,
unmaintained invariants (or at least in the case of `lowest_key` it was
unmaintained). I do believe that this structure at least better
represents intent.

`CommentBlock` now keeps track of what lines it's on, and the "start of
file sled" (what even is that?!) is kept separately from the rest of the
comments. This reduces (but does not eliminates) the amount of state
that this type has to keep, and makes the intent clearer both in the
type itself, and its state at any single point. At absolute minimum, I
have at least removed all panics from this type's implementation.

That said, this interface has a ton of pitfalls. I really dislike how
much it needs to mutate itself. While developing this patch, it became
clear to me why this is the case. The parser that we've written only
retains the line number and the comment on that line. This means we have
no way to determine if two comments are part of a contiguous block or
not, and it seems we leave the formatter to determine whether that's the
case. We do treat the first comment block specially though, and assume
it's a contiguous block (though I'm not entirely clear why yet).

This is a problem for a number of reasons. First of all, it means that
we will just delete comments if there are more than one on a given line,
potentially breaking comments on method arguments that are significant
to rdoc.

This also misbehaves if the first non-comment line has a trailing
comment (most likely for rdoc, but could also potentially happen if the
first comment is for the file itself, and the trailing comment is a
poorly placed, very short comment for the item it's on)

This type very clearly wants to be `Map<Range<LineNumber>, Vec<String>>`
or even better `Vec<Span, String>` since the formatter should be able to
choose/change where newlines are inserted, and really shouldn't be
coupled to line numbers in the source. I'm sure Ripper *must* give us a
way to determine if non-comment tokens appear between two comments, but
I do not know enough about that layer of the code to fix it in this
patch. The fact that `FileComments` is constructed outside of the main
deserializer is surprising, and I would hope that we can perhaps at
least handle this in a `Deserialize` impl`.

But short of what I'd consider to be a more complete fix, I have at
least tried to make the invariants of this type better upheld, and those
that aren't enforced are now documented (mostly in `push_comment`, which
is still extremely subtle)

I don't think `push_comment` is the right interface for this type.
However, since it was marked as public, I've assumed that it is an
interface intended to be externally consumed and thus needs to be
maintained. If that's not the case, I think we should replace it with
something that only operates when we have a full view of the data, such
as `FromIterator`. In that case we can either manually sort the data
before consuming it, or at least include a debug assertion that it's
already sorted.

Speaking of debug assertions, one thing that stood out to me while
writing this is that the test suite is run in release mode. I'd like to
learn more about why that is.  Previous iterations of this patch
included debug assertions for the invariants that were implied but not
upheld. While none of these landed in the final patch, if they did I
feel like they should be run as part of the test suite.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
