### PR TITLE
Allow passing a fixture name to the test runner

### DIFF
--- a/script/functions.sh
+++ b/script/functions.sh
@@ -30,7 +30,10 @@ diff_files() {
 test_fixtures_folder() {
     current_dir="$1"
 
-    find "$current_dir" -name "*_expected.rb" -maxdepth 1 | while read -r expected_file; do
+    # Fallback to * (all tests)
+    fixture_name=${FIXTURE_NAME:-*}
+
+    find "$current_dir" -name "${fixture_name}_expected.rb" -maxdepth 1 | while read -r expected_file; do
       actual_file="${expected_file//expected/actual}"
 
       ## Test if the formatting works as expected


### PR DESCRIPTION
This patch lets you easily run a single test fixture, to make the red-green test loop faster. You can pass in the name of a fixture in `FIXTURE_NAME`.

```
$ FIXTURE_NAME=trailing_empty_star script/tests/test_fixtures_small.sh

# runs fixtures/small/trailing_empty_star_actual.rb
```