### PR TITLE
Add support for endless method definitions

### DIFF
--- a/fixtures/small/endless_methods_actual.rb
+++ b/fixtures/small/endless_methods_actual.rb
@@ -1,0 +1,13 @@
+class ForWeiMu
+  def we_are_both(travelers) = "dark-eyed with love".uppercase
+  def self.and_both_possessed_of = white_cloud_mind
+
+  private def why_set_out_for = EastMountain.when_here!
+  def spring_grasses = grow_deeper_day.by_day?
+end
+
+def more_examples = begin
+  dangerous_stuff!
+rescue
+  puts "saved the day"
+end

--- a/fixtures/small/endless_methods_expected.rb
+++ b/fixtures/small/endless_methods_expected.rb
@@ -1,0 +1,13 @@
+class ForWeiMu
+  def we_are_both(travelers) = "dark-eyed with love".uppercase
+  def self.and_both_possessed_of = white_cloud_mind
+
+  private def why_set_out_for = EastMountain.when_here!
+  def spring_grasses = grow_deeper_day.by_day?
+end
+
+def more_examples = begin
+  dangerous_stuff!
+rescue
+  puts("saved the day")
+end

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -18,35 +18,62 @@ pub fn format_def(ps: &mut dyn ConcreteParserState, def: Def) {
         ps.emit_indent();
     }
     ps.emit_def(def_expression.0);
+
+    format_def_body(ps, pp, *body, end_line);
+
+    if ps.at_start_of_line() {
+        ps.emit_newline();
+    }
+}
+
+fn format_def_body(
+    ps: &mut dyn ConcreteParserState,
+    pp: ParenOrParams,
+    bodystmt: DefBodyStmt,
+    end_line: LineNumber,
+) {
+    let has_end = matches!(bodystmt, DefBodyStmt::EndBodyStmt(..));
     ps.new_scope(Box::new(|ps| {
         format_paren_or_params(ps, pp);
 
         ps.with_formatting_context(
             FormattingContext::Def,
-            Box::new(|ps| {
-                ps.new_block(Box::new(|ps| {
-                    ps.emit_newline();
+            Box::new(|ps| match bodystmt {
+                DefBodyStmt::EndBodyStmt(bodystmt) => {
+                    ps.new_block(Box::new(|ps| {
+                        ps.emit_newline();
+                        ps.with_start_of_line(
+                            true,
+                            Box::new(|ps| {
+                                format_bodystmt(ps, Box::new(bodystmt), end_line);
+                            }),
+                        );
+                    }));
+                }
+                DefBodyStmt::EndlessBodyStmt(bodystmt) => {
+                    ps.emit_space();
+                    ps.emit_op("=".to_string());
+                    ps.emit_space();
+
                     ps.with_start_of_line(
-                        true,
+                        false,
                         Box::new(|ps| {
-                            format_bodystmt(ps, body, end_line);
+                            format_expression(ps, bodystmt.1);
                         }),
-                    );
-                }));
+                    )
+                }
             }),
         );
     }));
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.wind_dumping_comments_until_line(end_line);
-            ps.emit_end();
-        }),
-    );
-
-    if ps.at_start_of_line() {
-        ps.emit_newline();
+    if has_end {
+        ps.with_start_of_line(
+            true,
+            Box::new(|ps| {
+                ps.wind_dumping_comments_until_line(end_line);
+                ps.emit_end();
+            }),
+        );
     }
 }
 
@@ -2252,32 +2279,10 @@ pub fn format_defs(ps: &mut dyn ConcreteParserState, defs: Defs) {
             ps.emit_dot();
             let (ident, linecol) = ident_or_kw.to_def_parts();
             handle_string_and_linecol(ps, ident, linecol);
-            format_paren_or_params(ps, paren_or_params);
         }),
     );
 
-    ps.with_formatting_context(
-        FormattingContext::Def,
-        Box::new(|ps| {
-            ps.new_block(Box::new(|ps| {
-                ps.emit_newline();
-                ps.with_start_of_line(
-                    true,
-                    Box::new(|ps| {
-                        format_bodystmt(ps, bodystmt, end_line);
-                    }),
-                );
-            }));
-        }),
-    );
-
-    ps.wind_dumping_comments_until_line(end_line);
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_end();
-        }),
-    );
+    format_def_body(ps, paren_or_params, *bodystmt, end_line);
 
     if ps.at_start_of_line() {
         ps.emit_newline();

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -732,7 +732,7 @@ pub struct Def(
     pub def_tag,
     pub IdentOrOpOrKeywordOrConst,
     pub ParenOrParams,
-    pub Box<BodyStmt>,
+    pub Box<DefBodyStmt>,
     pub StartEnd,
 );
 
@@ -777,6 +777,16 @@ pub struct BodyStmt(
     pub Option<RescueElseOrExpressionList>,
     pub Option<Ensure>,
 );
+
+// The bodystmt for endless defs
+#[derive(Deserialize, Debug, Clone)]
+pub struct EndlessBodyStmt(pub bodystmt_tag, pub Expression);
+
+#[derive(RipperDeserialize, Debug, Clone)]
+pub enum DefBodyStmt {
+    EndBodyStmt(BodyStmt),
+    EndlessBodyStmt(EndlessBodyStmt),
+}
 
 // deals with 2.6, where else is a vec expression and not an else
 #[derive(RipperDeserialize, Debug, Clone)]
@@ -1693,7 +1703,7 @@ pub struct Defs(
     pub DotOrColon,
     pub IdentOrOpOrKeywordOrConst,
     pub ParenOrParams,
-    pub Box<BodyStmt>,
+    pub Box<DefBodyStmt>,
     pub StartEnd,
 );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Related to #399 

On the tin -- endless method definitions are ~the same as regular definitions in Ripper, the only difference being that instead of an array of expressions (and the optional rescue/ensure/etc.), it returns only a single expression.

In terms of style, this PR does nothing special -- endless method definitions just render expressions the same as e.g. an assignment. Note that they don't increase the indentation level here, same as variable assignments (although that's not a strong opinion, happy to change that if we want), so multiline expressions do end up left-aligned. (My only reasoning for this is that it looks a little strange to indent it without an`end` somewhere 🤷)