### PR TITLE
Handle assigning to an object's field with an uppercase name.

### DIFF
--- a/fixtures/small/assign_field_actual.rb
+++ b/fixtures/small/assign_field_actual.rb
@@ -1,2 +1,3 @@
 foo.bar = :c
 foo.bar.baz = :c
+foo.Bar = :c

--- a/fixtures/small/assign_field_expected.rb
+++ b/fixtures/small/assign_field_expected.rb
@@ -1,2 +1,3 @@
 foo.bar = :c
 foo.bar.baz = :c
+foo.Bar = :c

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1427,7 +1427,10 @@ pub fn format_field(ps: &mut dyn ConcreteParserState, f: Field) {
         Box::new(|ps| {
             format_expression(ps, *f.1);
             format_dot(ps, f.2);
-            format_ident(ps, f.3);
+            match f.3 {
+                IdentOrConst::Const(c) => format_const(ps, c),
+                IdentOrConst::Ident(i) => format_ident(ps, i),
+            }
         }),
     );
 

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -433,7 +433,7 @@ pub struct Field(
     pub field_tag,
     pub Box<Expression>,
     pub DotTypeOrOp,
-    pub Ident,
+    pub IdentOrConst,
 );
 
 def_tag!(var_ref_tag, "var_ref");


### PR DESCRIPTION
This PR enables rubyfmt to handle this file: https://github.com/chef/chef/blob/master/lib/chef/resource/windows_shortcut.rb

Assigning to an object's field that starts with an uppercase letter has a slightly different parse tree:

```
$ ruby -rripper -rpp -e "pp Ripper.sexp('foo.bar = 1')"
[:program,
 [[:assign,
   [:field,
    [:vcall, [:@ident, "foo", [1, 0]]],
    [:@period, ".", [1, 3]],
    [:@ident, "bar", [1, 4]]],
   [:@int, "1", [1, 10]]]]]
$ ruby -rripper -rpp -e "pp Ripper.sexp('foo.Bar = 1')"
[:program,
 [[:assign,
   [:field,
    [:vcall, [:@ident, "foo", [1, 0]]],
    [:@period, ".", [1, 3]],
    [:@const, "Bar", [1, 4]]],
   [:@int, "1", [1, 10]]]]]
```
