### PR TITLE
Workaround incompatibility between ruby 2.6 and bison 3 on ubuntu 20.10.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "librubyfmt/ruby_checkout/ruby-2.6.6"]
 	path = librubyfmt/ruby_checkout/ruby-2.6.6
-	url = https://github.com/ruby/ruby
+	url = https://github.com/nobu/ruby
+	branch = 2.6-bison3

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ target/release/rubyfmt-main: librubyfmt/src/*.rs librubyfmt/Cargo.toml src/*.rs 
 
 submodules:
 	git submodule init
-	git submodule update
+	git submodule update --remote
 
 target/c_main_debug: main.c target/debug/librubyfmt.a
 	clang -O3 main.c target/debug/librubyfmt.a $(LDFLAGS) -o $@


### PR DESCRIPTION
Preface: I don't expect this to be merged. I wanted to leave this here in case anyone else ran into the same problem (or if I forget what I did to fix this :sweat_smile:).

Changes from using the trunk branch of ruby 2.6.6 to a branch with backported fixes for newer versions of `bison`. The version of `bison` installed in Ubuntu 20.10 is too new and will not compile ruby 2.6.6. This has been fixed in newer versions of ruby but had to be backported. Cherry-picking the commit from this branch allows `make all` to succeed in Ubuntu 20.10.

* Issue describing the compilation failure: https://bugs.ruby-lang.org/issues/17106
* Issue for backporting the fixes: https://bugs.ruby-lang.org/issues/16998
* The branch with backported bison fixes: https://github.com/nobu/ruby/tree/2.6-bison3
