### PR TITLE
Allow `test` to be an unparenthesized method

### DIFF
--- a/fixtures/small/rspec_its_actual.rb
+++ b/fixtures/small/rspec_its_actual.rb
@@ -39,6 +39,10 @@ describe "writing some really really long test name",
   opinion: "please don't name your DSL 'describe', but a little too late now I guess" do
 end
 
+test "some really good test name" do
+  assert(true)
+end
+
 RSpec.describe "bees" do
 end
 

--- a/fixtures/small/rspec_its_expected.rb
+++ b/fixtures/small/rspec_its_expected.rb
@@ -43,6 +43,10 @@ describe(
 ) do
 end
 
+test "some really good test name" do
+  assert(true)
+end
+
 RSpec.describe "bees" do
 end
 

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -696,7 +696,7 @@ pub fn args_has_single_def_expression(args: &ArgsAddStarOrExpressionListOrArgsFo
 }
 
 lazy_static! {
-    static ref RSPEC_METHODS: HashSet<&'static str> = vec!["it", "describe"].into_iter().collect();
+    static ref TEST_METHODS: HashSet<&'static str> = vec!["it", "describe", "test"].into_iter().collect();
     static ref GEMFILE_METHODS: HashSet<&'static str> = vec![
         // Gemfile
         "gem",
@@ -2762,7 +2762,7 @@ fn can_elide_parens_for_reserved_names(cc: &[CallChainElement]) -> bool {
             Ident(_, ident, _),
         ))) => {
             let ident = ident.as_str();
-            RSPEC_METHODS.contains(ident) || GEMFILE_METHODS.contains(ident)
+            TEST_METHODS.contains(ident) || GEMFILE_METHODS.contains(ident)
         }
         _ => false,
     };


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Closes #383 

`test` works just like `it` and `describe` in Rails tests, so I think it's fine to let it not use parens just like the other test methods.
