### PR TITLE
Don't crash with invalid syntax.

### DIFF
--- a/librubyfmt/rubyfmt_lib.rb
+++ b/librubyfmt/rubyfmt_lib.rb
@@ -62,11 +62,10 @@ class Parser < Ripper::SexpBuilderPP
   def parse
     res = super
 
-    if res != nil
-      x = [res, @comments, @lines_with_any_ruby, @last_ln]
-      x
-    else
+    if res == nil || error?
       nil
+    else
+      [res, @comments, @lines_with_any_ruby, @last_ln]
     end
   end
 


### PR DESCRIPTION
Fixes #312

Ripper continues parsing after finds some syntactically invalid code. For rubyfmt's purposes, invalid code is an error, so don't attempt to format the partial tree returned with invalid syntax.