### PR TITLE
[bugfix] Bump bundled ruby to 2.7 branch to include fix for m1

### DIFF
--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -53,6 +53,7 @@ fn main() -> Output {
         .object(ruby_checkout_path.join(&ripper))
         .include(ruby_checkout_path.join("include"))
         .include(ruby_checkout_path.join(".ext/include/arm64-darwin21"))
+        .include(ruby_checkout_path.join(".ext/include/arm64-darwin22"))
         .include(ruby_checkout_path.join(".ext/include/x86_64-darwin21"))
         .include(ruby_checkout_path.join(".ext/include/x86_64-darwin20"))
         .include(ruby_checkout_path.join(".ext/include/x86_64-darwin19"))


### PR DESCRIPTION
the ruby submodule was pointing to an older version of ruby 2.7 which did not contain fix for M1 apple silicon.
The latest fixes have not yet been released as a patch version for ruby 2.7.X. I'm now using the default ruby 2.7 branch which works with rubyfmt without any issue.

With this patch, I can successfully build rubyfmt on M1 apple silicon (also tested in Mac OSX Ventura)

For example: https://github.com/ruby/ruby/pull/6297 is where ruby has the patch for building in M1 but is not in 2.7.6 ruby tag.

cc: @penelopezone @reese 