### PR TITLE
Fix build for MacOS Big Sur arm builds

### DIFF
--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -52,6 +52,7 @@ fn main() -> Output {
         .file("src/rubyfmt.c")
         .object(ruby_checkout_path.join(&ripper))
         .include(ruby_checkout_path.join("include"))
+        .include(ruby_checkout_path.join(".ext/include/arm64-darwin20"))
         .include(ruby_checkout_path.join(".ext/include/arm64-darwin21"))
         .include(ruby_checkout_path.join(".ext/include/arm64-darwin22"))
         .include(ruby_checkout_path.join(".ext/include/x86_64-darwin21"))


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

On the tin -- we package rubyfmt for Big Sur arm (see Homebrew/homebrew-core#116203, which includes this commit as a patch), so we need to handle the right headers for it.
