### PR TITLE
Improve line length enforcement for breakables

### DIFF
--- a/fixtures/large/rspec_mocks_proxy_expected.rb
+++ b/fixtures/large/rspec_mocks_proxy_expected.rb
@@ -393,7 +393,9 @@ module RSpec
       # That's what this method (together with `original_unbound_method_handle_from_ancestor_for`)
       # does.
       def original_method_handle_for(message)
-        unbound_method = superclass_proxy && superclass_proxy.original_unbound_method_handle_from_ancestor_for(message.to_sym)
+        unbound_method = superclass_proxy && superclass_proxy.original_unbound_method_handle_from_ancestor_for(
+          message.to_sym
+        )
 
         return super unless unbound_method
         unbound_method.bind(object)

--- a/fixtures/small/breakables_over_line_length_actual.rb
+++ b/fixtures/small/breakables_over_line_length_actual.rb
@@ -1,0 +1,7 @@
+# Nested breakables over the max line length
+# (Sung to the tune of "Carol of the Bells")
+[ReallyLongThing, ReallyLongThing, ReallyLongThing, ReallyLongThing, [ReallyLongThing, ReallyLongThing, ReallyLongThing, ReallyLongThing, ReallyLongThing, ReallyLongThing, ReallyLongThing], ReallyLongThing, ReallyLongThing]
+
+if Opus::Foo::Bar::Baz::ReallyLongName::Example::ExampleExampleExampleExampleExampleExampleExampleExample.calls_a_thing(a, b)
+    puts ""
+end

--- a/fixtures/small/breakables_over_line_length_expected.rb
+++ b/fixtures/small/breakables_over_line_length_expected.rb
@@ -1,0 +1,26 @@
+# Nested breakables over the max line length
+# (Sung to the tune of "Carol of the Bells")
+[
+  ReallyLongThing,
+  ReallyLongThing,
+  ReallyLongThing,
+  ReallyLongThing,
+  [
+    ReallyLongThing,
+    ReallyLongThing,
+    ReallyLongThing,
+    ReallyLongThing,
+    ReallyLongThing,
+    ReallyLongThing,
+    ReallyLongThing
+  ],
+  ReallyLongThing,
+  ReallyLongThing
+]
+
+if Opus::Foo::Bar::Baz::ReallyLongName::Example::ExampleExampleExampleExampleExampleExampleExampleExample.calls_a_thing(
+    a,
+    b
+  )
+  puts("")
+end

--- a/librubyfmt/src/delimiters.rs
+++ b/librubyfmt/src/delimiters.rs
@@ -91,4 +91,8 @@ impl BreakableDelims {
             contents: self.multi_line.close.clone(),
         }
     }
+
+    pub fn single_line_len(&self) -> usize {
+        self.single_line.open.len() + self.single_line.close.len()
+    }
 }

--- a/librubyfmt/src/intermediary.rs
+++ b/librubyfmt/src/intermediary.rs
@@ -90,6 +90,17 @@ impl Intermediary {
         self.tokens
     }
 
+    pub fn current_line_length(&self) -> usize {
+        if self.tokens.is_empty() {
+            return 0;
+        }
+
+        let line_start_index = self.index_of_last_hard_newline + 1;
+        let tokens_on_current_line = &self.tokens[line_start_index..];
+
+        tokens_on_current_line.iter().map(|t| t.len()).sum()
+    }
+
     pub fn push(&mut self, lt: ConcreteLineToken) {
         self.debug_assert_newlines();
         let mut do_push = true;

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -98,6 +98,34 @@ impl ConcreteLineToken {
         }
     }
 
+    /// The length of the token's string representation
+    pub fn len(&self) -> usize {
+        use ConcreteLineToken::*;
+        // The alternative to this match condition would be to clone and render
+        // each individual string token, which would increase the allocations of rubyfmt
+        // by an order of magnitude
+        match self {
+            AfterCallChain => 0, // purely semantic token, doesn't render
+            Indent { depth } => *depth as usize,
+            Keyword { keyword: contents }
+            | Op { op: contents }
+            | DirectPart { part: contents }
+            | LTStringContent { content: contents }
+            | Comment { contents }
+            | Delim { contents }
+            | ConditionalKeyword { contents }
+            | HeredocClose { symbol: contents }
+            | ModKeyword { contents } => contents.len(),
+            HardNewLine | Comma | Space | Dot | OpenSquareBracket | CloseSquareBracket
+            | OpenCurlyBracket | CloseCurlyBracket | OpenParen | CloseParen | SingleSlash => 1,
+            DoKeyword | CommaSpace | LonelyOperator | ColonColon | DoubleQuote => 2,
+            DefKeyword | Ellipsis | End => 3, // "def"/"..."/"end"
+            ClassKeyword => 5,                // "class"
+            ModuleKeyword => 6,               // "module"
+            DataEnd => 7,                     // "__END__"
+        }
+    }
+
     fn is_block_closing_token(&self) -> bool {
         match self {
             Self::End => true,

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -115,7 +115,7 @@ impl RenderQueueWriter {
     }
 
     fn format_breakable_entry(accum: &mut Intermediary, be: BreakableEntry) {
-        let length = be.single_line_string_length();
+        let length = accum.current_line_length() + be.single_line_string_length();
 
         if (length > MAX_LINE_LENGTH || be.is_multiline())
             && be.entry_formatting_context() != FormattingContext::StringEmbexpr

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -136,7 +136,8 @@ impl AbstractTokenTarget for BreakableEntry {
             .iter()
             .map(|tok| tok.clone().into_single_line())
             .map(|tok| tok.into_ruby().len())
-            .sum()
+            .sum::<usize>()
+            + self.delims.single_line_len()
     }
 
     fn push_line_number(&mut self, number: LineNumber) {


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Part of #379

This doesn't totally resolve our line-length woes, but it does get us closer to what I think users expect, which is that the render queue now takes into account both the current line length so far _and_ the breakable's length when deciding whether or not to render it as a single- or multi-line.

Note that this only solves it for _true_ breakables, but not for method calls and binary operators, which are currently hand-implemented due to having some more intricate special casings. Those will have to be resolved in later PRs and will generally be more involved.