### PR TITLE
Automatically inform the user if a new version is available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "miniz_oxide",
  "object",
@@ -36,22 +36,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecount"
-version = "0.6.0"
+name = "base64"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0017894339f586ccb943b01b9555de56770c11cda818e7e3d8bd93f4ed7f46e"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bumpalo"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "cc"
-version = "1.0.55"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1be3409f94d7bdceeb5f5fac551039d9b3f00e25da7a74fc4d33400a0d96368"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -65,16 +83,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+
+[[package]]
+name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 
 [[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "itoa"
@@ -104,6 +198,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,12 +220,18 @@ checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "miniz_oxide"
@@ -153,10 +268,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.18"
+name = "once_cell"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -171,6 +298,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "ripper_deserialize"
 version = "0.1.0"
 dependencies = [
@@ -181,10 +342,9 @@ dependencies = [
 
 [[package]]
 name = "rubyfmt"
-version = "0.1.0"
+version = "0.6.8-pre"
 dependencies = [
  "backtrace",
- "bytecount",
  "cc",
  "jemallocator",
  "libc",
@@ -198,10 +358,16 @@ dependencies = [
 
 [[package]]
 name = "rubyfmt-main"
-version = "0.1.0"
+version = "0.6.8-pre"
 dependencies = [
+ "dirs",
+ "filetime",
+ "glob",
  "libc",
  "rubyfmt",
+ "semver",
+ "serde",
+ "ureq",
 ]
 
 [[package]]
@@ -211,10 +377,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "serde"
@@ -259,10 +454,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.33"
+name = "spin"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "syn"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -289,10 +490,168 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2475a6781e9bc546e7b64f4013d2f4032c8c6a40fcffd7c6f4ee734a890972ab"
+dependencies = [
+ "base64",
+ "chunked_transfer",
+ "log",
+ "once_cell",
+ "rustls",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,18 @@ members = [
 
 [package]
 name = "rubyfmt-main"
-version = "0.1.0"
+version = "0.6.8-pre"
 authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rubyfmt = { path = "./librubyfmt" }
+dirs = "3.0.2"
+filetime = "0.2.14"
+glob = "0.3"
 libc = "0.2.71"
+rubyfmt = { path = "./librubyfmt" }
+semver = "1.0.1"
+serde = { version = "1.0", features = ["derive"] }
+ureq = { version = "2.1.1", features = ["json"] }

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rubyfmt"
-version = "0.1.0"
+version = "0.6.8-pre"
 authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
 edition = "2018"
 build = "build.rs"
@@ -10,7 +10,6 @@ build = "build.rs"
 [dependencies]
 serde = { version = "1.0", features=["derive"] }
 serde_json = "1.0.40"
-bytecount = "0.6.0"
 backtrace = "0.3.45"
 libc = "0.2.68"
 ripper_deserialize = { path = "ripper_deserialize" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #![deny(warnings, missing_copy_implementations)]
 
+mod updates;
+
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, metadata, read_to_string, OpenOptions};
 use std::io::{self, Read, Write};
@@ -111,6 +113,7 @@ fn handle_error_from(err: rubyfmt::RichFormatError, source: &Path, error_exit: E
 }
 
 fn main() {
+    updates::begin_checking_for_updates();
     let res = rubyfmt::rubyfmt_init();
     if res != rubyfmt::InitStatus::OK as libc::c_int {
         panic!(
@@ -142,6 +145,9 @@ fn main() {
             eprintln!("{}", include_str!("../README.md"));
             exit(1);
         }
+        (Some("--internal-fetch-latest-version"), _) => {
+            updates::fetch_latest_version().unwrap();
+        }
         // Single file
         (_, [filename]) => {
             if let Ok(md) = metadata(&filename) {
@@ -168,4 +174,5 @@ fn main() {
             format_parts(parts);
         }
     }
+    updates::report_if_update_available();
 }

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -1,0 +1,128 @@
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+#[cfg(not(debug_assertions))]
+use std::process::Stdio;
+use std::time::Duration;
+
+const ONE_DAY: Duration = Duration::from_secs(60 * 60 * 24);
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct GithubTag {
+    name: String,
+}
+
+/// Begins the process of checking if a new version is available
+///
+/// This will check the timestamp of a file containing the latest version of rubyfmt. If the file
+/// hasn't been updated in at least a day, the file will be touched and a process will be spawned
+/// to write the most recent version.
+///
+/// Panics on any error in debug builds. Since this process is strictly optional, any errors are
+/// ignored in release builds.
+pub(crate) fn begin_checking_for_updates() {
+    let result = try_begin_checking_for_updates();
+    if cfg!(debug_assertions) {
+        result.unwrap();
+    }
+}
+
+fn try_begin_checking_for_updates() -> io::Result<()> {
+    let path = path_to_latest_version_file()?;
+    let time_since_modified = time_since_last_update(&path)?;
+    if time_since_modified >= ONE_DAY {
+        // Eagerly update the timestamp. If something goes wrong, we don't
+        // want to be spamming GitHub's API.
+        filetime::set_file_mtime(&path, filetime::FileTime::now())?;
+        let mut command = Command::new(env::current_exe()?);
+        command.arg("--internal-fetch-latest-version");
+        #[cfg(not(debug_assertions))]
+        {
+            command.stdout(Stdio::null());
+            command.stderr(Stdio::null());
+        }
+        command.spawn()?;
+    }
+    Ok(())
+}
+
+/// Reports if updates are available
+///
+/// This will check a file which contains the latest available version of rubyfmt. If it is greater
+/// than the current version, we will print to stderr that an update is available. Since this
+/// process is strictly optional, any errors will be silently ignored.
+///
+/// For most code bases, rubyfmt will finish running well before the update check is completed.
+/// This means that this function will most likely only print a warning on the second run after an
+/// update is available.
+pub(crate) fn report_if_update_available() {
+    let result = try_report_if_update_available();
+    if cfg!(debug_assertions) {
+        result.unwrap();
+    }
+}
+
+fn try_report_if_update_available() -> io::Result<()> {
+    let latest_version = latest_available_rubyfmt_version()?;
+    if latest_version > installed_rubyfmt_version() {
+        eprintln!("A new version of rubyfmt is available at https://github.com/penelopezone/rubyfmt/releases/tag/v{}", latest_version);
+    }
+    Ok(())
+}
+
+fn installed_rubyfmt_version() -> semver::Version {
+    semver::Version::parse(env!("CARGO_PKG_VERSION"))
+        .expect("$CARGO_PKG_VERSION should always be a valid semver version")
+}
+
+fn latest_available_rubyfmt_version() -> io::Result<semver::Version> {
+    let latest_version_str = fs::read_to_string(path_to_latest_version_file()?)?;
+    semver::Version::parse(&latest_version_str)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+/// Determine the most recent version of Rubyfmt, and write it to a file
+///
+/// Because GitHub paginates its responses to this endpoint, this assumes that the latest version
+/// is in the first 30 tags given to us (which are sorted in lexographically descending order).
+/// Tags which are a version release are assumed to always be `v` followed by a semver version (for
+/// example, v1.0.0)
+pub(crate) fn fetch_latest_version() -> Result<(), Box<dyn Error>> {
+    let max_version = ureq::get("https://api.github.com/repos/penelopezone/rubyfmt/tags")
+        .set("Accept", "application/vnd.github.v3+json")
+        .set("User-Agent", "rubyfmt update checker")
+        .call()?
+        .into_json::<Vec<GithubTag>>()?
+        .into_iter()
+        .filter(|tag| tag.name.starts_with('v'))
+        .filter_map(|tag| semver::Version::parse(&tag.name[1..]).ok())
+        .max()
+        .ok_or("no valid versions found")?;
+    fs::write(path_to_latest_version_file()?, max_version.to_string())?;
+    Ok(())
+}
+
+fn path_to_latest_version_file() -> io::Result<PathBuf> {
+    let path = dirs::data_dir()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "No data directory configured"))?
+        .join(".rubyfmt-latest-version");
+    Ok(path)
+}
+
+fn time_since_last_update(path: &Path) -> io::Result<Duration> {
+    let meta = match fs::metadata(path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            fs::write(&path, env!("CARGO_PKG_VERSION"))?;
+            return Ok(Duration::default());
+        }
+        Err(e) => return Err(e),
+    };
+    let time_since_modified = meta.modified()?.elapsed();
+    // If mtime is in the future, we'll get an error from `elapsed`.
+    // Just return a zero duration in this case
+    Ok(time_since_modified.unwrap_or_default())
+}


### PR DESCRIPTION
(This PR includes #302, as that refactor was done to make this PR easier to write)

Penelope asked me to "build an auto-update checking mechanism that
doesn't slow it down". This should meet that criteria, though not
slowing things down definitely made it trickier.

Once this PR is merged, the version field in `Cargo.toml` will need to
start getting updated whenever a new release is put out. I've also
updated the version field for librubyfmt, but it's not used by the code
in this commit.

To determine what the most recent version is, we hit GitHub's API to get
the tags on the repo, and look for the highest tag that looks like a
version (using semver sorting, not lexographic sorting which is what
GitHub would give us). To avoid spamming their API, we perform this
check at most once per day.

The difficult thing about checking for updates this way is that rubyfmt
is very likely to finish doing its thing faster than we can make that
network request, especially if the user is on a high latency connection.

Because of this, we spawn a detached child process to make the API
request. The version it finds is written to a file, and the mtime of
that file is used to track when the last time we asked GitHub was. The
only work done by the main rubyfmt process is reading that file.

As written, this commit does technically slow it down since I'm blocking
on the file I/O. I believe the impact here should be negligible, though
it might be measurable if rubyfmt is reading from stdin/out instead of
doing file I/O elsewhere. If this is a concern, I can move the file IO
to another thread and have it race, so if we can't read the file to
check the version before formatting finishes, we just exit. I think the
gains from doing this would be marginal at best.

Since we need to have persistent state across runs, the question arises
of where we should actually put this file. I opted to put this in a data
dir, rather than a cache dir, since we don't actually want this file
getting cleaned up if disk space is low. On Linux this will end up in
either `$XDG_DATA_HOME` or `~/.local/store`. On Mac it'll end up in
`~/Library/Application Support`. On Windows it'll end up in
`~/AppData/Roaming`.

Because we're hitting an external API for something that is strictly an
optional feature, I've been very defensive about making sure we hit the
API *at most* once per day. We pessimistically update the mtime before
actually making the request, so that if something goes wrong we don't
end up spamming their API after every run. If an error does occur for
some reason, it will be silently ignored in release mode. In debug
builds it will panic if the error happened in the parent process, or
print to stderr if it happened in the child.

This uses `ureq`, which is definitely not a common or standard HTTP
client. I would normally go with `reqwest`, but that ends up pulling in
the entire tokio ecosystem, since it's async by default. I didn't want
to add that sort of impact on our compile times. `ureq` is a lighter
weight HTTP client that suits our needs, and is widely used enough that
I'm comfortable with depending on it.