### PR TITLE
Handle escaping characters in single-quoted dyna_symbol expressions

### DIFF
--- a/fixtures/small/dyna_symbol_with_escapes_actual.rb
+++ b/fixtures/small/dyna_symbol_with_escapes_actual.rb
@@ -1,0 +1,10 @@
+:'"foo"'
+
+:"'#{<<~LOL}'"
+  I'm so sorry for \n writing this
+  #{:'"雷神の"'}
+  少し響みて
+  さし曇り
+  雨も降らぬか
+  君を留めむ
+LOL

--- a/fixtures/small/dyna_symbol_with_escapes_expected.rb
+++ b/fixtures/small/dyna_symbol_with_escapes_expected.rb
@@ -1,0 +1,10 @@
+:"\"foo\""
+
+:"'#{<<~LOL}'"
+  I'm so sorry for \n writing this
+  #{:"\"\u96F7\u795E\u306E\""}
+  少し響みて
+  さし曇り
+  雨も降らぬか
+  君を留めむ
+LOL


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Closes #347 

`rubyfmt` enforces using double quotes _everywhere_, including dynamic symbol literals, but it previously was only doing escaping for string literals, so things like `:'"foo"'` were transformed into `:""foo""`, which is invalid syntax. We should also be transforming the string contents of dyna_symbols as well.