### PR TITLE
Update formatting of `private def`

### DIFF
--- a/fixtures/small/memoist_expected.rb
+++ b/fixtures/small/memoist_expected.rb
@@ -1,10 +1,7 @@
-memoize(
-  def foo
-  end
-)
-memoize(
-  def foo(x, y, z)
-    aboiqjfdw
-    foo(bar, 1, 2)
-  end
-)
+memoize def foo
+end
+
+memoize def foo(x, y, z)
+  aboiqjfdw
+  foo(bar, 1, 2)
+end

--- a/fixtures/small/private_def_actual.rb
+++ b/fixtures/small/private_def_actual.rb
@@ -1,0 +1,9 @@
+class Foo
+  private def bar
+    42
+  end
+
+  private def baz(a, b, c)
+    a + b + c
+  end
+end

--- a/fixtures/small/private_def_expected.rb
+++ b/fixtures/small/private_def_expected.rb
@@ -1,0 +1,9 @@
+class Foo
+  private def bar
+    42
+  end
+
+  private def baz(a, b, c)
+    a + b + c
+  end
+end

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -586,8 +586,12 @@ pub fn format_ensure(ps: &mut dyn ConcreteParserState, ensure_part: Option<Ensur
     }
 }
 
-pub fn get_def_expression_from_args(args: &ArgsAddStarOrExpressionList) -> Option<&Def> {
+pub fn get_single_def_expression_from_args(args: &ArgsAddStarOrExpressionList) -> Option<&Def> {
     if let ArgsAddStarOrExpressionList::ExpressionList(el) = args {
+        if el.len() != 1 {
+            return None;
+        }
+
         if let Some(Expression::Def(def)) = el.first() {
             return Some(def);
         }
@@ -649,7 +653,7 @@ pub fn use_parens_for_method_call(
         //
         //   private def foo
         //   end
-        if get_def_expression_from_args(&args).is_some() {
+        if get_single_def_expression_from_args(&args).is_some() {
             return false;
         }
     }
@@ -727,7 +731,7 @@ pub fn format_method_call(ps: &mut dyn ConcreteParserState, method_call: MethodC
             };
 
             if !args.is_empty() {
-                match get_def_expression_from_args(&args) {
+                match get_single_def_expression_from_args(&args) {
                     Some(_) => {
                         // If we match `def ...` as the first argument, just
                         // emit it without any delimiters.

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -743,12 +743,7 @@ pub fn format_method_call(ps: &mut dyn ConcreteParserState, method_call: MethodC
                         let expr = el.pop().expect("checked the list is not empty");
 
                         if let Expression::Def(def_expression) = expr {
-                            ps.with_start_of_line(
-                                false,
-                                Box::new(|ps| {
-                                    format_def(ps, def_expression);
-                                }),
-                            );
+                            format_def(ps, def_expression);
                         }
                     }
                 } else {

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2718,10 +2718,6 @@ pub fn format_mod_statement(
                 ps.emit_end();
             }),
         );
-
-        if ps.at_start_of_line() {
-            ps.emit_newline();
-        }
     } else {
         if ps.at_start_of_line() {
             ps.emit_indent();
@@ -2736,10 +2732,10 @@ pub fn format_mod_statement(
                 format_expression(ps, *conditional);
             }),
         );
+    }
 
-        if ps.at_start_of_line() {
-            ps.emit_newline();
-        }
+    if ps.at_start_of_line() {
+        ps.emit_newline();
     }
 }
 


### PR DESCRIPTION
Closes #317.

This _almost_ passes, but I have a trailing newline in the output:

```
$ FIXTURE_NAME=private_def script/tests/test_fixtures_small.sh

+ source ./script/functions.sh
+++ git rev-parse --show-toplevel
++ REPO_BASE=/Users/dbalatero/code/rubyfmt
+++ command -v colordiff
++ DIFF_BINARY=/usr/local/bin/colordiff
+ make
cargo build --release
   Compiling rubyfmt v0.6.8-pre (/Users/dbalatero/code/rubyfmt/librubyfmt)
   Compiling rubyfmt-main v0.6.8-pre (/Users/dbalatero/code/rubyfmt)
    Finished release [optimized] target(s) in 54.46s
cargo build
   Compiling rubyfmt-main v0.6.8-pre (/Users/dbalatero/code/rubyfmt)
   Compiling rubyfmt v0.6.8-pre (/Users/dbalatero/code/rubyfmt/librubyfmt)
    Finished dev [unoptimized + debuginfo] target(s) in 7.89s
+ test_fixtures_folder fixtures/small
+ current_dir=fixtures/small
+ fixture_name=private_def
+ find fixtures/small -name private_def_expected.rb -maxdepth 1
+ read -r expected_file
+ actual_file=fixtures/small/private_def_actual.rb
+ f_rubyfmt fixtures/small/private_def_actual.rb
+ /Users/dbalatero/code/rubyfmt/target/release/rubyfmt-main fixtures/small/private_def_actual.rb

real    0m0.017s
user    0m0.012s
sys     0m0.004s
+ diff_files o /tmp/out.rb fixtures/small/private_def_expected.rb
+ IDEMPOTENCY=o
+ ACTUAL=/tmp/out.rb
+ EXPECTED=fixtures/small/private_def_expected.rb
+ /usr/local/bin/colordiff -u fixtures/small/private_def_expected.rb /tmp/out.rb
--- fixtures/small/private_def_expected.rb      2021-06-19 19:22:13.000000000 -0400
+++ /tmp/out.rb 2021-06-19 19:28:44.000000000 -0400
@@ -6,4 +6,5 @@
   private def baz(a, b, c)
     a + b + c
   end
+
 end
+ [[ o == \i ]]
+ echo 'got diff between formated formatted actual and expected'
got diff between formated formatted actual and expected
+ exit 1
```

I'm new to Rust and this codebase, so if there's something obvious I missed you can point me at, that would be great :)

Also, this will update `memoize def blah` to match this style as well.
