### PR TITLE
Correctly handle empty `Paren` nodes as args

### DIFF
--- a/fixtures/small/empty_arg_paren_actual.rb
+++ b/fixtures/small/empty_arg_paren_actual.rb
@@ -1,1 +1,8 @@
 foo()
+
+foo ()
+
+foo () { }
+
+foo () do
+end

--- a/fixtures/small/empty_arg_paren_expected.rb
+++ b/fixtures/small/empty_arg_paren_expected.rb
@@ -1,1 +1,8 @@
 foo
+
+foo
+
+foo {  }
+
+foo do
+end

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1118,6 +1118,7 @@ pub struct ArgsAddBlock(
 #[derive(RipperDeserialize, Debug, Clone)]
 pub enum AABParen {
     Paren((paren_tag, Box<Expression>)),
+    EmptyParen((paren_tag, bool)),
     Expression(Box<Expression>),
 }
 
@@ -1134,9 +1135,13 @@ impl ArgsAddBlockInner {
             ArgsAddBlockInner::Parens(ps) => {
                 let el = ps
                     .into_iter()
+                    .filter(|aabp| !matches!(aabp, AABParen::EmptyParen(..)))
                     .map(|aabp| match aabp {
                         AABParen::Paren(p) => *p.1,
                         AABParen::Expression(e) => *e,
+                        AABParen::EmptyParen(..) => {
+                            unreachable!("We should have already filtered these out")
+                        }
                     })
                     .collect();
                 ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(el)


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Resolves #367 

Method calls like `foo (arg)` are represented with `paren` nodes by Ripper, and our deserialization previously assumed that these always had an `Expression` in the parens. However, you can still do things like `foo ()`, which Ripper represents as `[:paren, false]` instead of something like `[:paren,[:void]]` or whatever.

---

*Note*: it's worth calling out that `foo ()` and `foo` are not technically the same, and that if we're being pedantic the _actual_ output should be `foo(())`. Take as example the following:

```ruby
def foo(arg)
  arg
end

foo () # => nil
foo # => wrong number of arguments (given 0, expected 1) (ArgumentError)
```

However, simply removing empty parens is the way we currently handle _all_ equivalent cases currently, so that's the method I'm going with for this PR. I also think it's pretty fair to assume that most users would be somewhat surprised by the `foo(())` transformation, and that if that's what you really mean, we can just tell users to use `foo(nil)` instead.
