### PR TITLE
Fix missing newline in some situations with trailing comments.

### DIFF
--- a/fixtures/small/separated_statements_with_trailing_comment_actual.rb
+++ b/fixtures/small/separated_statements_with_trailing_comment_actual.rb
@@ -1,0 +1,3 @@
+a = 1
+
+puts a # trailing comment

--- a/fixtures/small/separated_statements_with_trailing_comment_expected.rb
+++ b/fixtures/small/separated_statements_with_trailing_comment_expected.rb
@@ -1,0 +1,4 @@
+a = 1
+
+# trailing comment
+puts(a)

--- a/librubyfmt/src/comment_block.rs
+++ b/librubyfmt/src/comment_block.rs
@@ -49,6 +49,10 @@ impl CommentBlock {
     pub fn len(&self) -> usize {
         self.comments.len()
     }
+
+    pub fn is_trailing(&self) -> bool {
+        self.span.start + 1 == self.span.end
+    }
 }
 
 pub trait Merge<Other = Self> {

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -741,9 +741,12 @@ impl BaseParserState {
                     .expect("comments stack is never empty")
                 {
                     let len = comments.len();
+                    let trailing_comment = comments.is_trailing();
                     self.insert_comment_collection(comments);
-                    self.current_orig_line_number += len as u64;
-                    debug!("pe coln: {}", len);
+                    if !trailing_comment {
+                        self.current_orig_line_number += len as u64;
+                        debug!("pe coln: {}", len);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Related to #273. 

`push_comments` was incrementing the `current_orig_line_number`, which as far as I understand things, is used to track the line number from the original source file. Since trailing comments do not take up a line in the original source file this feels like a bug to me. 

If I have a file that looks like this:

```
puts "some code at the start of the file"

# multiline comment line 1
# multiline comment line 2
a = 1

# singleline comment
b = 2

c = 3 # trailing comment
```

After adding a debug statement to `push_comments`, I see these lines in the debug output:

```
19:33:19 [DEBUG] (1) rubyfmt::parser_state: on_line called: 5
19:33:19 [DEBUG] (1) rubyfmt::parser_state: CommentBlock { span: 3..6, comments: ["# multiline comment line 1", "# multiline comment line 2"] }

19:33:19 [DEBUG] (1) rubyfmt::parser_state: on_line called: 8
19:33:19 [DEBUG] (1) rubyfmt::parser_state: CommentBlock { span: 7..9, comments: ["# singleline comment"] }

19:33:19 [DEBUG] (1) rubyfmt::parser_state: on_line called: 10
19:33:19 [DEBUG] (1) rubyfmt::parser_state: CommentBlock { span: 10..11, comments: ["# trailing comment"] }
```

Since the end of the range is exclusive, the trailing comment on line 10 has a span that only covers that line, which means a comment with a one-line span is fairly easy to identify as a trailing comment and avoid incrementing the line count for it.