### PR TITLE
Make empty arrays with comments stay multilined

### DIFF
--- a/fixtures/small/empty_array_actual.rb
+++ b/fixtures/small/empty_array_actual.rb
@@ -1,1 +1,9 @@
 []
+
+# This one should collapse, since there's nothing in it
+[
+]
+
+[
+  # This one should stay multilined, since there's stuff in it
+]

--- a/fixtures/small/empty_array_expected.rb
+++ b/fixtures/small/empty_array_expected.rb
@@ -1,1 +1,8 @@
 []
+
+# This one should collapse, since there's nothing in it
+[]
+
+[
+  # This one should stay multilined, since there's stuff in it
+]


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Closes #409

This makes arrays work the same way as hashes, which is that if they contain comments inside of them, they'll stay multilined even when empty. Previously, we _always_ made empty arrays collapse to `[]`, but it's common to comment out the contents but want to leave it on multiple lines.