### PR TITLE
Bump Ruby checkout to 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         key: ${{ runner.os }}-ruby-v1-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/HEAD') }}
     - if: runner.os == 'macOS'
       run: |
-        brew install automake
+        brew install automake bison
     - run: ./script/test.sh
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
     - if: runner.os == 'macOS'
       run: |
         brew install automake bison
+        echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
     - run: ./script/test.sh
     - uses: actions/upload-artifact@v3
       with:

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -10,11 +10,11 @@ fn main() -> Output {
     #[cfg(target_os = "linux")]
     let libname = "ruby-static";
     #[cfg(target_os = "macos")]
-    let libname = "ruby.3.0-static";
+    let libname = "ruby.3.2-static";
     #[cfg(all(target_arch = "x86_64", windows))]
-    let libname = "x64-vcruntime140-ruby300-static";
+    let libname = "x64-vcruntime140-ruby320-static";
     #[cfg(all(target_arch = "x86", windows))]
-    let libname = "vcruntime140-ruby300-static";
+    let libname = "vcruntime140-ruby320-static";
     #[cfg(all(target_env = "gnu", windows))]
     compile_error!("rubyfmt on Windows is currently only supported with msvc");
 

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -862,17 +862,25 @@ impl Paren {
     }
 }
 
+def_tag!(block_tag, "&");
+
+#[derive(RipperDeserialize, Debug, Clone)]
+pub enum BlockArgOrTag {
+    BlockArg(BlockArg),
+    Tag(block_tag),
+}
+
 def_tag!(params_tag, "params");
 #[derive(Deserialize, Debug, Clone)]
 pub struct Params(
     pub params_tag,
     pub Option<Vec<IdentOrMLhs>>,
     pub Option<Vec<(Ident, Expression)>>,
-    pub Option<RestParamOr0OrExcessedCommaOrArgsForward>,
+    pub Option<RestParamOr0OrExcessedComma>,
     pub Option<Vec<IdentOrMLhs>>,
     pub Option<Vec<(Label, ExpressionOrFalse)>>,
-    pub Option<KwRestParam>,
-    pub Option<BlockArg>,
+    pub Option<KwRestParamOrArgsForward>,
+    pub Option<BlockArgOrTag>,
     pub StartEnd,
 );
 
@@ -943,11 +951,10 @@ impl Params {
 //   a single representative node, but that didn't work with the serde setup
 //   we have for some reason.
 #[derive(RipperDeserialize, Debug, Clone)]
-pub enum RestParamOr0OrExcessedCommaOrArgsForward {
+pub enum RestParamOr0OrExcessedComma {
     Zero(i64),
     RestParam(RestParam),
     ExcessedComma(ExcessedComma),
-    ArgsForward(ArgsForward),
 }
 
 def_tag!(excessed_comma_tag, "excessed_comma");
@@ -982,6 +989,12 @@ pub enum ExpressionOrFalse {
 def_tag!(rest_param_tag, "rest_param");
 #[derive(Deserialize, Debug, Clone)]
 pub struct RestParam(pub rest_param_tag, pub Option<RestParamAssignable>);
+
+#[derive(RipperDeserialize, Debug, Clone)]
+pub enum KwRestParamOrArgsForward {
+    KwRestParam(KwRestParam),
+    ArgsForward(ArgsForward),
+}
 
 def_tag!(kw_rest_param_tag, "kwrest_param");
 #[derive(Deserialize, Debug, Clone)]

--- a/librubyfmt/src/ruby.rs
+++ b/librubyfmt/src/ruby.rs
@@ -46,8 +46,9 @@ pub enum ruby_value_type {
     RUBY_T_MASK = 0x1f,
 }
 
+// From https://github.com/ruby/ruby/blob/f55212bce939f736559709a8cd16c409772389c8/include/ruby/internal/special_consts.h#L97
 #[allow(non_upper_case_globals)]
-pub const Qnil: VALUE = VALUE(8);
+pub const Qnil: VALUE = VALUE(4);
 
 extern "C" {
     // stuff that we need to compile out rubyfmt


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Fully unblocks #399 

On the tin -- this bumps the checkout to `a7d467a792c644a7260d6560ea2002fdb8ff6de3`, which is the most recent [revision](https://github.com/ruby/ruby/commit/a7d467a792c644a7260d6560ea2002fdb8ff6de3) on the `ruby_3_2` branch. There are a few changes to support this:
- The value of `Qnil` was [updated internally](https://github.com/ruby/ruby/commit/f55212bce939f736559709a8cd16c409772389c8), so I've updated to reflect that
- Ripper now requires Bison 3, so I updated the github action
- Arg forwarding's representation in Ripper was changed (although I didn't look up the exact commits there), I imagine to support anonymous blocks and so on, so I at least updated the deserialization to work for our existing use cases