### PR TITLE
Handle flags in calls to rspec DSL methods.

### DIFF
--- a/fixtures/small/rspec_its_actual.rb
+++ b/fixtures/small/rspec_its_actual.rb
@@ -7,6 +7,10 @@ it "a" do
   #hi
 end
 
+it "a", flag: true do
+  #hi
+end
+
 describe "foo" do
   it "foo" do
   end

--- a/fixtures/small/rspec_its_expected.rb
+++ b/fixtures/small/rspec_its_expected.rb
@@ -7,6 +7,10 @@ it "a" do
   #hi
 end
 
+it "a", flag: true do
+  #hi
+end
+
 describe "foo" do
   it "foo" do
   end

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -678,7 +678,12 @@ pub fn format_list_like_thing_items(
             //raise "this is bad" if expr[0] == :tstring_content
 
             if single_line {
-                format_expression(ps, expr);
+                match expr {
+                    Expression::BareAssocHash(bah) => {
+                        format_assocs(ps, bah.1, SpecialCase::NoLeadingTrailingCollectionMarkers)
+                    }
+                    expr => format_expression(ps, expr),
+                }
                 if idx != args_count - 1 {
                     ps.emit_comma_space();
                 }


### PR DESCRIPTION
Another one from looking at #221, this caused rubyfmt to panic with this error message:

```
thread 'main' panicked at 'failed to convert', librubyfmt/src/parser_state.rs:754:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

