### PR TITLE
Fix handling of `it` and `describe` style tests

### DIFF
--- a/fixtures/small/more_methods_expected.rb
+++ b/fixtures/small/more_methods_expected.rb
@@ -8,7 +8,6 @@ a.b(1)
 a.b(1).c
 
 a do
-
 end.after_block
 
 a.<=(3)

--- a/fixtures/small/rspec_its_actual.rb
+++ b/fixtures/small/rspec_its_actual.rb
@@ -1,0 +1,16 @@
+it "a" \
+  "b" do
+  #hi
+end
+
+it "a" do
+  #hi
+end
+
+describe "foo" do
+  it "foo" do
+  end
+end
+
+RSpec.describe "bees" do
+end

--- a/fixtures/small/rspec_its_expected.rb
+++ b/fixtures/small/rspec_its_expected.rb
@@ -1,0 +1,16 @@
+it "a" \
+  "b" do
+  #hi
+end
+
+it "a" do
+  #hi
+end
+
+describe "foo" do
+  it "foo" do
+  end
+end
+
+RSpec.describe "bees" do
+end


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
