### PR TITLE
Fix bug with yield arguments within ifop

### DIFF
--- a/fixtures/small/yield0_in_ifop_actual.rb
+++ b/fixtures/small/yield0_in_ifop_actual.rb
@@ -1,0 +1,5 @@
+class Foo
+  def bees
+    x ? yield : nil
+  end
+end

--- a/fixtures/small/yield0_in_ifop_expected.rb
+++ b/fixtures/small/yield0_in_ifop_expected.rb
@@ -1,0 +1,5 @@
+class Foo
+  def bees
+    x ? yield : nil
+  end
+end

--- a/fixtures/small/yield_in_ifop_actual.rb
+++ b/fixtures/small/yield_in_ifop_actual.rb
@@ -1,0 +1,5 @@
+class Foo
+  def bees
+    x ? yield(x) : nil
+  end
+end

--- a/fixtures/small/yield_in_ifop_expected.rb
+++ b/fixtures/small/yield_in_ifop_expected.rb
@@ -1,0 +1,5 @@
+class Foo
+  def bees
+    x ? yield(x) : nil
+  end
+end

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -457,10 +457,7 @@ pub fn use_parens_for_method_call(
     }
 
     if name == "return" || name == "raise" || name == "yield" || name == "break" {
-        if ps.current_formatting_context() == FormattingContext::Binary {
-            return true;
-        }
-        if ps.current_formatting_context() == FormattingContext::IfOp {
+        if ps.current_formatting_context_requires_parens() {
             return true;
         }
         match args {

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -460,6 +460,9 @@ pub fn use_parens_for_method_call(
         if ps.current_formatting_context() == FormattingContext::Binary {
             return true;
         }
+        if ps.current_formatting_context() == FormattingContext::IfOp {
+            return true;
+        }
         match args {
             ArgsAddStarOrExpressionList::ArgsAddStar(_) => return true,
             _ => return false,
@@ -2440,15 +2443,17 @@ pub fn format_ifop(ps: &mut ParserState, ifop: IfOp) {
     }
 
     ps.with_start_of_line(false, |ps| {
-        format_expression(ps, *ifop.1);
-        ps.emit_space();
-        ps.emit_keyword("?".to_string());
-        ps.emit_space();
-        format_expression(ps, *ifop.2);
-        ps.emit_space();
-        ps.emit_keyword(":".to_string());
-        ps.emit_space();
-        format_expression(ps, *ifop.3);
+        ps.with_formatting_context(FormattingContext::IfOp, |ps| {
+            format_expression(ps, *ifop.1);
+            ps.emit_space();
+            ps.emit_keyword("?".to_string());
+            ps.emit_space();
+            format_expression(ps, *ifop.2);
+            ps.emit_space();
+            ps.emit_keyword(":".to_string());
+            ps.emit_space();
+            format_expression(ps, *ifop.3);
+        });
     });
 
     if ps.at_start_of_line() {

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -20,6 +20,7 @@ pub enum FormattingContext {
     Def,
     CurlyBlock,
     ArgsList,
+    IfOp,
 }
 
 #[derive(Clone, Copy)]

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -447,6 +447,11 @@ impl ParserState {
             .expect("formatting context is never empty")
     }
 
+    pub fn current_formatting_context_requires_parens(&self) -> bool {
+        self.current_formatting_context() == FormattingContext::Binary
+            || self.current_formatting_context() == FormattingContext::IfOp
+    }
+
     pub fn new_with_depth_stack_from(ps: &ParserState) -> Self {
         let mut next_ps = ParserState::new(FileComments::default());
         next_ps.depth_stack = ps.depth_stack.clone();


### PR DESCRIPTION
Fixes https://github.com/penelopezone/rubyfmt/issues/227

-------------------

**Fix bug with yield arguments within ifop**

A call to yield with arguments within an IfOp (which is what the ruby parser calls a ternery hook) would remove the parentheses from the yield call, which would then produce code that Ruby could not parse because of the precedence of the `?` and `:` operators.

This commit fixes that by ensuring that within an IfOp context we always keep the parentheses around a yield call if it has arguments.

--------------------

Thanks for pointing me in the right direction @penelopezone, your instructions with file names and line numbers were super helpful! 

My commit only adds tests for `yield` but the change would also affect `return`, `raise` and `break` in an IfOp context. I think that's correct because those also fail to parse:

```
$ ruby -c -e 'x ? yield x : nil' 
-e:1: syntax error, unexpected tIDENTIFIER, expecting ':'
x ? yield x : nil

$ ruby -c -e 'x ? return x : nil'
-e:1: syntax error, unexpected tIDENTIFIER, expecting ':'
x ? return x : nil

$ ruby -c -e 'x ? break x : nil' 
-e:1: syntax error, unexpected tIDENTIFIER, expecting ':'
x ? break x : nil

$ ruby -c -e 'x ? raise x : nil'
-e:1: syntax error, unexpected tIDENTIFIER, expecting do or '{' or '('
x ? raise x : nil
```

Let me know if you'd like me to add more tests for those other cases.