### PR TITLE
Support shorthand hash syntax

### DIFF
--- a/fixtures/small/shorthand_hash_actual.rb
+++ b/fixtures/small/shorthand_hash_actual.rb
@@ -1,0 +1,9 @@
+a = 1
+b = 2
+
+single_line = {a:, b:}
+
+multi_line = {
+    a:,
+    b:
+}

--- a/fixtures/small/shorthand_hash_expected.rb
+++ b/fixtures/small/shorthand_hash_expected.rb
@@ -1,0 +1,9 @@
+a = 1
+b = 2
+
+single_line = {a:, b:}
+
+multi_line = {
+  a:,
+  b:
+}

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1176,16 +1176,17 @@ pub fn format_assoc(
                             ps.emit_space();
                             ps.emit_ident("=>".to_string());
                         }
-                        ps.emit_space();
                     }
                     AssocKey::Expression(expression) => {
                         format_expression(ps, expression);
                         ps.emit_space();
                         ps.emit_ident("=>".to_string());
-                        ps.emit_space();
                     }
                 }
-                format_expression(ps, new.2);
+                if let Some(expr) = new.2 {
+                    ps.emit_space();
+                    format_expression(ps, expr);
+                }
             }
             AssocNewOrAssocSplat::AssocSplat(splat) => {
                 ps.emit_ident("**".to_string());

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1187,7 +1187,7 @@ pub enum AssocNewOrAssocSplat {
 
 def_tag!(assoc_new_tag, "assoc_new");
 #[derive(Deserialize, Debug, Clone)]
-pub struct AssocNew(pub assoc_new_tag, pub AssocKey, pub Expression);
+pub struct AssocNew(pub assoc_new_tag, pub AssocKey, pub Option<Expression>);
 
 def_tag!(assoc_splat_tag, "assoc_splat");
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Closes #398
Related to #399 

On the tin -- newer Ruby versions support a shorthand hash syntax, like `{a:, b:}`. Thankfully, this basically works out of the box by just making the value optional.