### PR TITLE
Support unparenthesized Gemfile methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,7 @@ dependencies = [
  "backtrace",
  "cc",
  "jemallocator",
+ "lazy_static",
  "libc",
  "log",
  "ripper_deserialize",

--- a/fixtures/small/gemfile_actual.rb
+++ b/fixtures/small/gemfile_actual.rb
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+ruby "2.7.3"
+gem "nokogiri"
+
+source "https://my_special_hosted_thing.io" do
+  gem "my_hosted_gem", '~>1.2.3'
+  gem "rake", :require => false
+end
+
+group :test do
+  gem 'rspec'
+end

--- a/fixtures/small/gemfile_expected.rb
+++ b/fixtures/small/gemfile_expected.rb
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+ruby "2.7.3"
+gem "nokogiri"
+
+source "https://my_special_hosted_thing.io" do
+  gem "my_hosted_gem", "~>1.2.3"
+  gem "rake", :require => false
+end
+
+group :test do
+  gem "rspec"
+end

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1.0.40"
 backtrace = "0.3.45"
 libc = "0.2.68"
 ripper_deserialize = { path = "ripper_deserialize" }
+lazy_static = "1.4.0"
 log = { version = "0.4.8", features = ["max_level_debug", "release_max_level_warn"] }
 simplelog = "0.8"
 

--- a/librubyfmt/src/lib.rs
+++ b/librubyfmt/src/lib.rs
@@ -6,6 +6,9 @@ use std::io::{Cursor, Write};
 use std::slice;
 use std::str;
 
+#[macro_use]
+extern crate lazy_static;
+
 #[cfg(all(feature = "use_jemalloc", not(target_env = "msvc")))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Resolves #330

This adds support for `gem`, `source`, `ruby`, and `group` as special unparenthesized methods. This logic is a _little_ duplicated since we separately handle methods with and without blocks (and some of these methods handle both), so I pulled other similar method names out as constants.