### PR TITLE
Print help args if running `rubyfmt` with no args in tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
 name = "rubyfmt-main"
 version = "0.8.0-pre"
 dependencies = [
+ "atty",
  "clap",
  "dirs",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+atty = "0.2"
 clap = { version = "3.2.16", features = ["derive"] }
 dirs = "3.0.2"
 filetime = "0.2.14"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::ffi::OsStr;
 use std::fs::{read_to_string, File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::Path;
-use std::process::exit;
+use std::process::{exit, Command};
 use std::sync::{Arc, Mutex};
 
 #[macro_use]
@@ -289,6 +289,15 @@ fn iterate_input_files(opts: &CommandlineOpts, f: &dyn Fn((&Path, &String))) {
     if opts.include_paths.is_empty() {
         // If not include paths are present, assume user is passing via STDIN
         let mut buffer = String::new();
+
+        if atty::is(atty::Stream::Stdin) {
+            // Call executable with `--help` args to print help statement
+            let mut command = Command::new(std::env::current_exe().unwrap());
+            command.arg("--help");
+            command.spawn().unwrap().wait().unwrap();
+            return;
+        }
+
         io::stdin()
             .read_to_string(&mut buffer)
             .expect("reading from stdin to not fail");


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Resolves #373 

`rubyfmt` with no args generally reads from stdin, but some users will just run it on its own. There are several things we could do here, like just exit early, return what would be formatted by passing `""`, or something else, but I think printing the equivalent of `rubyfmt --help` is the most user-friendly (although I'm open to an alternative, since many unix tools will just return `""` or something like that).

I tried adding a test for this, but I'm terrible with bash and faking `tty` in our bash tests was getting to be more effort than it's worth, so I opted to just stick with manual testing with `cargo run` and making sure that `echo "class Foo; end" | cargo run` still works as expected.