### PR TITLE
Don't strip parens when the receiver of a method call is a const

### DIFF
--- a/fixtures/small/const_call_actual.rb
+++ b/fixtures/small/const_call_actual.rb
@@ -1,2 +1,7 @@
 require 'bees'
+class Foo; end
+def Foo; end
+
 Foo 1
+Foo()
+Foo

--- a/fixtures/small/const_call_expected.rb
+++ b/fixtures/small/const_call_expected.rb
@@ -1,3 +1,11 @@
 require "bees"
 
+class Foo
+end
+
+def Foo
+end
+
 Foo(1)
+Foo()
+Foo

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -688,6 +688,18 @@ pub fn use_parens_for_method_call(
 ) -> bool {
     let name = method.get_name();
     debug!("name: {:?}", name);
+
+    // If the calling method is a const, the parens become
+    // semantically important, e.g.
+    // ```
+    // class Foo; end
+    // def Foo; end
+    // Foo # class reference
+    // Foo() # method call
+    // ```
+    if matches!(method, IdentOrOpOrKeywordOrConst::Const(..)) {
+        return true;
+    }
     if name.starts_with("attr_") && context == FormattingContext::ClassOrModule {
         return original_used_parens;
     }


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Resolves #394 

On the tin -- if a method is named as a const (e.g. `def Bees`), it _must_ use parens when called. Without parens, it'll evaluate as a constant, so the parens are semantically important. This PR makes it such that if the receiver is a `Const`, we always leave the parens.