### PR TITLE
Don't unnecessarily install ruby on CI.

### DIFF
--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -41,9 +41,6 @@ jobs:
         path: |
           librubyfmt/ruby_checkout/ruby-2.6.6
         key: ${{ runner.os }}-ruby26-full
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.6
     - if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y shellcheck build-essential ruby-dev bison


### PR DESCRIPTION
Github actions runners come with ruby preinstalled:

https://github.com/actions/virtual-environments/blob/ff4ba2e7258b8183db5cc13d30a840222a149ac0/images/linux/Ubuntu2004-README.md
https://github.com/actions/virtual-environments/blob/ff4ba2e7258b8183db5cc13d30a840222a149ac0/images/macos/macos-10.15-Readme.md

Ruby only requires ruby 2+ during installation so any modern ruby should be fine, we do not need to go out of our way to install a specific version.
