### PR TITLE
Use a cargo workspace.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[workspace]
+members = [
+  "librubyfmt",
+  "librubyfmt/ripper_deserialize"
+]
+
 [package]
 name = "rubyfmt-main"
 version = "0.1.0"

--- a/Makefile
+++ b/Makefile
@@ -12,34 +12,26 @@ endif
 LDFLAGS +=  -lz
 
 all: submodules release debug
-debug: target/debug/librubyfmt.a target/debug/rubyfmt-main
-release: target/release/librubyfmt.a target/release/rubyfmt-main
 
-target/debug/rubyfmt-main: librubyfmt/src/*.rs librubyfmt/Cargo.toml src/*.rs Cargo.toml
+debug:
 	cargo build
 
-target/release/rubyfmt-main: librubyfmt/src/*.rs librubyfmt/Cargo.toml src/*.rs Cargo.toml
+release:
 	cargo build --release
 
 submodules:
 	git submodule init
 	git submodule update
 
-target/c_main_debug: main.c target/debug/librubyfmt.a
-	clang -O3 main.c target/debug/librubyfmt.a $(LDFLAGS) -o $@
+target/c_main_debug: target/debug/deps/librubyfmt-*.a main.c
+	clang -O3 main.c $< $(LDFLAGS) -o $@
 
-target/c_main_release: main.c target/release/librubyfmt.a
-	clang -O3 main.c target/release/librubyfmt.a $(LDFLAGS) -o $@
+target/c_main_release: target/release/deps/librubyfmt-*.a main.c
+	clang -O3 main.c $< $(LDFLAGS) -o $@
 
-target/release/librubyfmt.a: librubyfmt/src/*.rs librubyfmt/Cargo.toml
-	mkdir -p target/release
-	cd librubyfmt && cargo build --release
-	cp librubyfmt/target/release/librubyfmt.a $@
+target/release/deps/librubyfmt-*.a: release
 
-target/debug/librubyfmt.a: librubyfmt/src/*.rs librubyfmt/Cargo.toml
-	mkdir -p target/debug
-	cd librubyfmt && cargo build
-	cp librubyfmt/target/debug/librubyfmt.a $@
+target/debug/deps/librubyfmt-*.a: debug
 
 lint: clippy
 	./script/lints/lint_fixtures.sh
@@ -51,7 +43,6 @@ clean:
 
 fmt:
 	cargo fmt
-	cd librubyfmt && cargo fmt && git add -u ./
 
 clippy:
-	cargo clippy && cd librubyfmt && cargo clippy
+	cargo clippy

--- a/script/lints/lint_rust.sh
+++ b/script/lints/lint_rust.sh
@@ -4,7 +4,4 @@ set -euxo pipefail
 (
 cargo clippy
 cargo fmt -- --check
-cd librubyfmt
-cargo clippy
-cargo fmt -- --check
 )


### PR DESCRIPTION
Implements #233.

This doesn't seem like a huge change but makes building the project and using all the `cargo` commands a little simpler. 

* [The workspaces section of the cargo book was a useful reference](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html)
* [The workspaces section of the rust book was less useful](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspace-section), it made it sound like only one option, what the cargo book calls the `virtual manifest`, was possible.