### PR TITLE
Fix special case when formatting paren-wrapped MLhs

### DIFF
--- a/fixtures/small/mlhs_paren_actual.rb
+++ b/fixtures/small/mlhs_paren_actual.rb
@@ -1,2 +1,4 @@
 call do |arg, (paren1, paren2, (paren3, paren4))|
 end
+
+(a, *b) = ARGV

--- a/fixtures/small/mlhs_paren_expected.rb
+++ b/fixtures/small/mlhs_paren_expected.rb
@@ -1,2 +1,4 @@
 call do |arg, (paren1, paren2, (paren3, paren4))|
 end
+
+(a, *b) = ARGV

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -390,10 +390,16 @@ pub fn format_mlhs(ps: &mut dyn ConcreteParserState, mlhs: MLhs) {
                     MLhsInner::Field(f) => format_field(ps, f),
                     MLhsInner::Ident(i) => format_ident(ps, i),
                     MLhsInner::RestParam(rp) => {
+                        let special_case =
+                            if ps.current_formatting_context() == FormattingContext::Assign {
+                                SpecialCase::RestParamOutsideOfParamDef
+                            } else {
+                                SpecialCase::NoSpecialCase
+                            };
                         format_rest_param(
                             ps,
                             Some(RestParamOr0OrExcessedComma::RestParam(rp)),
-                            SpecialCase::NoSpecialCase,
+                            special_case,
                         );
                     }
                     MLhsInner::VarField(vf) => format_var_field(ps, vf),
@@ -1926,41 +1932,46 @@ pub fn format_massign(ps: &mut dyn ConcreteParserState, massign: MAssign) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
+    ps.with_formatting_context(
+        FormattingContext::Assign,
         Box::new(|ps| {
-            match massign.1 {
-                AssignableListOrMLhs::AssignableList(al) => {
-                    let length = al.len();
-                    for (idx, v) in al.into_iter().enumerate() {
-                        let is_rest_param = matches!(v, Assignable::RestParam(..));
-                        format_assignable(ps, v);
-                        let last = idx == length - 1;
-                        if !last {
-                            ps.emit_comma_space();
+            ps.with_start_of_line(
+                false,
+                Box::new(|ps| {
+                    match massign.1 {
+                        AssignableListOrMLhs::AssignableList(al) => {
+                            let length = al.len();
+                            for (idx, v) in al.into_iter().enumerate() {
+                                let is_rest_param = matches!(v, Assignable::RestParam(..));
+                                format_assignable(ps, v);
+                                let last = idx == length - 1;
+                                if !last {
+                                    ps.emit_comma_space();
+                                }
+                                // `*foo = []` is valid ruby, but
+                                // `*foo, = []` is not (but `foo, = []` is!),
+                                // so in cases where the only assignable is a rest param,
+                                // leave the comma out
+                                if length == 1 && !is_rest_param {
+                                    ps.emit_comma();
+                                }
+                            }
                         }
-                        // `*foo = []` is valid ruby, but
-                        // `*foo, = []` is not (but `foo, = []` is!),
-                        // so in cases where the only assignable is a rest param,
-                        // leave the comma out
-                        if length == 1 && !is_rest_param {
-                            ps.emit_comma();
+                        AssignableListOrMLhs::MLhs(mlhs) => format_mlhs(ps, mlhs),
+                    }
+                    ps.emit_space();
+                    ps.emit_ident("=".to_string());
+                    ps.emit_space();
+                    match massign.2 {
+                        MRHSOrArray::MRHS(mrhs) => {
+                            format_mrhs(ps, Some(mrhs));
+                        }
+                        MRHSOrArray::Array(array) => {
+                            format_array(ps, array);
                         }
                     }
-                }
-                AssignableListOrMLhs::MLhs(mlhs) => format_mlhs(ps, mlhs),
-            }
-            ps.emit_space();
-            ps.emit_ident("=".to_string());
-            ps.emit_space();
-            match massign.2 {
-                MRHSOrArray::MRHS(mrhs) => {
-                    format_mrhs(ps, Some(mrhs));
-                }
-                MRHSOrArray::Array(array) => {
-                    format_array(ps, array);
-                }
-            }
+                }),
+            );
         }),
     );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Closes #416 

`MLhs` nodes have a special case for rest params which was previously incorrectly trying to emit soft indents outside of a breakable. We _could_ have just made mlhs nodes breakables, but the parser interface for mlhs specifically is pretty awkward, so in this particular case I opted to leave it as-is and instead correctly pass the right special-case enum when inside of a multiassign.

(Reviewing this with hiding whitespace changes makes this a bit clearer)
