### PR TITLE
Fix rendering of single-item massigns for rest params 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "rubyfmt-main"
-version = "0.8.0-pre"
+version = "0.8.1"
 dependencies = [
  "atty",
  "clap",

--- a/fixtures/small/massign_actual.rb
+++ b/fixtures/small/massign_actual.rb
@@ -1,5 +1,6 @@
 class Foo
   def bees
     a, b = [1, 2]
+    *nums = [a, b, c]
   end
 end

--- a/fixtures/small/massign_expected.rb
+++ b/fixtures/small/massign_expected.rb
@@ -1,5 +1,6 @@
 class Foo
   def bees
     a, b = [1, 2]
+    *nums = [a, b, c]
   end
 end

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1878,12 +1878,17 @@ pub fn format_massign(ps: &mut dyn ConcreteParserState, massign: MAssign) {
                 AssignableListOrMLhs::AssignableList(al) => {
                     let length = al.len();
                     for (idx, v) in al.into_iter().enumerate() {
+                        let is_rest_param = matches!(v, Assignable::RestParam(..));
                         format_assignable(ps, v);
                         let last = idx == length - 1;
                         if !last {
                             ps.emit_comma_space();
                         }
-                        if length == 1 {
+                        // `*foo = []` is valid ruby, but
+                        // `*foo, = []` is not (but `foo, = []` is!),
+                        // so in cases where the only assignable is a rest param,
+                        // leave the comma out
+                        if length == 1 && !is_rest_param {
                             ps.emit_comma();
                         }
                     }


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Resolves #392 

For massigns, we have special handling for the case where the massign is only one item, e.g. `foo, = [1, 2]`, since that comma produces different behavior at runtime. However, Ruby also considers `*foo = [1, 2]` an massign, even though there's only one item and no comma. Ruby _also_ doesn't consider `*foo, = [1, 2]` valid syntax, so we shouldn't render that final comma when the only item in an massign is a rest param.