### PR TITLE
Don't use parentheses with `require_relative`

### DIFF
--- a/fixtures/small/require_relative_actual.rb
+++ b/fixtures/small/require_relative_actual.rb
@@ -1,0 +1,1 @@
+require_relative '../../blah'

--- a/fixtures/small/require_relative_actual.rb
+++ b/fixtures/small/require_relative_actual.rb
@@ -1,1 +1,1 @@
-require_relative '../../blah'
+require_relative "../../blah"

--- a/fixtures/small/require_relative_expected.rb
+++ b/fixtures/small/require_relative_expected.rb
@@ -1,0 +1,1 @@
+require_relative '../../blah'

--- a/fixtures/small/require_relative_expected.rb
+++ b/fixtures/small/require_relative_expected.rb
@@ -1,1 +1,1 @@
-require_relative '../../blah'
+require_relative "../../blah"

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -627,7 +627,7 @@ pub fn use_parens_for_method_call(
         }
     }
 
-    if name == "super" || name == "require" {
+    if name == "super" || name == "require" || name == "require_relative" {
         return original_used_parens;
     }
 

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2678,10 +2678,6 @@ pub fn format_mod_statement(
                 ps.emit_end();
             }),
         );
-
-        if ps.at_start_of_line() {
-            ps.emit_newline();
-        }
     } else {
         if ps.at_start_of_line() {
             ps.emit_indent();
@@ -2696,10 +2692,10 @@ pub fn format_mod_statement(
                 format_expression(ps, *conditional);
             }),
         );
-
-        if ps.at_start_of_line() {
-            ps.emit_newline();
-        }
+    }
+    
+    if ps.at_start_of_line() {
+        ps.emit_newline();
     }
 }
 

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2693,7 +2693,7 @@ pub fn format_mod_statement(
             }),
         );
     }
-    
+
     if ps.at_start_of_line() {
         ps.emit_newline();
     }


### PR DESCRIPTION
@penelopezone This PR should stop parens from being added to `require_relative`.