### PR TITLE
Properly exit when receiving `SIGINT`/`SIGTERM`/`SIGHUP`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "dirs"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +463,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +645,7 @@ name = "rubyfmt-main"
 version = "0.8.0-pre"
 dependencies = [
  "clap",
+ "ctrlc",
  "dirs",
  "filetime",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 
 [dependencies]
 clap = { version = "3.2.16", features = ["derive"] }
+ctrlc = { version = "3.2", features = ["termination"] }
 dirs = "3.0.2"
 filetime = "0.2.14"
 glob = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,6 +340,12 @@ fn puts_stdout(input: &String) {
 }
 
 fn main() {
+    ctrlc::set_handler(move || {
+        eprintln!("`rubyfmt` process was terminated. Exiting...");
+        exit(1);
+    })
+    .expect("Error setting Ctrl-C handler");
+
     updates::begin_checking_for_updates();
 
     let opts = get_command_line_options();


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Resolves #322

Currently, `rubyfmt` has no concept of signal handling, and while it's theoretically so fast it shouldn't matter, there are times where it can hang or run for very long times (e.g. running in debug mode on gigantic files) where users may want to kill it. This PR uses the `ctrlc` crate to just exit when receiving any of `SIGINT`/`SIGTERM`/`SIGHUP` from the OS.

There _may_ be more graceful ways to handle this (like setting a variable and then checking it at certain places in the program), but just exiting gets us 99% of the value here with far less invasive changes.