### PR TITLE
Update to currently supported ruby github action.

### DIFF
--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -41,9 +41,9 @@ jobs:
         path: |
           librubyfmt/ruby_checkout/ruby-2.6.6
         key: ${{ runner.os }}-ruby26-full
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
-        version: 2.6
+        ruby-version: 2.6
     - if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y shellcheck build-essential ruby-dev bison


### PR DESCRIPTION
This message appears in CI while installing ruby:

> Warning: Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use ruby-version instead

This PR fixes that and moves to the github action supported by the ruby team: https://github.com/ruby/setup-ruby