### PR TITLE
Use colordiff in test runner when available

### DIFF
--- a/script/functions.sh
+++ b/script/functions.sh
@@ -21,7 +21,7 @@ diff_files() {
     ACTUAL=$1
     EXPECTED=$2
 
-    if ! $DIFF_BINARY -u "$ACTUAL" "$EXPECTED"
+    if ! $DIFF_BINARY -u "$EXPECTED" "$ACTUAL"
     then
         echo "got diff between formated formatted actual and expected"
         exit 1

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 REPO_BASE=$(git rev-parse --show-toplevel)
 
+# Prefer colordiff if installed
+DIFF_BINARY=$( command -v colordiff || echo "diff" )
+
 f_md5() {
     if command -v md5sum >/dev/null
     then
@@ -14,12 +17,11 @@ f_rubyfmt() {
     "${REPO_BASE}/target/release/rubyfmt-main" "$@"
 }
 
-
 diff_files() {
     ACTUAL=$1
     EXPECTED=$2
 
-    if ! diff -u "$ACTUAL" "$EXPECTED"
+    if ! $DIFF_BINARY -u "$ACTUAL" "$EXPECTED"
     then
         echo "got diff between formated formatted actual and expected"
         exit 1


### PR DESCRIPTION
This updates the test runner to prefer `colordiff` if it's in the `$PATH`. Falls back to the original `diff` behavior.

![image](https://user-images.githubusercontent.com/59429/101565058-488ed880-399a-11eb-8081-aae0829fdc2a.png)
