### PR TITLE
Handle defining a method on a non local variable bare word.

### DIFF
--- a/fixtures/small/def_scope_actual.rb
+++ b/fixtures/small/def_scope_actual.rb
@@ -1,0 +1,9 @@
+def m
+  Object
+end
+
+def m.lol
+  :lol
+end
+
+puts m.lol

--- a/fixtures/small/def_scope_expected.rb
+++ b/fixtures/small/def_scope_expected.rb
@@ -1,0 +1,9 @@
+def m
+  Object
+end
+
+def m.lol
+  :lol
+end
+
+puts(m.lol)

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1847,6 +1847,9 @@ pub fn format_defs(ps: &mut dyn ConcreteParserState, defs: Defs) {
                 Singleton::Paren(pe) => {
                     format_paren(ps, pe);
                 }
+                Singleton::VCall(vc) => {
+                    format_method_call(ps, vc.to_method_call());
+                }
             }
 
             ps.emit_dot();

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1559,6 +1559,7 @@ pub enum IdentOrKw {
 pub enum Singleton {
     VarRef(VarRef),
     Paren(ParenExpr),
+    VCall(VCall),
 }
 
 // can only occur in defs, Op is always `::`


### PR DESCRIPTION
While investigating #221, I found that rubyfmt failed on this code: https://github.com/ruby-concurrency/concurrent-ruby/blob/7b7900a9133a5c31e60fc55133559ae07c934d69/spec/concurrent/mvar_spec.rb#L327-L336

It seems that Ripper generates a slightly different sexp when defining a method on a bare word that is not a local variable.

```
def foo.my_method
  :foo
end

bar = "bar"
def bar.my_method
  :bar
end
```

```
[:program,
 [[:defs,
   [:vcall, [:@ident, "foo", [1, 4]]],
   [:@period, ".", [1, 7]],
   [:@ident, "my_method", [1, 8]],
   [:params, nil, nil, nil, nil, nil, nil, nil],
   [:bodystmt,
    [[:symbol_literal, [:symbol, [:@ident, "foo", [2, 3]]]]],
    nil,
    nil,
    nil]],
  [:assign,
   [:var_field, [:@ident, "bar", [5, 0]]],
   [:string_literal, [:string_content, [:@tstring_content, "bar", [5, 7]]]]],
  [:defs,
   [:var_ref, [:@ident, "bar", [6, 4]]],
   [:@period, ".", [6, 7]],
   [:@ident, "my_method", [6, 8]],
   [:params, nil, nil, nil, nil, nil, nil, nil],
   [:bodystmt,
    [[:symbol_literal, [:symbol, [:@ident, "bar", [7, 3]]]]],
    nil,
    nil,
    nil]]]]
```