### PR TITLE
Handle more than one flag passed after description in rspec DSL methods.

### DIFF
--- a/fixtures/small/rspec_its_actual.rb
+++ b/fixtures/small/rspec_its_actual.rb
@@ -11,10 +11,30 @@ it "a", flag: true do
   #hi
 end
 
+it "a", flag: true, other: "b", another: false do
+  #hi
+end
+
 describe "foo" do
   it "foo" do
   end
 end
 
+describe "foo", flag: true do
+  it "foo" do
+  end
+end
+
+describe "foo", flag: true, other: "b", another: false do
+  it "foo" do
+  end
+end
+
 RSpec.describe "bees" do
+end
+
+RSpec.describe "bees", flag: true do
+end
+
+RSpec.describe "bees", flag: true, other: "b", another: false do
 end

--- a/fixtures/small/rspec_its_expected.rb
+++ b/fixtures/small/rspec_its_expected.rb
@@ -11,10 +11,30 @@ it "a", flag: true do
   #hi
 end
 
+it "a", flag: true, other: "b", another: false do
+  #hi
+end
+
 describe "foo" do
   it "foo" do
   end
 end
 
+describe "foo", flag: true do
+  it "foo" do
+  end
+end
+
+describe "foo", flag: true, other: "b", another: false do
+  it "foo" do
+  end
+end
+
 RSpec.describe "bees" do
+end
+
+RSpec.describe "bees", flag: true do
+end
+
+RSpec.describe "bees", flag: true, other: "b", another: false do
 end


### PR DESCRIPTION
Followup to #283.
This is the last PR needed to close #221.

This ended up being more involved than I expected because `format_assocs` was written expecting there was a breakable on the breakable stack, and in the single line case this wasn't true.

I might have been able to fix this by wrapping the initial divergence in a breakable, in the top branch of this code, but it seemed like a deliberate choice not to do that: https://github.com/phiggins/rubyfmt/blob/81b710e8f86a7b466ecdff410581347da66fa79a/librubyfmt/src/format.rs#L2292-L2297

@penelopezone do you have thoughts on this one?