### PR TITLE
Emit a build artifact after github actions run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,8 @@ jobs:
       run: |
         brew install automake
     - run: ./script/test.sh
+    - uses: actions/upload-artifact@v3
+      with:
+        name: rubyfmt-artifact
+        path: target/release/rubyfmt-main
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,6 @@ jobs:
     - run: ./script/test.sh
     - uses: actions/upload-artifact@v3
       with:
-        name: rubyfmt-artifact
+        name: rubyfmt-artifact-${{ matrix.os }}
         path: target/release/rubyfmt-main
 


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
It'd be really handy to be able to test rubyfmt PRs or commits between releases on the Stripe codebase in an automated way without having to pull and build the whole repo, so this PR uploads the release binary for each OS as a build artifact, which we can fetch in some dev scripts with the `gh` CLI.

(N.B. I could see this being a way to make automated releases, e.g. make an [action that runs on tag creation](https://futurestud.io/tutorials/github-actions-run-a-workflow-when-creating-a-tag) to create builds for all our supported OSs, combine the build artifacts, and publish the release)