### PR TITLE
Transform multiline brace blocks to do/end blocks

### DIFF
--- a/fixtures/small/block_local_variables_expected.rb
+++ b/fixtures/small/block_local_variables_expected.rb
@@ -1,10 +1,10 @@
 y = 12
-lambda { |x, ;y|
+lambda do |x, ;y|
   puts(x)
   puts(y)
   y = 19
   puts(y)
-}
+end
   .call(17)
 puts(y)
 

--- a/fixtures/small/blocks_with_only_comments_expected.rb
+++ b/fixtures/small/blocks_with_only_comments_expected.rb
@@ -15,7 +15,7 @@ def foo
   end
 
   # More comments!!
-  commented_brace_block {
+  commented_brace_block do
     # Such plainness of the pre-baroque
     # Hardly involves the eye, until
     # It meets his left-hand gauntlet, still
@@ -23,7 +23,7 @@ def foo
     # One sees, with a sharp tender shock,
 
     # His hand withdrawn, holding her hand.
-  }
+  end
 
   method_call
 end

--- a/fixtures/small/brace_to_do_blocks_actual.rb
+++ b/fixtures/small/brace_to_do_blocks_actual.rb
@@ -1,0 +1,14 @@
+things.map { |thing| stuff; thing ** 2 }
+
+things.map { |thing|
+    # A comment makes this multiline!
+    thing
+}
+
+class Foo
+  # !! `example_dsl [].map { |k| k; k+1 }` is not equivalent to 
+  # !! `example_dsl [].map do |k| k; k+1 end`
+  example_dsl [].map { |k| k; k+1 }
+end
+
+group(:test) { gem 'mocha'; gem 'rack-test' }

--- a/fixtures/small/brace_to_do_blocks_actual.rb
+++ b/fixtures/small/brace_to_do_blocks_actual.rb
@@ -10,5 +10,3 @@ class Foo
   # !! `example_dsl [].map do |k| k; k+1 end`
   example_dsl [].map { |k| k; k+1 }
 end
-
-group(:test) { gem 'mocha'; gem 'rack-test' }

--- a/fixtures/small/brace_to_do_blocks_expected.rb
+++ b/fixtures/small/brace_to_do_blocks_expected.rb
@@ -18,8 +18,3 @@ class Foo
     end
   )
 end
-
-group(:test) do
-  gem "mocha"
-  gem "rack-test"
-end

--- a/fixtures/small/brace_to_do_blocks_expected.rb
+++ b/fixtures/small/brace_to_do_blocks_expected.rb
@@ -1,0 +1,25 @@
+things.map do |thing|
+  stuff
+  thing ** 2
+end
+
+things.map do |thing|
+  # A comment makes this multiline!
+  thing
+end
+
+class Foo
+  # !! `example_dsl [].map { |k| k; k+1 }` is not equivalent to
+  # !! `example_dsl [].map do |k| k; k+1 end`
+  example_dsl(
+    [].map do |k|
+      k
+      k + 1
+    end
+  )
+end
+
+group(:test) do
+  gem "mocha"
+  gem "rack-test"
+end

--- a/fixtures/small/curly_line_breaking_expected.rb
+++ b/fixtures/small/curly_line_breaking_expected.rb
@@ -1,5 +1,5 @@
 do_something { |a| [a] }
-do_something { |a|
+do_something do |a|
   [
     1,
     2,
@@ -105,4 +105,4 @@ do_something { |a|
     3,
     3
   ]
-}
+end

--- a/fixtures/small/method_chains_expected.rb
+++ b/fixtures/small/method_chains_expected.rb
@@ -1,8 +1,8 @@
 returns_array
-  .map { |foo|
+  .map do |foo|
     thing = foo.idk
     thing.call
-  }
+  end
   .chain do |bar|
     bar.do_stuff!
   end
@@ -110,10 +110,10 @@ var = MyModule::MyClass
   .foo
   .bar
   .baz
-  .map { |x|
+  .map do |x|
     multiline
     block
-  }
+  end
   .bacon
   .next_call(
     a: "",

--- a/fixtures/small/multiline_chain_in_block_expected.rb
+++ b/fixtures/small/multiline_chain_in_block_expected.rb
@@ -1,8 +1,8 @@
-sig {
+sig do
   params(
     route: String
   ).void
-}
+end
 def ajax_get(route)
   super
 end

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -3072,7 +3072,20 @@ fn should_multiline_call_chain(ps: &mut dyn ConcreteParserState, method_call: &M
 }
 
 pub fn format_block(ps: &mut dyn ConcreteParserState, b: Block) {
-    match b {
+    let block = match b {
+        Block::DoBlock(..) => b,
+        Block::BraceBlock(bb) => {
+            // Transform multiline BraceBlocks into do/end blocks
+            if bb.2.len() > 1
+                || ps.will_render_as_multiline(Box::new(|ps| format_brace_block(ps, bb.clone())))
+            {
+                Block::DoBlock(bb.into_do_block())
+            } else {
+                Block::BraceBlock(bb)
+            }
+        }
+    };
+    match block {
         Block::BraceBlock(bb) => format_brace_block(ps, bb),
         Block::DoBlock(db) => format_do_block(ps, db),
     }

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1912,6 +1912,17 @@ pub struct BraceBlock(
     pub StartEnd,
 );
 
+impl BraceBlock {
+    pub fn into_do_block(self) -> DoBlock {
+        DoBlock(
+            do_block_tag,
+            self.1,
+            Box::new(BodyStmt(bodystmt_tag, self.2, None, None, None)),
+            self.3,
+        )
+    }
+}
+
 def_tag!(while_tag, "while");
 #[derive(Deserialize, Debug, Clone)]
 pub struct While(


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
It's a pretty standard convention to use `{ }` for single-line blocks and `do`/`end` for multiline blocks, and for the sake of consistency, we should also enforce that in rubyfmt.

(Note that while there _are_ edge cases in terms of precedence differences between the two block types, this only happens in the case of unparenthesized arguments that use brace blocks, and since transforming them to `do/end` makes them multiline, rubyfmt will always wrap them in parentheses, which avoids the precedence issues. Because of that, this should be a safe transformation.)