### PR TITLE
Do not elide parens when special-cased names are used in call chains

### DIFF
--- a/fixtures/small/gemfile_actual.rb
+++ b/fixtures/small/gemfile_actual.rb
@@ -10,3 +10,9 @@ end
 group :test do
   gem 'rspec'
 end
+
+# Usages of gemfile methods but in call chains
+
+scope :with_ticket_types, -> { group('shops.id').joins('LEFT JOIN foos ON foos.bar_id
+= bars.id').select('foos.*, COUNT(bars.id) count') }
+

--- a/fixtures/small/gemfile_expected.rb
+++ b/fixtures/small/gemfile_expected.rb
@@ -10,3 +10,15 @@ end
 group :test do
   gem "rspec"
 end
+
+# Usages of gemfile methods but in call chains
+
+scope(
+  :with_ticket_types,
+  -> {
+    group("shops.id")
+      .joins("LEFT JOIN foos ON foos.bar_id
+= bars.id")
+      .select("foos.*, COUNT(bars.id) count")
+  }
+)

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2772,11 +2772,9 @@ fn can_elide_parens_for_reserved_names(cc: &[CallChainElement]) -> bool {
     // elements will end up on the call arguments, which is incorrect. These
     // only apply to "bare" calls, e.g. calls with only arguments (including blocks)
     // but nothing else
-    let is_bare_call = cc
+    let is_bare_call = !cc
         .iter()
-        .filter(|e| matches!(e, CallChainElement::DotTypeOrOp(..)))
-        .count()
-        == 0;
+        .any(|e| matches!(e, CallChainElement::DotTypeOrOp(..)));
     let is_bare_reserved_method_name = is_bare_call
         && match cc.get(0) {
             Some(CallChainElement::IdentOrOpOrKeywordOrConst(

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2776,7 +2776,7 @@ fn can_elide_parens_for_reserved_names(cc: &[CallChainElement]) -> bool {
         .iter()
         .filter(|e| matches!(e, CallChainElement::DotTypeOrOp(..)))
         .count()
-        == 1;
+        == 0;
     let is_bare_reserved_method_name = is_bare_call
         && match cc.get(0) {
             Some(CallChainElement::IdentOrOpOrKeywordOrConst(
@@ -2849,7 +2849,7 @@ fn format_call_chain_elements(
             CallChainElement::VarRef(vr) => format_var_ref(ps, vr),
             CallChainElement::ArgsAddStarOrExpressionListOrArgsForward(aas, start_end) => {
                 if !aas.is_empty() || next_args_list_must_use_parens {
-                    let delims = if dbg!(elide_parens) {
+                    let delims = if elide_parens {
                         BreakableDelims::for_kw()
                     } else {
                         BreakableDelims::for_method_call()


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Closes #414 

In some cases, we special-cased certain "reserved words" for common usages like Gemfiles and tests. These should only ever be used outside of proper "call chains," i.e. they should only really be called directly with arguments and not chained to other methods. However, if someone _happens_ to use a method with the same name in a call chain, we should correctly wrap it in parens.