### PR TITLE
Update embedded ruby from 2.6.6 -> 2.7.x

### DIFF
--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -57,13 +57,4 @@ jobs:
         rustup component add clippy --toolchain stable-x86_64-apple-darwin
         rustup component add rustfmt --toolchain stable-x86_64-apple-darwin
         brew install shellcheck sccache
-
-        # Homebrew installs autoconf 2.71 which is incompatible with the
-        # version of ruby embedded in this project, so force the installation
-        # of the last known good version, 2.69.
-        brew unlink autoconf
-        brew tap-new $USER/local-autoconf
-        brew extract --version=2.69 autoconf $USER/local-autoconf
-        brew install autoconf@2.69
-        echo "/usr/local/opt/autoconf@2.69/bin" >> $GITHUB_PATH
     - run: ./script/ci

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         path: |
           librubyfmt/ruby_checkout/ruby-2.6.6
-        key: ${{ runner.os }}-ruby26-full
+        key: ${{ runner.os }}-ruby-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/ruby-2.6.6/HEAD') }}
     - if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y shellcheck build-essential ruby-dev bison

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -56,5 +56,5 @@ jobs:
       run: |
         rustup component add clippy --toolchain stable-x86_64-apple-darwin
         rustup component add rustfmt --toolchain stable-x86_64-apple-darwin
-        brew install shellcheck sccache
+        brew install shellcheck sccache automake
     - run: ./script/ci

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -65,4 +65,5 @@ jobs:
         brew tap-new $USER/local-autoconf
         brew extract --version=2.69 autoconf $USER/local-autoconf
         brew install autoconf@2.69
+        echo "/usr/local/opt/autoconf@2.69/bin" >> $GITHUB_PATH
     - run: ./script/ci

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -39,8 +39,8 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: |
-          librubyfmt/ruby_checkout/ruby-2.6.6
-        key: ${{ runner.os }}-ruby-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/ruby-2.6.6/HEAD') }}
+          librubyfmt/ruby_checkout
+        key: ${{ runner.os }}-ruby-v0-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/HEAD') }}
     - if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y shellcheck build-essential ruby-dev bison

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -17,6 +17,7 @@ jobs:
   CI_26:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI 2.6
+name: CI
 on:
   push:
     branches: [ trunk ]
@@ -14,7 +14,7 @@ env:
     RUSTC_WRAPPER: sccache
 
 jobs:
-  CI_26:
+  CI:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "librubyfmt/ruby_checkout/ruby-2.6.6"]
-	path = librubyfmt/ruby_checkout/ruby-2.6.6
+[submodule "librubyfmt/ruby_checkout"]
+	path = librubyfmt/ruby_checkout
 	url = https://github.com/ruby/ruby

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Darwin)
-	LDFLAGS=-framework Foundation
+	LDFLAGS=-framework Foundation -framework Security
 endif
 
 ifeq ($(UNAME_S), Linux)

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -10,7 +10,7 @@ fn main() -> Output {
     #[cfg(target_os = "linux")]
     let libname = "ruby-static";
     #[cfg(target_os = "macos")]
-    let libname = "ruby.2.6-static";
+    let libname = "ruby.2.7-static";
     #[cfg(all(target_arch = "x86_64", windows))]
     let libname = "x64-vcruntime140-ruby260-static";
     #[cfg(all(target_arch = "x86", windows))]

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -12,9 +12,9 @@ fn main() -> Output {
     #[cfg(target_os = "macos")]
     let libname = "ruby.2.7-static";
     #[cfg(all(target_arch = "x86_64", windows))]
-    let libname = "x64-vcruntime140-ruby260-static";
+    let libname = "x64-vcruntime140-ruby270-static";
     #[cfg(all(target_arch = "x86", windows))]
-    let libname = "vcruntime140-ruby260-static";
+    let libname = "vcruntime140-ruby270-static";
     #[cfg(all(target_env = "gnu", windows))]
     compile_error!("rubyfmt on Windows is currently only supported with msvc");
 

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -19,7 +19,7 @@ fn main() -> Output {
     compile_error!("rubyfmt on Windows is currently only supported with msvc");
 
     let path = std::env::current_dir()?;
-    let ruby_checkout_path = path.join("ruby_checkout").join("ruby-2.6.6");
+    let ruby_checkout_path = path.join("ruby_checkout");
     make_configure(&ruby_checkout_path)?;
     run_configure(&ruby_checkout_path)?;
     build_ruby(&ruby_checkout_path)?;

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -55,18 +55,11 @@ fn main() -> Output {
 
 #[cfg(unix)]
 fn make_configure(ruby_checkout_path: &Path) -> Output {
-    if ruby_checkout_path.join("Makefile").exists() {
-        let o = Command::new("make")
-            .arg("configure")
-            .current_dir(ruby_checkout_path)
-            .status()?;
-        check_process_success("make configure", o)
-    } else {
-        let o = Command::new("autoconf")
-            .current_dir(ruby_checkout_path)
-            .status()?;
-        check_process_success("autoconf", o)
-    }
+    let o = Command::new("autoreconf")
+        .arg("--install")
+        .current_dir(ruby_checkout_path)
+        .status()?;
+    check_process_success("autoreconf --install", o)
 }
 
 #[cfg(windows)]

--- a/librubyfmt/ruby_checkout/README.md
+++ b/librubyfmt/ruby_checkout/README.md
@@ -1,3 +1,0 @@
-Files checked out in this directory are verbatim copies of the Ruby interpreter
-source, pulled from: https://www.ruby-lang.org/en/downloads/. Copyrights are
-retained

--- a/librubyfmt/src/lib.rs
+++ b/librubyfmt/src/lib.rs
@@ -170,20 +170,18 @@ unsafe fn load_ripper() -> Result<(), ()> {
     Init_ripper();
 
     //load each ripper program
+    ruby::eval_str(include_str!("../ruby_checkout/ext/ripper/lib/ripper.rb"))?;
     ruby::eval_str(include_str!(
-        "../ruby_checkout/ruby-2.6.6/ext/ripper/lib/ripper.rb"
+        "../ruby_checkout/ext/ripper/lib/ripper/core.rb"
     ))?;
     ruby::eval_str(include_str!(
-        "../ruby_checkout/ruby-2.6.6/ext/ripper/lib/ripper/core.rb"
+        "../ruby_checkout/ext/ripper/lib/ripper/lexer.rb"
     ))?;
     ruby::eval_str(include_str!(
-        "../ruby_checkout/ruby-2.6.6/ext/ripper/lib/ripper/lexer.rb"
+        "../ruby_checkout/ext/ripper/lib/ripper/filter.rb"
     ))?;
     ruby::eval_str(include_str!(
-        "../ruby_checkout/ruby-2.6.6/ext/ripper/lib/ripper/filter.rb"
-    ))?;
-    ruby::eval_str(include_str!(
-        "../ruby_checkout/ruby-2.6.6/ext/ripper/lib/ripper/sexp.rb"
+        "../ruby_checkout/ext/ripper/lib/ripper/sexp.rb"
     ))?;
 
     Ok(())

--- a/script/make_source_release
+++ b/script/make_source_release
@@ -10,12 +10,12 @@ git archive --format=zip HEAD > archive.zip
 git submodule init
 git submodule update
 (
-cd librubyfmt/ruby_checkout/ruby-2.6.6/
+cd librubyfmt/ruby_checkout/
 git reset --hard && git clean -fdx
 )
 mkdir /tmp/rubyfmt_source
 unzip archive.zip -d /tmp/rubyfmt_source
-cp -r librubyfmt/ruby_checkout/ruby-2.6.6/ /tmp/rubyfmt_source/librubyfmt/ruby_checkout/ruby-2.6.6/
+cp -r librubyfmt/ruby_checkout/ /tmp/rubyfmt_source/librubyfmt/ruby_checkout/
 )
 tar -cvz -f "rubyfmt-$1-sources.tar.gz" -C "/tmp/rubyfmt_source" .
 mkdir -p "releases/$1/"


### PR DESCRIPTION
- Updates the version of ruby embedded in the repo to https://github.com/ruby/ruby/tree/29bbad939939c6dceb804aac667ba372fdee4ef5, the commit on the 2.7 branch that has the fixes needed for building with autoconf 2.7+.
- Fixes the cache key for the ruby checkout to (hopefully) invalidate the cache when the commit of the git submodule changes.
- Move the submodule to a version agnostic directory (`ruby_checkout/ruby-2.6.6` -> `ruby_checkout`).
- Remove macos autoconf hacks from CI config.