### PR TITLE
WIP: Handle heredoc strings in expressions

### DIFF
--- a/fixtures/small/heredoc_param_actual.rb
+++ b/fixtures/small/heredoc_param_actual.rb
@@ -1,0 +1,22 @@
+puts <<~STRING, <<-STRING2,
+    yellow
+    fruit
+    peel
+  STRING
+    cheese
+    noodle
+    sauce
+  STRING2
+  :burrito,
+  <<~STRING3,
+    jasmine
+    earl grey
+    oolong
+  STRING3
+  :rice
+
+puts [:one, <<~TWO, :three], :four, [:five, <<~SIX, :seven], :eight
+two
+TWO
+six
+SIX

--- a/fixtures/small/heredoc_param_expected.rb
+++ b/fixtures/small/heredoc_param_expected.rb
@@ -1,0 +1,25 @@
+puts(
+  <<~STRING,
+yellow
+fruit
+peel
+  STRING
+  <<-STRING2,
+    cheese
+    noodle
+    sauce
+STRING2
+  :burrito,
+  <<~STRING3,
+jasmine
+earl grey
+oolong
+  STRING3
+  :rice
+)
+
+puts([:one, <<~TWO, :three], :four, [:five, <<~SIX, :seven], :eight)
+two
+    TWO
+six
+    SIX

--- a/fixtures/small/multiline_strings_in_parameter_list_actual.rb
+++ b/fixtures/small/multiline_strings_in_parameter_list_actual.rb
@@ -1,0 +1,16 @@
+puts "
+    yellow
+    fruit
+    peel
+    cheese
+    noodle
+    sauce",
+  :burrito,
+  # add some comments here,
+  # why not
+  "
+    jasmine
+    earl grey
+    oolong
+  ",
+  :rice

--- a/fixtures/small/multiline_strings_in_parameter_list_expected.rb
+++ b/fixtures/small/multiline_strings_in_parameter_list_expected.rb
@@ -1,0 +1,18 @@
+puts(
+  "
+    yellow
+    fruit
+    peel
+    cheese
+    noodle
+    sauce",
+  :burrito,
+  # add some comments here,
+  # why not
+  "
+    jasmine
+    earl grey
+    oolong
+  ",
+  :rice
+)

--- a/fixtures/small/pathalogical_heredocs_actual.rb
+++ b/fixtures/small/pathalogical_heredocs_actual.rb
@@ -1,5 +1,5 @@
 a = <<EOD
-part 1 of heredoc #{ "not a heredoc" + <<EOM }
+part 1 of heredoc #{ "not a heredoc" + <<EOM } after brace before newline
 eom part
 EOM
 part 2 of heredoc

--- a/fixtures/small/pathalogical_heredocs_expected.rb
+++ b/fixtures/small/pathalogical_heredocs_expected.rb
@@ -1,5 +1,5 @@
 a = <<EOD
-part 1 of heredoc #{"not a heredoc" + <<EOM}
+part 1 of heredoc #{"not a heredoc" + <<EOM} after brace before newline
 eom part
 EOM
 part 2 of heredoc

--- a/fixtures/small/separated_statements_with_trailing_comment_actual.rb
+++ b/fixtures/small/separated_statements_with_trailing_comment_actual.rb
@@ -1,0 +1,3 @@
+a = 1
+
+puts a # trailing comment

--- a/fixtures/small/separated_statements_with_trailing_comment_expected.rb
+++ b/fixtures/small/separated_statements_with_trailing_comment_expected.rb
@@ -1,0 +1,4 @@
+a = 1
+
+# trailing comment
+puts(a)

--- a/librubyfmt/src/comment_block.rs
+++ b/librubyfmt/src/comment_block.rs
@@ -49,6 +49,10 @@ impl CommentBlock {
     pub fn len(&self) -> usize {
         self.comments.len()
     }
+
+    pub fn is_trailing(&self) -> bool {
+        self.span.start + 1 == self.span.end
+    }
 }
 
 pub trait Merge<Other = Self> {

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1241,17 +1241,6 @@ pub fn format_inner_string(
                     }),
                 );
                 ps.emit_string_content("}".to_string());
-
-                let on_line_skip = tipe == StringType::Heredoc
-                    && match peekable.peek() {
-                        Some(StringContentPart::TStringContent(TStringContent(_, s, _))) => {
-                            s.starts_with('\n')
-                        }
-                        _ => false,
-                    };
-                if on_line_skip {
-                    ps.render_heredocs(true)
-                }
             }
             StringContentPart::StringDVar(dv) => {
                 ps.emit_string_content("#{".to_string());

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -678,8 +678,11 @@ impl BaseParserState {
                     .expect("comments stack is never empty")
                 {
                     let len = comments.len();
+                    let trailing_comment = comments.is_trailing();
                     self.insert_comment_collection(comments);
-                    self.current_orig_line_number += len as u64;
+                    if !trailing_comment {
+                        self.current_orig_line_number += len as u64;
+                    }
                 }
             }
         }

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -375,6 +375,9 @@ impl ConcreteParserState for BaseParserState {
     }
 
     fn emit_string_content(&mut self, s: String) {
+        let newline_count = s.matches('\n').count() as u64;
+        self.current_orig_line_number += newline_count;
+
         self.push_concrete_token(ConcreteLineToken::LTStringContent { content: s });
     }
 

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -154,3 +154,22 @@ impl BreakableEntry {
         }
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct HeredocString {
+    pub symbol: String,
+    pub squiggly: bool,
+    pub content: String,
+    pub indent: u32,
+}
+
+impl HeredocString {
+    pub fn new(symbol: String, squiggly: bool, content: String, indent: u32) -> Self {
+        HeredocString {
+            symbol,
+            squiggly,
+            content,
+            indent,
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I've made progress resolving some issues I found with rubyfmt's handling of heredocs, but I've reached a point where I can't find a solution for the problems I've found without changing some existing behavior, so this seems like a good point to ask for guidance in how to proceed. To avoid burying the lede, the problem is that there is not enough information present at the time of walking the Ripper tree to know what to do with the content of heredoc strings.

I initially found the problem trying to lint this file: https://github.com/chef/chef/blob/1899968131a27f703deac7de8f186abcf12da86b/lib/chef/resource/chef_client_config.rb#L131-L139

If I extract the troublesome portion to a file:
```
property :ssl_verify_mode, [Symbol, String],
  equal_to: %i{verify_none verify_peer},
  coerce: proc { |x| string_to_symbol(x) },
  description: <<~DESC
  Set the verify mode for HTTPS requests.

  * Use :verify_none for no validation of SSL certificates.
  * Use :verify_peer for validation of all SSL certificates, including the #{ChefUtils::Dist::Server::PRODUCT} connections, S3 connections, and any HTTPS remote_file resource URLs used in #{ChefUtils::Dist::Infra::PRODUCT} runs. This is the recommended setting.
  DESC
```

... this is the output when passed to rubyfmt:
```
property(
  :ssl_verify_mode,
  [Symbol, String],
  equal_to: %i[verify_none verify_peer],
  coerce: proc { |x| string_to_symbol(x) },
  description: <<~DESC
)
Set the verify mode for HTTPS requests.

* Use :verify_none for no validation of SSL certificates.
* Use :verify_peer for validation of all SSL certificates, including the #{ChefUtils::Dist::Server::PRODUCT}connections, S3 connections, and any HTTPS remote_file resource URLs used in #{ChefUtils::Dist::Infra::PRODUCT}runs. This is the recommended setting.
DESC
```

I initially thought it was a problem with the delimiter being printed to early, but a more focused example shows the problem is that heredoc string content is output too late. For example, this code:

```
puts <<~STRING, <<-STRING2,
    yellow
    fruit
    peel
  STRING
    cheese
    noodle
    sauce
  STRING2
  :burrito,
  <<~STRING3,
    jasmine
    earl grey
    oolong
  STRING3
  :rice
```

... produces this output:
```
puts(
  <<~STRING,
  <<-STRING2,

  :burrito,
  <<~STRING3,

  :rice
)
jasmine
earl grey
oolong
    cheese
    noodle
    sauce
yellow
fruit
peel
STRING
STRING2
STRING3
```

A related problem can be demonstrated by modifying one of the fixtures(https://github.com/penelopezone/rubyfmt/blob/367d43bee80c4c9a720d1c30aad3a57e55e0ffab/fixtures/small/pathalogical_heredocs_actual.rb#L1-L6). This code:

```
a = <<EOD
part 1 of heredoc #{ "not a heredoc" + <<EOM } after brace before newline
eom part
EOM
part 2 of heredoc
EOD
```

... produces this output:
```
a = <<EOD
part 1 of heredoc #{"not a heredoc" + <<EOM} after brace before newline
part 2 of heredoc

eom part
EOM
EOD
```

As I stated above, the problem as I see it is that at the time of walking the Ripper tree there is not enough information to decide what to do with the content of heredoc strings. In this PR, I've tried to move that decision making to the point when the abstract tree built from the Ripper tree is converted into the concrete tree of tokens that get output. I'll leave comments inline where necessary to explain particular decisions made.

Some form of the code in this PR was able to correctly format the examples I mentioned above. I say some form because I've tried so many small changes trying to get things to work that it's hard to remember what the current state is sometimes. :sweat_smile: 

The remaining problems I have been trying to deal with:
* Heredoc strings suffer from the same problem solved for other multiline strings in #273. Attempts to fix this have led to creating other formatting problems, mostly around the `is_multiline` function on `BreakableEntry`, which is finicky with respect to the record of lines processed from the original source file. I believe some of the existing fixtures include extra newlines as a result of this bug, for example: https://github.com/penelopezone/rubyfmt/blob/367d43bee80c4c9a720d1c30aad3a57e55e0ffab/fixtures/small/pathalogical_heredocs_expected.rb#L12-L18
* The attempt to solve #273 for heredocs by checking for the presence of newlines in an expression led to problems with maintaining whitespace from the original source file, for example not preserving multiline arrays in this fixture: https://github.com/penelopezone/rubyfmt/blob/367d43bee80c4c9a720d1c30aad3a57e55e0ffab/fixtures/small/return_actual.rb

I'm experienced with ruby but currently learning rust so I apologize for the rough code. :sweat_smile:  I realize this description is a bit scattered but I'm trying to coherently capture a bunch of random thoughts I've had while noodling on this for a while. Hopefully this makes some sense. This PR includes the commits from #273 and #274 to build off of the fixes from those PR.

Any advice on how to proceed would be greatly appreciated. Even if this is not something you want to take on at this time I've had fun and learned a lot about rust poking around and trying things. :heart: