### PR TITLE
Do not require file arguments to use `--` in CLI invocations

### DIFF
--- a/script/tests/test_cli_interface.sh
+++ b/script/tests/test_cli_interface.sh
@@ -475,6 +475,24 @@ DIFF
     )
 }
 
+test_does_not_require_double_dash() {
+    (
+    cd "$(mktemp -d)"
+
+    cat > a_ruby_file_1.rb <<- DIFF
+a 1,2,3
+DIFF
+
+    f_rubyfmt -i a_ruby_file_1.rb
+
+    cat > expected.rb <<- DIFF
+a(1, 2, 3)
+DIFF
+
+    diff_files o expected.rb a_ruby_file_1.rb
+    )
+}
+
 test_format_respects_opt_out_header() {
     (
     cd "$(mktemp -d)"
@@ -662,6 +680,7 @@ test_format_directory_with_changes
 test_format_input_file_with_changes
 test_format_respects_opt_in_header
 test_format_respects_opt_out_header
+test_does_not_require_double_dash
 
 test_format_without_changes
 test_format_multiple_files_without_changes

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ struct CommandlineOpts {
     /// - Directories (i.e. lib/foo/){n}
     /// - Input files (i.e. @/tmp/files.txt). These files must contain one file path or directory per line
     /// rubyfmt will use these as input.{n}
-    #[clap(name = "include-paths", last = true)]
+    #[clap(name = "include-paths")]
     include_paths: Vec<String>,
 }
 


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

For whatever reason, when we rewrote the CLI in clap, the [`last` argument](https://teaclave.apache.org/api-docs/crates-app/clap/struct.Arg.html#method.last) was added to the argument for input files. There's not really a good reason for this -- every other flag is just a bool, so there's no other list args -- and we can still support it without _requiring_ it, which is what this PR does. This also lets users do totally reasonable things like run `rubyfmt file.rb` and then remember to add a `-i`, so they can just tack it on the end instead of having to put it back at the beginning.

I've opted to leave the `--` in the README examples, since the current version in `brew` doesn't support not using them, but both with and without `--` will now work.