### PR TITLE
Replace `glob` with basic directory traversal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,12 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,7 +199,6 @@ dependencies = [
 name = "rubyfmt-main"
 version = "0.1.0"
 dependencies = [
- "glob",
  "libc",
  "rubyfmt",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ edition = "2018"
 [dependencies]
 rubyfmt = { path = "./librubyfmt" }
 libc = "0.2.71"
-glob = "0.3"


### PR DESCRIPTION
The `glob` crate as well as any alternatives I could find, don't provide
a way to provide a base directory. That means that in the unlikely event
that `rubyfmt` was called on a directory that is not valid UTF-8, we
error out. Ultimately the thing we were using `glob` for, was relatively
simple, and we don't need to pull in a dependency to save us ~3 lines of
code

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
