### PR TITLE
Handle arbitrary expression types in `aref_field` nodes

### DIFF
--- a/fixtures/small/aref_field_actual.rb
+++ b/fixtures/small/aref_field_actual.rb
@@ -1,3 +1,13 @@
 # As above
 a[0] = b
 # So below
+
+a[puts a] = ""
+a[puts(a)] = ""
+a[()] = ""
+a[class A; def foo; puts a; end; end] = ""
+a[begin; ""; rescue StandardException; ""; end] = ""
+# Users can override #[]= to not have args
+a[] = ""
+# Users can override #[]= to have multiple args
+a[1, 2] = ""

--- a/fixtures/small/aref_field_actual.rb
+++ b/fixtures/small/aref_field_actual.rb
@@ -11,3 +11,13 @@ a[begin; ""; rescue StandardException; ""; end] = ""
 a[] = ""
 # Users can override #[]= to have multiple args
 a[1, 2] = ""
+
+a[puts a]
+a[puts(a)]
+a[()]
+a[class A; def foo; puts a; end; end]
+a[begin; ""; rescue StandardException; ""; end]
+# Users can override #[] to not have args
+a[]
+# Users can override #[] to have multiple args
+a[1, 2]

--- a/fixtures/small/aref_field_expected.rb
+++ b/fixtures/small/aref_field_expected.rb
@@ -20,3 +20,22 @@ a[begin
 a[] = ""
 # Users can override #[]= to have multiple args
 a[1, 2] = ""
+
+a[puts(a)]
+a[puts(a)]
+a[()]
+
+a[class A
+    def foo
+      puts(a)
+    end
+end]
+a[begin
+    ""
+  rescue StandardException
+    ""
+  end]
+# Users can override #[] to not have args
+a[]
+# Users can override #[] to have multiple args
+a[1, 2]

--- a/fixtures/small/aref_field_expected.rb
+++ b/fixtures/small/aref_field_expected.rb
@@ -1,3 +1,22 @@
 # As above
 a[0] = b
 # So below
+
+a[puts(a)] = ""
+a[puts(a)] = ""
+a[()] = ""
+
+a[class A
+    def foo
+      puts(a)
+    end
+end] = ""
+a[begin
+    ""
+  rescue StandardException
+    ""
+  end] = ""
+# Users can override #[]= to not have args
+a[] = ""
+# Users can override #[]= to have multiple args
+a[1, 2] = ""

--- a/fixtures/small/aref_field_expected.rb
+++ b/fixtures/small/aref_field_expected.rb
@@ -5,17 +5,20 @@ a[0] = b
 a[puts(a)] = ""
 a[puts(a)] = ""
 a[()] = ""
-
-a[class A
+a[
+  class A
     def foo
       puts(a)
     end
-end] = ""
-a[begin
+  end
+] = ""
+a[
+  begin
     ""
   rescue StandardException
     ""
-  end] = ""
+  end
+] = ""
 # Users can override #[]= to not have args
 a[] = ""
 # Users can override #[]= to have multiple args
@@ -24,17 +27,20 @@ a[1, 2] = ""
 a[puts(a)]
 a[puts(a)]
 a[()]
-
-a[class A
+a[
+  class A
     def foo
       puts(a)
     end
-end]
-a[begin
+  end
+]
+a[
+  begin
     ""
   rescue StandardException
     ""
-  end]
+  end
+]
 # Users can override #[] to not have args
 a[]
 # Users can override #[] to have multiple args

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2298,7 +2298,12 @@ fn format_constant_body(ps: &mut dyn ConcreteParserState, bodystmt: Box<BodyStmt
     }));
 
     ps.on_line(end_line);
-    ps.emit_end();
+    ps.with_start_of_line(
+        true,
+        Box::new(|ps| {
+            ps.emit_end();
+        }),
+    );
     if ps.at_start_of_line() {
         ps.emit_newline();
     }

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1755,19 +1755,18 @@ pub fn format_aref_field(ps: &mut dyn ConcreteParserState, af: ArefField) {
         false,
         Box::new(|ps| {
             format_expression(ps, *af.1);
-            let aab = af.2;
-            match aab.2 {
-                ToProcExpr::Present(_) => {
-                    panic!("got a to_proc in an aref_field, should be impossible");
+
+            let index_expr = af.2;
+            let arr_contents = match index_expr {
+                None => None,
+                Some(ArgsAddBlockOrExpressionList::ArgsAddBlock(aab)) => {
+                    Some(aab.1.into_args_add_star_or_expression_list())
                 }
-                ToProcExpr::NotPresent(_) => {
-                    format_array_fast_path(
-                        ps,
-                        end_line,
-                        Some((aab.1).into_args_add_star_or_expression_list()),
-                    );
-                }
-            }
+                Some(ArgsAddBlockOrExpressionList::ExpressionList(expr_list)) => Some(
+                    ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(expr_list),
+                ),
+            };
+            format_array_fast_path(ps, end_line, arr_contents);
         }),
     );
 

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -1,5 +1,5 @@
 use crate::delimiters::BreakableDelims;
-use crate::line_tokens::{AbstractLineToken, ConcreteLineTokenAndTargets};
+use crate::line_tokens::{AbstractLineToken, ConcreteLineToken, ConcreteLineTokenAndTargets};
 use crate::parser_state::FormattingContext;
 use crate::types::{ColNumber, LineNumber};
 use std::collections::HashSet;
@@ -144,7 +144,9 @@ impl AbstractTokenTarget for BreakableEntry {
     }
 
     fn is_multiline(&self) -> bool {
-        self.line_numbers.len() > 1 || self.any_collapsing_newline_has_heredoc_content()
+        self.line_numbers.len() > 1
+            || self.any_collapsing_newline_has_heredoc_content()
+            || self.contains_hard_newline()
     }
 
     fn len(&self) -> usize {
@@ -175,6 +177,15 @@ impl BreakableEntry {
                 be.any_collapsing_newline_has_heredoc_content()
             }
             _ => false,
+        })
+    }
+
+    fn contains_hard_newline(&self) -> bool {
+        self.tokens.iter().any(|t| {
+            matches!(
+                t,
+                AbstractLineToken::ConcreteLineToken(ConcreteLineToken::HardNewLine)
+            )
         })
     }
 }

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -431,7 +431,7 @@ def_tag!(aref_field_tag, "aref_field");
 pub struct ArefField(
     pub aref_field_tag,
     pub Box<Expression>,
-    pub ArgsAddBlock,
+    pub Option<ArgsAddBlockOrExpressionList>,
     pub LineCol,
 );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Resolves #380 

`aref_field` nodes (e.g. `foo[:bar] = :baz`) can really handle _any_ expression in the index position, and in reality they can handle any _number_ of items for users overriding `#[]=`, so we should handle an arbitrary expression list here.
