### PR TITLE
Remove cargo action from ci config.

### DIFF
--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -24,7 +24,6 @@ jobs:
     - run: |
         git submodule init
         git submodule update
-    - uses: actions-rs/cargo@v1
     - uses: actions/cache@v2
       with:
         path: |


### PR DESCRIPTION
This github action is made for running cargo. Not supplying the command to run means it does not do anything:

```
 (node:1467) UnhandledPromiseRejectionWarning: Error: Input required and not supplied: command
    at Object.getInput (/Users/runner/work/_actions/actions-rs/cargo/v1/dist/index.js:1:279405)
    at Object.getInput (/Users/runner/work/_actions/actions-rs/cargo/v1/dist/index.js:1:139626)
    at Object.get (/Users/runner/work/_actions/actions-rs/cargo/v1/dist/index.js:1:38199)
    at /Users/runner/work/_actions/actions-rs/cargo/v1/dist/index.js:1:24270
    at Generator.next (<anonymous>)
    at /Users/runner/work/_actions/actions-rs/cargo/v1/dist/index.js:1:23557
    at new Promise (<anonymous>)
    at n (/Users/runner/work/_actions/actions-rs/cargo/v1/dist/index.js:1:23305)
    at main (/Users/runner/work/_actions/actions-rs/cargo/v1/dist/index.js:1:24134)
    at Object.131 (/Users/runner/work/_actions/actions-rs/cargo/v1/dist/index.js:1:24328)
(node:1467) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:1467) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```