### PR TITLE
Don't add extra newlines to parameter list with multiline strings.

### DIFF
--- a/fixtures/small/multiline_strings_in_parameter_list_actual.rb
+++ b/fixtures/small/multiline_strings_in_parameter_list_actual.rb
@@ -1,0 +1,16 @@
+puts "
+    yellow
+    fruit
+    peel
+    cheese
+    noodle
+    sauce",
+  :burrito,
+  # add some comments here,
+  # why not
+  "
+    jasmine
+    earl grey
+    oolong
+  ",
+  :rice

--- a/fixtures/small/multiline_strings_in_parameter_list_expected.rb
+++ b/fixtures/small/multiline_strings_in_parameter_list_expected.rb
@@ -1,0 +1,18 @@
+puts(
+  "
+    yellow
+    fruit
+    peel
+    cheese
+    noodle
+    sauce",
+  :burrito,
+  # add some comments here,
+  # why not
+  "
+    jasmine
+    earl grey
+    oolong
+  ",
+  :rice
+)

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -370,6 +370,9 @@ impl ConcreteParserState for BaseParserState {
     }
 
     fn emit_string_content(&mut self, s: String) {
+        let newline_count = s.matches('\n').count() as u64;
+        self.current_orig_line_number += newline_count;
+
         self.push_concrete_token(ConcreteLineToken::LTStringContent { content: s });
     }
 


### PR DESCRIPTION
I've run into a problem parsing code in the wild involving heredocs that I am still working on, but I was able to reproduce a small issue I found while working on that in a simpler scenario.

If I run `fixtures/small/multiline_strings_in_parameter_list_actual.rb` through rubyfmt, I get this output:

```
puts(
  "
    yellow
    fruit
    peel
    cheese
    noodle
    sauce",

  :burrito,
  # add some comments here,
  # why not
  "
    jasmine
    earl grey
    oolong
  ",

  :rice
)
```

Notice the extra newlines added after the multiline strings and before the symbols.

Looking at the debug output, the ripper tree generated looks like this:

```
06:24:36 [DEBUG] (1) rubyfmt::format: Program(program_tag, [Command(Command(command_tag, Ident(Ident(ident_tag, "puts", LineCol(1, 0))), ArgsAddBlock(ArgsAddBlock(args_add_block_tag, Parens([Expression(StringLiteral(Normal(string_literal_tag, StringContent(string_content_tag, [TStringContent(TStringContent(tstring_content_tag, "\n    yellow\n    fruit\n    peel\n    cheese\n    noodle\n    sauce", LineCol(1, 6)))])))), Expression(SymbolLiteral(SymbolLiteral(symbol_literal_tag, Symbol(Symbol(symbol_tag, Ident(Ident(ident_tag, "burrito", LineCol(8, 3)))))))), Expression(StringLiteral(Normal(string_literal_tag, StringContent(string_content_tag, [TStringContent(TStringContent(tstring_content_tag, "\n    jasmine\n    earl grey\n    oolong\n  ", LineCol(11, 3)))])))), Expression(SymbolLiteral(SymbolLiteral(symbol_literal_tag, Symbol(Symbol(symbol_tag, Ident(Ident(ident_tag, "rice", LineCol(16, 3))))))))]), NotPresent(false)))))])
```

The first multiline string starts on line 1 and the following symbol starts on line 8. When the symbol is processed `current_orig_line_number` is 1, so during the call to `on_line` with 8, the difference between the two is greater than 1 so an extra newline is added after the previous one on line 1 by the code here https://github.com/phiggins/rubyfmt/blob/cd82aa6f8ae1aab7065f532e016e54337194c231/librubyfmt/src/parser_state.rs#L331-L333.