### PR TITLE
Generically handle all method visibility modifiers

### DIFF
--- a/fixtures/small/private_def_actual.rb
+++ b/fixtures/small/private_def_actual.rb
@@ -1,9 +1,0 @@
-class Foo
-  private def bar
-    42
-  end
-
-  private def baz(a, b, c)
-    a + b + c
-  end
-end

--- a/fixtures/small/private_def_expected.rb
+++ b/fixtures/small/private_def_expected.rb
@@ -1,9 +1,0 @@
-class Foo
-  private def bar
-    42
-  end
-
-  private def baz(a, b, c)
-    a + b + c
-  end
-end

--- a/fixtures/small/visibility_modifier_actual.rb
+++ b/fixtures/small/visibility_modifier_actual.rb
@@ -1,0 +1,23 @@
+class Foo
+  private def bar
+    42
+  end
+
+  private def baz(a, b, c)
+    a + b + c
+  end
+end
+
+module WhiteTeaBowl
+  sig do
+    params(walking_this: Path)
+  end
+  module_function def i_choose_one; end
+
+  sig do
+    void
+  end
+  patch_of def sunlight
+    "after another"
+  end
+end

--- a/fixtures/small/visibility_modifier_expected.rb
+++ b/fixtures/small/visibility_modifier_expected.rb
@@ -1,0 +1,24 @@
+class Foo
+  private def bar
+    42
+  end
+
+  private def baz(a, b, c)
+    a + b + c
+  end
+end
+
+module WhiteTeaBowl
+  sig do
+    params(walking_this: Path)
+  end
+  module_function def i_choose_one
+  end
+
+  sig do
+    void
+  end
+  patch_of def sunlight
+    "after another"
+  end
+end

--- a/librubyfmt/src/intermediary.rs
+++ b/librubyfmt/src/intermediary.rs
@@ -222,6 +222,13 @@ impl Intermediary {
         }
     }
 
+    pub fn insert_blankline_from_end(&mut self, index_from_end: usize) {
+        self.tokens.insert(
+            self.tokens.len() - index_from_end,
+            ConcreteLineToken::HardNewLine,
+        )
+    }
+
     pub fn insert_trailing_blankline(&mut self, _bl: BlanklineReason) {
         if self.index_of_last_hard_newline <= 2 {
             self.tokens.insert(

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -116,19 +116,6 @@ impl ConcreteLineToken {
         }
     }
 
-    pub fn is_method_visibility_modifier(&self) -> bool {
-        match self {
-            Self::DirectPart { part } => {
-                part == "public"
-                    || part == "private"
-                    || part == "protected"
-                    || part == "public_class_method"
-                    || part == "private_class_method"
-            }
-            _ => false,
-        }
-    }
-
     pub fn is_single_line_breakable_garbage(&self) -> bool {
         match self {
             Self::DirectPart { part } => part == &"".to_string(),

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -75,7 +75,17 @@ impl RenderQueueWriter {
                                 (ConcreteLineToken::Space, ConcreteLineToken::DefKeyword)
                             )
                         {
-                            accum.insert_blankline_from_end(4);
+                            // If we're here, the last few tokens must look like this:
+                            // | token             | index_from_end |
+                            // |  End              | 6              |
+                            // |. AfterCallChain   | 5              |
+                            // |  HardNewline      | 4              | <-- insert after this token
+                            // |. Indent           | 3 .            |
+                            // |  (ArbitraryToken) | 2              |
+                            // |  (ArbitraryToken) | 1              |
+                            // |  (ArbitraryToken) | 0              |
+                            const LAST_NEWLINE_INDEX_FROM_END: usize = 4;
+                            accum.insert_blankline_from_end(LAST_NEWLINE_INDEX_FROM_END);
                         }
                     }
                 }

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -63,16 +63,19 @@ impl RenderQueueWriter {
             }
 
             if let Some(
-                [&ConcreteLineToken::End, &ConcreteLineToken::AfterCallChain, &ConcreteLineToken::HardNewLine, &ConcreteLineToken::Indent { .. }, x],
-            ) = accum.last::<5>()
+                [&ConcreteLineToken::End, &ConcreteLineToken::AfterCallChain, &ConcreteLineToken::HardNewLine, &ConcreteLineToken::Indent { .. }, x, maybe_space, maybe_def],
+            ) = accum.last::<7>()
             {
                 match x {
                     ConcreteLineToken::DefKeyword => {}
                     _ => {
                         if x.is_in_need_of_a_trailing_blankline()
-                            && !x.is_method_visibility_modifier()
+                            && !matches!(
+                                (maybe_space, maybe_def),
+                                (ConcreteLineToken::Space, ConcreteLineToken::DefKeyword)
+                            )
                         {
-                            accum.insert_trailing_blankline(BlanklineReason::ComesAfterEnd);
+                            accum.insert_blankline_from_end(4);
                         }
                     }
                 }


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Resolves #363

Previously we explicitly listed out all "visibility modifiers" like `private`, `private_class_method`, etc. to avoid adding extra newlines to them when rendering "method modifiers" like `sig`s. However, there will probably always be some we could be missing this way (right now, this includes things like `module_function` and `ruby2_keywords`), so this PR changes it such that we generically this for anything of the shape
```ruby
end
<whatever> def func
```
which seems more reasonable, especially if a user defined their own special method (like Sorbet's custom `package_private`).