### PR TITLE
Fix indentation for multiline expressions in interpolations in heredocs

### DIFF
--- a/fixtures/small/squiggly_heredoc_interpolation_actual.rb
+++ b/fixtures/small/squiggly_heredoc_interpolation_actual.rb
@@ -14,3 +14,15 @@ def foo
     thing #{"#{interploation} more"} even more
   FOO
 end
+
+class Foo
+  def to_chunks
+    <<~JS
+      #{array.map do |c|
+        <<~JS
+          "#{c[:path]}": () => import(/* webpackChunkName: '#{c[:name]}' */ '#{c[:path].gsub(%r{/index(/\.js)?\z}, "")}'),
+        JS
+      end}
+    JS
+  end
+end

--- a/fixtures/small/squiggly_heredoc_interpolation_expected.rb
+++ b/fixtures/small/squiggly_heredoc_interpolation_expected.rb
@@ -13,3 +13,15 @@ def foo
     thing #{"#{interploation} more"} even more
   FOO
 end
+
+class Foo
+  def to_chunks
+    <<~JS
+      #{array.map do |c|
+        <<~JS
+          "#{c[:path]}": () => import(/* webpackChunkName: '#{c[:name]}' */ '#{c[:path].gsub(%r{/index(/\.js)?\z}, "")}'),
+        JS
+      end}
+    JS
+  end
+end

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -911,10 +911,17 @@ impl BaseParserState {
     }
 
     fn new_with_depth_stack_from(ps: &BaseParserState) -> Self {
+        let mut next_ps = BaseParserState::new_with_reset_depth_stack(ps);
+        next_ps.depth_stack = ps.depth_stack.clone();
+        next_ps
+    }
+
+    // Creates a copy of the parser state *with the depth_stack reset*.
+    // This is used for heredocs, where we explicitly want to ignore current indentation.
+    fn new_with_reset_depth_stack(ps: &BaseParserState) -> Self {
         let mut next_ps = BaseParserState::new(FileComments::default());
         next_ps.comments_hash = ps.comments_hash.clone();
         next_ps.start_of_line = ps.start_of_line.clone();
-        next_ps.depth_stack = ps.depth_stack.clone();
         next_ps.current_orig_line_number = ps.current_orig_line_number;
         next_ps
     }
@@ -1013,7 +1020,7 @@ impl BaseParserState {
     where
         F: FnOnce(&mut BaseParserState),
     {
-        let mut next_ps = BaseParserState::new_with_depth_stack_from(ps);
+        let mut next_ps = BaseParserState::new_with_reset_depth_stack(ps);
         f(&mut next_ps);
         next_ps
     }


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Resolves #351 

We already explicitly add spaces before the contents of squiggly heredocs (and for other heredoc types, the spacing on the left matters so we should probably left-align anyways) so if we don't reset the depth stack when rendering heredocs, we'll over-indent the contents of the expression.
