### PR TITLE
Add Ubuntu 20.04 target in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-20.04, macos-latest]
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
We use these build artifacts to test changes on Stripe's codebase, but we need `ubuntu-20.04` for it to work off the shelf. Historically, I've kinda hacked around this by running custom builds of rubyfmt, but I'd like to make it fully automated without that.