### PR TITLE
Format all file paths when not traversing directories

### DIFF
--- a/script/tests/test_cli_interface.sh
+++ b/script/tests/test_cli_interface.sh
@@ -654,6 +654,23 @@ DIFF
     )
 }
 
+test_formats_non_rb_files() {
+    (
+    cd "$(mktemp -d)"
+    echo "a 1, 2, 3" > test.rake
+
+    f_rubyfmt -i -- test.rake
+
+    cat > test_expected.rake <<- DIFF
+a(1, 2, 3)
+DIFF
+
+    cat test.rake
+
+    diff_files o test_expected.rake test.rake
+    )
+}
+
 test_simple_stdout
 test_i_flag
 test_i_flag_no_changes
@@ -691,3 +708,5 @@ test_respects_gitignore
 test_includes_gitignore
 
 test_respects_rubyfmt_ignore_file
+
+test_formats_non_rb_files


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Fixes #396 

If a user passes an explicit file path, we should always format it, regardless of its extension. This requires a bit of a messy implementation to be able to know which files are passed on the command line, so I implemented it by separately running the file walker on just the files and then just the directories.

In the future, we could allow users to pass custom file paths, but I don't think that's strictly required for sake of #396.