### PR TITLE
Handle intentionally bad code

### DIFF
--- a/librubyfmt/rubyfmt_lib.rb
+++ b/librubyfmt/rubyfmt_lib.rb
@@ -213,7 +213,7 @@ class Parser < Ripper::SexpBuilderPP
       end_delim = @string_stack.pop
       start_delim = @string_stack.pop
 
-      if start_delim != "\""
+      if start_delim && end_delim && start_delim != "\""
         if start_delim == "'" || start_delim.start_with?("%q")
           # re-evaluate the string with its own quotes to handle escaping.
           if args[0][1]

--- a/librubyfmt/rubyfmt_lib.rb
+++ b/librubyfmt/rubyfmt_lib.rb
@@ -5,8 +5,8 @@ module TrackAllScannerEvents
       super(*args)
     end
   end
-
 end
+
 class Parser < Ripper::SexpBuilderPP
   ARRAY_SYMBOLS = {qsymbols: "%i", qwords: "%w", symbols: "%I", words: "%W"}.freeze
 


### PR DESCRIPTION
For whatever reason the chef repo has files with an .rb extension with garbage text: https://github.com/chef/chef/blob/master/spec/data/cookbooks/ignorken/recipes/ignoreme.rb

This was getting into the `on_string_literal` method with only one element on the string_delimiter stack, making `start_delim` nil on line 217: https://github.com/penelopezone/rubyfmt/blob/641534ce3730eaf060115a0c59b6bbbdd55ef4c0/librubyfmt/rubyfmt_lib.rb#L217

Before:
```
$ cat ../chef/spec/data/cookbooks/ignorken/recipes/ignoreme.rb | ./target/release/rubyfmt-main
A ruby error occurred: #<NoMethodError: undefined method `start_with?' for nil:NilClass>, please file a bug report at https://github.com/penelopezone/rubyfmt/issues/new
```

After:
```
$ cat ../chef/spec/data/cookbooks/ignorken/recipes/ignoreme.rb | ./target/release/rubyfmt-main
stdin contained invalid ruby syntax
```
