### PR TITLE
Break CI job into smaller jobs and pin rust version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,43 @@ env:
     RUSTC_WRAPPER: sccache
 
 jobs:
-  CI:
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          override: true
+          profile: minimal
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.51.0
+          components: clippy
+          override: true
+          profile: minimal
+      - run: cargo clippy --all --all-features -- -D warnings
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: |
+          sudo apt-get install -y shellcheck
+          ./script/lints/lint_fixtures.sh
+          ./script/lints/lint_scripts.sh
+
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,6 +60,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.51.0
+        override: true
+        profile: minimal
     - uses: actions/cache@v2
       with:
         path: |
@@ -42,7 +83,7 @@ jobs:
         key: ${{ runner.os }}-ruby-v1-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/HEAD') }}
     - if: runner.os == 'Linux'
       run: |
-        sudo apt-get install -y shellcheck build-essential ruby-dev bison
+        sudo apt-get install -y build-essential ruby-dev bison
 
         SCCACHE_VERSION=0.2.15
         SCCACHE_FILE=sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl
@@ -53,7 +94,5 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
     - if: runner.os == 'macOS'
       run: |
-        rustup component add clippy --toolchain stable-x86_64-apple-darwin
-        rustup component add rustfmt --toolchain stable-x86_64-apple-darwin
-        brew install shellcheck sccache automake
-    - run: ./script/ci
+        brew install sccache automake
+    - run: ./script/test.sh

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ ubuntu_shell:
 lint: clippy
 	./script/lints/lint_fixtures.sh
 	./script/lints/lint_scripts.sh
-	./script/lints/lint_rust.sh
 
 clean:
 	rm -rf target/

--- a/script/ci
+++ b/script/ci
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-source ./script/functions.sh
-rm -rf tmp/
-make lint
-./script/test.sh

--- a/script/lints/lint_rust.sh
+++ b/script/lints/lint_rust.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-
-(
-cargo clippy
-cargo fmt -- --check
-)

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -ex
+set -euxo pipefail
+
+rm -rf tmp/
+source ./script/functions.sh
 
 cargo build --release
 


### PR DESCRIPTION
I poked around at other rust projects seeing how they handled clippy versions and mostly borrowed from this: https://github.com/RustCrypto/AEADs/blob/master/.github/workflows/workspace.yml

I did this to avoid the scenario happening in #335, where a new PR is opened and it fails because clippy fails on existing code. I went into this thinking that I could pin the version of clippy used somehow but that does not appear to be the case. Ideally we'd be able to have something like Dependabot bump the version when a new release is made, but for now it seems we'll have to explicitly update the rust version used in CI occasionally. The version of rust to pin to, 1.51.0, is arbitrary as it was the version used in the example I cribbed from. 

I'll leave this up for a few days in case anyone wants to give feedback, then I'll merge it, bump the version number and fix the lint failures, and merge #335.