### PR TITLE
Handle undef with string symbol.

### DIFF
--- a/fixtures/small/undef_actual.rb
+++ b/fixtures/small/undef_actual.rb
@@ -1,1 +1,2 @@
 undef items_for
+undef :"foo"

--- a/fixtures/small/undef_expected.rb
+++ b/fixtures/small/undef_expected.rb
@@ -1,1 +1,2 @@
 undef items_for
+undef :"foo"

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1807,7 +1807,10 @@ pub fn format_undef(ps: &mut dyn ConcreteParserState, undef: Undef) {
     ps.emit_ident("undef ".to_string());
     let length = undef.1.len();
     for (idx, literal) in undef.1.into_iter().enumerate() {
-        ps.with_start_of_line(false, Box::new(|ps| format_symbol_literal(ps, literal)));
+        ps.with_start_of_line(
+            false,
+            Box::new(|ps| format_symbol_literal_or_dyna_symbol(ps, literal)),
+        );
         if idx != length - 1 {
             ps.emit_comma_space();
         }

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -256,7 +256,7 @@ pub struct Else(pub else_tag, pub Vec<Expression>);
 
 def_tag!(undef_tag, "undef");
 #[derive(Deserialize, Debug, Clone)]
-pub struct Undef(pub undef_tag, pub Vec<SymbolLiteral>);
+pub struct Undef(pub undef_tag, pub Vec<SymbolLiteralOrDynaSymbol>);
 
 def_tag!(string_concat_tag, "string_concat");
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
Followup to #268, applies the same fix for string symbols to `undef`.