### PR TITLE
Differences in *_expected.rb fixtures after standard@1.17.0

### DIFF
--- a/fixtures/large/concurrent_ruby_future_expected.rb
+++ b/fixtures/large/concurrent_ruby_future_expected.rb
@@ -1,4 +1,3 @@
-require "thread"
 require "concurrent/constants"
 require "concurrent/errors"
 require "concurrent/ivar"
@@ -9,7 +8,6 @@ require "concurrent/options"
 # TODO (pitr-ch 14-Mar-2017): deprecate, Future, Promise, etc.
 
 module Concurrent
-
   # {include:file:docs-source/future.md}
   #
   # @!macro copy_options
@@ -18,7 +16,6 @@ module Concurrent
   # @see http://clojuredocs.org/clojure_core/clojure.core/future Clojure's future function
   # @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Future.html java.util.concurrent.Future
   class Future < IVar
-
     # Create a new `Future` in the `:unscheduled` state.
     #
     # @yield the asynchronous operation to perform
@@ -30,7 +27,7 @@ module Concurrent
     #
     # @raise [ArgumentError] if no block is given
     def initialize(opts = {}, &block)
-      raise ArgumentError.new("no block given") unless block_given?
+      raise ArgumentError.new("no block given") unless block
       super(NULL, opts.merge(__task_from_block__: block), &nil)
     end
 
@@ -79,12 +76,12 @@ module Concurrent
 
     # @!macro ivar_set_method
     def set(value = NULL, &block)
-      check_for_block_or_value!(block_given?, value)
+      check_for_block_or_value!(block, value)
       synchronize do
         if @state != :unscheduled
           raise MultipleAssignmentError
         else
-          @task = block || Proc.new { value }
+          @task = block || proc { value }
         end
       end
 

--- a/fixtures/large/rspec_core_notifications_expected.rb
+++ b/fixtures/large/rspec_core_notifications_expected.rb
@@ -121,7 +121,7 @@ module RSpec::Core
       # @return [String] The list of pending examples, fully formatted in the
       #   way that RSpec's built-in formatters emit.
       def fully_formatted_pending_examples(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
-        formatted = "\nPending: (Failures listed here are expected and do not affect your suite's status)\n".dup
+        formatted = +"\nPending: (Failures listed here are expected and do not affect your suite's status)\n"
 
         pending_notifications.each_with_index do |notification, index|
           formatted << notification.fully_formatted(index.next, colorizer)

--- a/fixtures/small/alias_bare_kw_expected.rb
+++ b/fixtures/small/alias_bare_kw_expected.rb
@@ -1,1 +1,1 @@
-alias bees defined?
+alias_method :bees, :defined?

--- a/fixtures/small/alias_equal_expected.rb
+++ b/fixtures/small/alias_equal_expected.rb
@@ -1,1 +1,1 @@
-alias == eql?
+alias_method :==, :eql?

--- a/fixtures/small/alias_expected.rb
+++ b/fixtures/small/alias_expected.rb
@@ -2,5 +2,5 @@ class Foo
   def bees
   end
 
-  alias :bees :cheese
+  alias_method :bees, :cheese
 end

--- a/fixtures/small/alias_string_symbol_expected.rb
+++ b/fixtures/small/alias_string_symbol_expected.rb
@@ -1,1 +1,1 @@
-alias :"a" :"b"
+alias_method :a, :b

--- a/fixtures/small/arg_list_with_bare_assoc_hash_expected.rb
+++ b/fixtures/small/arg_list_with_bare_assoc_hash_expected.rb
@@ -1,5 +1,5 @@
 begin
   value = Integer(argument)
 rescue ArgumentError
-  RSpec.warning("Expected an integer value for `--fail-fast`, got: #{argument.inspect}", :call_site => nil)
+  RSpec.warning("Expected an integer value for `--fail-fast`, got: #{argument.inspect}", call_site: nil)
 end

--- a/fixtures/small/args_forwarding_multiline_expected.rb
+++ b/fixtures/small/args_forwarding_multiline_expected.rb
@@ -1,5 +1,5 @@
 def a(...)
   if should_pass?
-    return b(...)
+    b(...)
   end
 end

--- a/fixtures/small/array_with_splat_expected.rb
+++ b/fixtures/small/array_with_splat_expected.rb
@@ -7,8 +7,8 @@
 ]
 
 [
-  "",
+  ""
   # Comment one
   # Comment two
-  *[]
+
 ]

--- a/fixtures/small/bare_alias_expected.rb
+++ b/fixtures/small/bare_alias_expected.rb
@@ -1,5 +1,5 @@
 class Foo
-  alias bees cheese
+  alias_method :bees, :cheese
 
   def bees
     :bees

--- a/fixtures/small/bare_assoc_multiple_expected.rb
+++ b/fixtures/small/bare_assoc_multiple_expected.rb
@@ -1,3 +1,3 @@
-foo(a, :a => b)
-foo(a, :a => b, :b => c)
-foo(a, :a => b, :b => c, :longlonglonglonglonglonglonglonglonglonglonglonglonglong => longlong)
+foo(a, a: b)
+foo(a, a: b, b: c)
+foo(a, a: b, b: c, longlonglonglonglonglonglonglonglonglonglonglonglonglong: longlong)

--- a/fixtures/small/bare_rescue_newline_expected.rb
+++ b/fixtures/small/bare_rescue_newline_expected.rb
@@ -1,6 +1,5 @@
 def valid?(new_value)
   @Validator.call(new_value)
 rescue
-
   false
 end

--- a/fixtures/small/begin_block_comment_expected.rb
+++ b/fixtures/small/begin_block_comment_expected.rb
@@ -1,10 +1,8 @@
 def foo
-  begin
-    # Call this method
-    this_method
+  # Call this method
+  this_method
 
-    # Then call that method
-    that_method
-  rescue => e
-  end
+  # Then call that method
+  that_method
+rescue => e
 end

--- a/fixtures/small/begin_ensure_rescue_expected.rb
+++ b/fixtures/small/begin_ensure_rescue_expected.rb
@@ -5,10 +5,8 @@ class ForIndents
   end
 
   def func2
-    begin
-    rescue Bees
-      a
-    end
+  rescue Bees
+    a
   end
 
   def func3
@@ -17,21 +15,17 @@ class ForIndents
   end
 
   def func4
-    begin
-    rescue Bees
-      a
-    ensure
-      b
-    end
+  rescue Bees
+    a
+  ensure
+    b
   end
 
   def func_with_comments
-    begin
-      foo!
-    rescue
-      # We could not foo!
-      # Our sincerest apologies
-    end
+    foo!
+  rescue
+    # We could not foo!
+    # Our sincerest apologies
   end
 
   def func_with_mulilines

--- a/fixtures/small/begin_with_comment_expected.rb
+++ b/fixtures/small/begin_with_comment_expected.rb
@@ -1,10 +1,9 @@
 def main
   # I am going to a commune in Vermont and will
   # deal with no unit of time shorter than a season
-  begin
-    go_to_vermont!
-  rescue TrafficError
-    puts("Had to deal with a unit of time shorter than a season")
-    exit(1)
-  end
+
+  go_to_vermont!
+rescue TrafficError
+  puts("Had to deal with a unit of time shorter than a season")
+  exit(1)
 end


### PR DESCRIPTION
*DO NOT MERGE — I'M REALLY JUST HERE FOR THE DIFFS AND EASY COMMENTING*

Hello @penelopezone and other rubyfmt/standard fans.

Since the inception of rubyfmt (and before the public release of Standard), it's been a stated goal that it'd be great if the syntax formatting bits of rubyfmt and standard agreed with one another so that they can be used in concert with one another to provide both formatting (rubyfmt) and linting (standard via its Rubocop configuration).

In order to achieve this goal, when Standard encounters a code listing formatted with rubyfmt (or vice versa), each should "first do no harm" and not churn the listing's formatting. 

I don't have any plans/proposals/solutions today, but wanted to start gaining awareness of what the delta looks like so here's a PR of what happens when you run standard against rubyfmt's fixtures and the resulting differences in its expected result files.

Some of these changes are probably be due to differences in assumed Ruby versions, but I don't know rubyfmt's baseline. I was using:
```
$ standardrb -v
1.17.0
$ rubocop -v
1.38.0
$ ruby -v
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin22]
```

Would love any feedback or reactions from @penelopezone and from interested parties in the Ruby community 💚 