### PR TITLE
Document `.rubyfmtignore` and `.gitignore` behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Rubyfmt supports the following CLI invocations:
 * `rubyfmt --header-opt-in -- files or directories` to format files only with a `# rubyfmt: true` comment at the top of the file
 * `rubyfmt --header-opt-out -- files or directories` to skip formatting files with a `# rubyfmt: false` comment at the top of the file
 
+`rubyfmt` also supports ignoring files with a `.rubyfmtignore` file when present in the root of the working directory.
+`.rubyfmtignore` uses the same syntax as `.gitignore`, so you can choose to ignore whole directories or use globs as needed.
+By default, `rubyfmt` also ignores files in `.gitignore` during file traversal, but you can force these files to be formatted by using the `--include-gitignored` flag.
+
 ## Editor Support
 
 ### Vim


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Resolves #354 

We added support for ignore-files some time ago, and I think some users will find them pretty useful, especially in bigger projects, so adding some docs to the README for them.
