### PR TITLE
fixes a bug with how the first arg being a rest param works

### DIFF
--- a/fixtures/small/first_rest_param_actual.rb
+++ b/fixtures/small/first_rest_param_actual.rb
@@ -1,0 +1,12 @@
+def spawn(
+  *args,
+    type: @Actor.class,
+  channel: Promises::Channel.new,
+  environment: Environment,
+  name: nil,
+  executor: default_executor,
+  link: false,
+  monitor: false,
+  &body
+)
+end

--- a/fixtures/small/first_rest_param_expected.rb
+++ b/fixtures/small/first_rest_param_expected.rb
@@ -1,0 +1,12 @@
+def spawn(
+  *args,
+  type: @Actor.class,
+  channel: Promises::Channel.new,
+  environment: Environment,
+  name: nil,
+  executor: default_executor,
+  link: false,
+  monitor: false,
+  &body
+)
+end


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
