### PR TITLE
Fixes rendering heredocs in method calls.

### DIFF
--- a/ci/string_literals_stress_test.rb
+++ b/ci/string_literals_stress_test.rb
@@ -36,3 +36,47 @@ puts %q(\\"\\")
 puts %q(\))
 puts %Q(\))
 puts %<foo\>>
+
+puts(
+  1,
+  2,
+  <<~TXT,
+    3
+    4
+  TXT
+)
+
+puts(
+  1,
+  2,
+  <<TXT,
+    3
+    4
+TXT
+)
+
+def foo
+  puts(
+    1,
+    2,
+    <<~TXT,
+      3
+      4
+    TXT
+  )
+
+  puts(
+    1,
+    2,
+    <<TXT,
+      3
+      4
+TXT
+  )
+end
+
+foo
+
+puts <<EOD.gsub("a", "b")
+"cde"
+EOD

--- a/fixtures/small/hash_heredoc_actual.rb
+++ b/fixtures/small/hash_heredoc_actual.rb
@@ -1,0 +1,8 @@
+hash = {
+  heredoc_key: <<EOD,
+  a
+EOD
+  non_heredoc_key: "c"
+}
+
+puts hash

--- a/fixtures/small/hash_heredoc_expected.rb
+++ b/fixtures/small/hash_heredoc_expected.rb
@@ -1,0 +1,8 @@
+hash = {
+  heredoc_key: <<EOD,
+  a
+EOD
+  non_heredoc_key: "c"
+}
+
+puts(hash)

--- a/fixtures/small/heredoc_ending_with_curly_expected.rb
+++ b/fixtures/small/heredoc_ending_with_curly_expected.rb
@@ -1,4 +1,5 @@
-raise <<-EOM.gsub(/^\s+\|/, "")
+raise(
+  <<-EOM.gsub(
               |#{"*" * 50}
               |:#{key} is not allowed
               |
@@ -12,3 +13,7 @@ raise <<-EOM.gsub(/^\s+\|/, "")
               |  #{RESERVED_KEYS.join("\n  ")}
               |#{"*" * 50}
 EOM
+    /^\s+\|/,
+    ""
+  )
+)

--- a/fixtures/small/heredoc_with_call_expected.rb
+++ b/fixtures/small/heredoc_with_call_expected.rb
@@ -1,5 +1,8 @@
-foo = <<EOM.gsub(".", "b")
+foo = <<EOM.gsub(
 qoiefjqwoeifjqwe
 EOM
+  ".",
+  "b"
+)
 
 puts(foo)

--- a/fixtures/small/heredocs_in_calls_actual.rb
+++ b/fixtures/small/heredocs_in_calls_actual.rb
@@ -1,0 +1,39 @@
+puts(
+  1,
+  2,
+  <<~TXT,
+    3
+    4
+  TXT
+)
+
+puts(
+  1,
+  2,
+  <<TXT,
+    3
+    4
+TXT
+)
+
+def foo
+  puts(
+    1,
+    2,
+    <<~TXT,
+      3
+      4
+    TXT
+  )
+
+  puts(
+    1,
+    2,
+    <<TXT,
+      3
+      4
+TXT
+  )
+end
+
+foo

--- a/fixtures/small/heredocs_in_calls_expected.rb
+++ b/fixtures/small/heredocs_in_calls_expected.rb
@@ -1,0 +1,39 @@
+puts(
+  1,
+  2,
+  <<~TXT
+  3
+  4
+  TXT
+)
+
+puts(
+  1,
+  2,
+  <<TXT
+    3
+    4
+TXT
+)
+
+def foo
+  puts(
+    1,
+    2,
+    <<~TXT
+    3
+    4
+    TXT
+    )
+
+  puts(
+    1,
+    2,
+    <<TXT
+      3
+      4
+TXT
+    )
+end
+
+foo

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1294,8 +1294,7 @@ pub fn format_heredoc_string_literal(
         Box::new(|ps| {
             let heredoc_type = (hd.1).0;
             let heredoc_symbol = (hd.1).1;
-            ps.emit_ident(heredoc_type.clone());
-            ps.emit_ident(heredoc_symbol.clone());
+            ps.emit_heredoc_start(heredoc_type.clone(), heredoc_symbol.clone());
 
             ps.push_heredoc_content(heredoc_symbol, heredoc_type.contains('~'), parts);
         }),

--- a/librubyfmt/src/heredoc_string.rs
+++ b/librubyfmt/src/heredoc_string.rs
@@ -1,0 +1,19 @@
+use crate::types::ColNumber;
+#[derive(Debug, Clone)]
+pub struct HeredocString {
+    pub symbol: String,
+    pub squiggly: bool,
+    pub buf: Vec<u8>,
+    pub indent: ColNumber,
+}
+
+impl HeredocString {
+    pub fn new(symbol: String, squiggly: bool, buf: Vec<u8>, indent: ColNumber) -> Self {
+        HeredocString {
+            symbol,
+            squiggly,
+            buf,
+            indent,
+        }
+    }
+}

--- a/librubyfmt/src/intermediary.rs
+++ b/librubyfmt/src/intermediary.rs
@@ -35,6 +35,12 @@ impl Intermediary {
         self.tokens.len()
     }
 
+    pub fn pop_heredoc_mistake(&mut self) {
+        self.tokens.remove(self.tokens.len() - 1);
+        self.tokens.remove(self.tokens.len() - 1);
+        self.index_of_last_hard_newline = self.tokens.len() - 1;
+    }
+
     pub fn last_4(
         &self,
     ) -> Option<(

--- a/librubyfmt/src/lib.rs
+++ b/librubyfmt/src/lib.rs
@@ -19,6 +19,7 @@ mod de;
 mod delimiters;
 mod file_comments;
 mod format;
+mod heredoc_string;
 mod intermediary;
 mod line_metadata;
 mod line_tokens;

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -37,6 +37,16 @@ impl RenderQueueWriter {
 
             if accum.len() >= 4 {
                 if let (
+                    &ConcreteLineToken::HeredocClose { .. },
+                    &ConcreteLineToken::HardNewLine,
+                    &ConcreteLineToken::Indent { .. },
+                    &ConcreteLineToken::HardNewLine,
+                ) = accum.last_4().expect("we checked length")
+                {
+                    accum.pop_heredoc_mistake();
+                }
+
+                if let (
                     &ConcreteLineToken::End,
                     &ConcreteLineToken::HardNewLine,
                     &ConcreteLineToken::Indent { .. },


### PR DESCRIPTION
The problem was that essentially they would always be placed in the
wrong place due to how we assumed they work with newlines. This puts the
heredocs on collapsing newlines if we go to render an abstract target
(like a method call) and then pops them in the right place at the render
queue writer stage.

Fixes #209