### PR TITLE
Handle redo keyword.

### DIFF
--- a/fixtures/small/redo_actual.rb
+++ b/fixtures/small/redo_actual.rb
@@ -1,0 +1,10 @@
+class Foo
+  def bees
+    begin
+    rescue
+      redo
+    end
+  end
+end
+
+Foo.machine

--- a/fixtures/small/redo_expected.rb
+++ b/fixtures/small/redo_expected.rb
@@ -1,0 +1,10 @@
+class Foo
+  def bees
+    begin
+    rescue
+      redo
+    end
+  end
+end
+
+Foo.machine

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2667,6 +2667,18 @@ pub fn format_retry(ps: &mut dyn ConcreteParserState, _r: Retry) {
     }
 }
 
+pub fn format_redo(ps: &mut dyn ConcreteParserState, _r: Redo) {
+    if ps.at_start_of_line() {
+        ps.emit_indent();
+    }
+
+    ps.emit_keyword("redo".to_string());
+
+    if ps.at_start_of_line() {
+        ps.emit_newline();
+    }
+}
+
 pub fn format_sclass(ps: &mut dyn ConcreteParserState, sc: SClass) {
     if ps.at_start_of_line() {
         ps.emit_indent();
@@ -3081,6 +3093,7 @@ pub fn format_expression(ps: &mut dyn ConcreteParserState, expression: Expressio
         Expression::UnlessMod(um) => format_mod_statement(ps, um.1, um.2, "unless".to_string()),
         Expression::Case(c) => format_case(ps, c),
         Expression::Retry(r) => format_retry(ps, r),
+        Expression::Redo(r) => format_redo(ps, r),
         Expression::SClass(sc) => format_sclass(ps, sc),
         Expression::StabbyLambda(sl) => format_stabby_lambda(ps, sl),
         Expression::Rational(rational) => format_rational(ps, rational),

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -141,6 +141,7 @@ pub enum Expression {
     UnlessMod(UnlessMod),
     Case(Case),
     Retry(Retry),
+    Redo(Redo),
     SClass(SClass),
     Break(Break),
     StabbyLambda(StabbyLambda),
@@ -1757,6 +1758,10 @@ pub struct CaseElse(case_else_tag, pub Vec<Expression>);
 def_tag!(retry_tag, "retry");
 #[derive(Deserialize, Debug, Clone)]
 pub struct Retry(retry_tag);
+
+def_tag!(redo_tag, "redo");
+#[derive(Deserialize, Debug, Clone)]
+pub struct Redo(redo_tag);
 
 def_tag!(sclass_tag, "sclass");
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
This fixes the file `lib/concurrent-ruby/concurrent/thread_safe/util/striped64.rb` in #221.