### PR TITLE
Support class/module top_const_ref

### DIFF
--- a/fixtures/small/top_const_ref_actual.rb
+++ b/fixtures/small/top_const_ref_actual.rb
@@ -1,0 +1,2 @@
+class ::String
+end

--- a/fixtures/small/top_const_ref_expected.rb
+++ b/fixtures/small/top_const_ref_expected.rb
@@ -1,0 +1,2 @@
+class ::String
+end

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1662,6 +1662,7 @@ pub fn format_class(ps: &mut ParserState, class: Class) {
             ConstPathRefOrConstRef::ConstRef(cr) => {
                 handle_string_and_linecol(ps, (cr.1).1, (cr.1).2);
             }
+            ConstPathRefOrConstRef::TopConstRef(tcr) => format_top_const_ref(ps, tcr),
         }
 
         if inherit.is_some() {
@@ -1711,6 +1712,7 @@ pub fn format_module(ps: &mut ParserState, module: Module) {
             ConstPathRefOrConstRef::ConstRef(cr) => {
                 handle_string_and_linecol(ps, (cr.1).1, (cr.1).2);
             }
+            ConstPathRefOrConstRef::TopConstRef(tcr) => format_top_const_ref(ps, tcr),
         }
     });
 

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1656,13 +1656,13 @@ pub fn format_class(ps: &mut ParserState, class: Class) {
         ps.emit_space();
 
         match class_name {
-            ConstPathRefOrConstRef::ConstPathRef(cpr) => {
+            ConstPathRefOrConstRefOrTopConstRef::ConstPathRef(cpr) => {
                 format_const_path_ref(ps, cpr);
             }
-            ConstPathRefOrConstRef::ConstRef(cr) => {
+            ConstPathRefOrConstRefOrTopConstRef::ConstRef(cr) => {
                 handle_string_and_linecol(ps, (cr.1).1, (cr.1).2);
             }
-            ConstPathRefOrConstRef::TopConstRef(tcr) => format_top_const_ref(ps, tcr),
+            ConstPathRefOrConstRefOrTopConstRef::TopConstRef(tcr) => format_top_const_ref(ps, tcr),
         }
 
         if inherit.is_some() {
@@ -1706,13 +1706,13 @@ pub fn format_module(ps: &mut ParserState, module: Module) {
         ps.emit_space();
 
         match module_name {
-            ConstPathRefOrConstRef::ConstPathRef(cpr) => {
+            ConstPathRefOrConstRefOrTopConstRef::ConstPathRef(cpr) => {
                 format_const_path_ref(ps, cpr);
             }
-            ConstPathRefOrConstRef::ConstRef(cr) => {
+            ConstPathRefOrConstRefOrTopConstRef::ConstRef(cr) => {
                 handle_string_and_linecol(ps, (cr.1).1, (cr.1).2);
             }
-            ConstPathRefOrConstRef::TopConstRef(tcr) => format_top_const_ref(ps, tcr),
+            ConstPathRefOrConstRefOrTopConstRef::TopConstRef(tcr) => format_top_const_ref(ps, tcr),
         }
     });
 

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1507,6 +1507,7 @@ pub struct Kw(pub kw_tag, pub String, pub LineCol);
 pub enum ConstPathRefOrConstRef {
     ConstPathRef(ConstPathRef),
     ConstRef(ConstRef),
+    TopConstRef(TopConstRef),
 }
 
 def_tag!(class_tag, "class");

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1504,7 +1504,7 @@ def_tag!(kw_tag, "@kw");
 pub struct Kw(pub kw_tag, pub String, pub LineCol);
 
 #[derive(RipperDeserialize, Debug, Clone)]
-pub enum ConstPathRefOrConstRef {
+pub enum ConstPathRefOrConstRefOrTopConstRef {
     ConstPathRef(ConstPathRef),
     ConstRef(ConstRef),
     TopConstRef(TopConstRef),
@@ -1514,7 +1514,7 @@ def_tag!(class_tag, "class");
 #[derive(Deserialize, Debug, Clone)]
 pub struct Class(
     pub class_tag,
-    pub ConstPathRefOrConstRef,
+    pub ConstPathRefOrConstRefOrTopConstRef,
     pub Option<Box<Expression>>,
     pub Box<BodyStmt>,
 );
@@ -1523,7 +1523,7 @@ def_tag!(module_tag, "module");
 #[derive(Deserialize, Debug, Clone)]
 pub struct Module(
     pub module_tag,
-    pub ConstPathRefOrConstRef,
+    pub ConstPathRefOrConstRefOrTopConstRef,
     pub Box<BodyStmt>,
 );
 


### PR DESCRIPTION
This kinda threw the name of `ConstPathRefOrConstRef` out the window, which is a little weird. But a TopConstRef is kind of just a ConstPathRef if you squint? 😅