### PR TITLE
Properly multiline user-multilined call chains

### DIFF
--- a/fixtures/large/rspec_mocks_proxy_expected.rb
+++ b/fixtures/large/rspec_mocks_proxy_expected.rb
@@ -305,7 +305,10 @@ module RSpec
     class PartialDoubleProxy < Proxy
       def original_method_handle_for(message)
         if any_instance_class_recorder_observing_method?(@object.class, message)
-          message = ::RSpec::Mocks.space.any_instance_recorder_for(@object.class).build_alias_method_name(message)
+          message = ::RSpec::Mocks
+            .space
+            .any_instance_recorder_for(@object.class)
+            .build_alias_method_name(message)
         end
 
         ::RSpec::Support.method_handle_for(@object, message)

--- a/fixtures/small/comments_at_indentation_changes_expected.rb
+++ b/fixtures/small/comments_at_indentation_changes_expected.rb
@@ -1,6 +1,9 @@
 it "" do
-  # Should only download the patches twice
-  Test::Mock.expects(Util, :download_file).twice.returns(true)
+  Test::Mock
+    .expects(Util, :download_file)
+    # Should only download the patches twice
+    .twice
+    .returns(true)
 end
 
 # Make some fake thing

--- a/fixtures/small/method_annotation_expected.rb
+++ b/fixtures/small/method_annotation_expected.rb
@@ -3,7 +3,9 @@ def empty_example
 end
 
 sig do
-  params(a: T::Array[String], b: T::Hash[Symbol, String]).returns(T::Set[Symbol]).checked(:tests)
+  params(a: T::Array[String], b: T::Hash[Symbol, String])
+    .returns(T::Set[Symbol])
+    .checked(:tests)
 end
 def do_the_thing(a, b)
   puts(a)

--- a/fixtures/small/method_chains_actual.rb
+++ b/fixtures/small/method_chains_actual.rb
@@ -13,6 +13,28 @@ returns_array.map { |foo|
   b: ""
 )
 
+foo.bar.baz
+
+foo.bar
+.baz
+
+# If they're all on the same line but different from
+# the first receiver, consider that "on one line"
+foo
+.bar.baz
+
+foo::bar
+&.nil?
+
+foo::bar
+&.nil?::klass
+.true?
+
+Class
+&.new
+.call!
+
+
 def example
   things
     .map do |thing|

--- a/fixtures/small/method_chains_expected.rb
+++ b/fixtures/small/method_chains_expected.rb
@@ -15,6 +15,28 @@ returns_array
     b: ""
   )
 
+foo.bar.baz
+
+foo
+  .bar
+  .baz
+
+# If they're all on the same line but different from
+# the first receiver, consider that "on one line"
+foo.bar.baz
+
+foo::bar&.nil?
+
+foo
+  ::bar
+  &.nil?
+  ::klass
+  .true?
+
+Class
+  &.new
+  .call!
+
 def example
   things
     .map do |thing|

--- a/fixtures/small/method_chains_expected.rb
+++ b/fixtures/small/method_chains_expected.rb
@@ -27,10 +27,8 @@ foo.bar.baz
 
 foo::bar&.nil?
 
-foo
-  ::bar
-  &.nil?
-  ::klass
+foo::bar
+  &.nil?::klass
   .true?
 
 Class

--- a/librubyfmt/rubyfmt_lib.rb
+++ b/librubyfmt/rubyfmt_lib.rb
@@ -169,6 +169,10 @@ class Parser < Ripper::SexpBuilderPP
     end
   end
 
+  def on_op(*_args)
+    super + [[lineno, lineno]]
+  end
+
   def on_next(*_args)
     super + [start_end_for_keyword('next')]
   end

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2789,10 +2789,15 @@ fn format_call_chain_elements(
                     ps.start_indent();
                     has_indented = true;
                 }
+                let is_double_colon = match &d {
+                    DotTypeOrOp::ColonColon(_) => true,
+                    DotTypeOrOp::StringDot(val) => val == "::",
+                    _ => false,
+                };
                 if render_multiline_chain
                     // Separating `::` calls with a newline
                     // isn't valid syntax
-                    && !matches!(d, DotTypeOrOp::ColonColon(_))
+                    && !is_double_colon
                 {
                     ps.emit_newline();
                     ps.emit_indent();

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2789,7 +2789,11 @@ fn format_call_chain_elements(
                     ps.start_indent();
                     has_indented = true;
                 }
-                if render_multiline_chain {
+                if render_multiline_chain
+                    // Separating `::` calls with a newline
+                    // isn't valid syntax
+                    && !matches!(d, DotTypeOrOp::ColonColon(_))
+                {
                     ps.emit_newline();
                     ps.emit_indent();
                 }
@@ -2844,9 +2848,10 @@ fn is_heredoc_call_chain_with_breakables(cc_elements: &[CallChainElement]) -> bo
 ///
 /// ## High-level rules
 ///
-/// The two main rules that govern whether or not to multiline a method chain is to split across multiple lines if
-/// (1) the whole chain exceeds the maximum line length or
-/// (2) the chain contains blocks that are split across multiple lines
+/// The three main rules that govern whether or not to multiline a method chain is to split across multiple lines if
+/// (1) the user multilined the chain,
+/// (2) the whole chain exceeds the maximum line length, or
+/// (3) the chain contains blocks that are split across multiple lines
 ///
 /// That said, both of these have some *very large* asterisks, since there are a lot of contexts in which these
 /// have special cases for various reasons (see below).
@@ -2883,6 +2888,38 @@ fn should_multiline_call_chain(ps: &mut dyn ConcreteParserState, method_call: &M
         CallChainElement::IdentOrOpOrKeywordOrConst(ident),
         CallChainElement::ArgsAddStarOrExpressionListOrArgsForward(args, start_end),
     ]);
+
+    let all_op_locations = call_chain_to_check
+        .iter()
+        .filter_map(|cc_elem| match cc_elem {
+            CallChainElement::DotTypeOrOp(dot_type_or_op) => {
+                match dot_type_or_op {
+                    // ColonColon is specially represented in the parser, and
+                    // it can't be properly multilined anyways, so we ignore it here
+                    DotTypeOrOp::ColonColon(..) => None,
+                    DotTypeOrOp::StringDot(..) => None,
+                    DotTypeOrOp::Op(Op(.., start_end))
+                    | DotTypeOrOp::DotType(
+                        DotType::LonelyOperator(LonelyOperator(_, start_end))
+                        | DotType::Dot(Dot(_, start_end)),
+                    ) => Some(start_end.clone()),
+                    DotTypeOrOp::Period(Period(.., linecol)) => {
+                        Some(StartEnd(linecol.0, linecol.0))
+                    }
+                }
+            }
+            _ => None,
+        })
+        .collect::<Vec<StartEnd>>();
+    // Multiline the chain if all the operators (dots, double colons, etc.) are not on the same line
+    if let Some(first_op_start_end) = all_op_locations.first() {
+        let chain_is_user_multilined = !all_op_locations
+            .iter()
+            .all(|op_start_end| op_start_end == first_op_start_end);
+        if chain_is_user_multilined {
+            return true;
+        }
+    }
 
     // Ignore chains that are basically only method calls, e.g.
     // ````ruby

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -994,7 +994,7 @@ pub struct BlockArg(pub blockarg_tag, pub Ident);
 #[derive(Deserialize, Debug, Clone)]
 pub struct LineCol(pub LineNumber, pub u64);
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct StartEnd(pub LineNumber, pub LineNumber);
 
 impl StartEnd {
@@ -1527,7 +1527,7 @@ pub struct Equals(pub equals_tag);
 
 def_tag!(dot_tag, ".");
 #[derive(Deserialize, Debug, Clone)]
-pub struct Dot(pub dot_tag);
+pub struct Dot(pub dot_tag, pub StartEnd);
 
 def_tag!(colon_colon_tag, "::");
 #[derive(Deserialize, Debug, Clone)]
@@ -1535,11 +1535,11 @@ pub struct ColonColon(pub colon_colon_tag);
 
 def_tag!(lonely_operator_tag, "&.");
 #[derive(Deserialize, Debug, Clone)]
-pub struct LonelyOperator(pub lonely_operator_tag);
+pub struct LonelyOperator(pub lonely_operator_tag, pub StartEnd);
 
 def_tag!(op_tag, "@op");
 #[derive(Deserialize, Debug, Clone)]
-pub struct Op(pub op_tag, pub Operator, pub LineCol);
+pub struct Op(pub op_tag, pub Operator, pub LineCol, pub StartEnd);
 
 #[derive(RipperDeserialize, Debug, Clone)]
 pub enum Operator {


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Related to #359 

In general, `rubyfmt` respects (within limits) user choices about multilining expressions, but we don't currently do this for multiline expressions. This has a few poor side effects: (1) users often _want_ to multiline to make e.g. adding comments for specific sections of a call chain easier, and (2) there end up being some (IMO) awkward formatting of chains like the following:
```ruby
MyClass.call(
  [],
  ""
).do_some_other_stuff!
```
which is inconsistent with `rubyfmt`'s normal call chain styling.

This PR implements multilining for user-multilined expressions. It does this by checking the line location of the `DotTypeOrOp` items in the call chain and multilining if they're on multiple lines. This _might_ be a slightly imperfect if the user writes something like this

```ruby
# both format as `foo.bar.baz`
foo
.bar.baz

foo.bar.
baz
```

but IMO this is a reasonable implementation tradeoff. We _could_ alternatively check every expression's start/end, but this ends up requiring a _lot_ more trickery and is more prone to inconsistency.