### PR TITLE
Fix comment rendering for sclasses

### DIFF
--- a/fixtures/small/sclass_actual.rb
+++ b/fixtures/small/sclass_actual.rb
@@ -3,4 +3,17 @@ class Foo
   end
 end
 
+# The moon beams white on the peach blossoms,
+# the Milky Way moored silvering at midnight.
+class MoonBeam
+  # I wonder if the nightingale has noticed
+  # the spring spirit already alive in the branch?
+  class << self
+    # I can hardly get to sleep
+    # as if tenderness were a sickness.
+    def show
+    end
+  end
+end
+
 Foo.machine

--- a/fixtures/small/sclass_expected.rb
+++ b/fixtures/small/sclass_expected.rb
@@ -3,4 +3,17 @@ class Foo
   end
 end
 
+# The moon beams white on the peach blossoms,
+# the Milky Way moored silvering at midnight.
+class MoonBeam
+  # I wonder if the nightingale has noticed
+  # the spring spirit already alive in the branch?
+  class << self
+    # I can hardly get to sleep
+    # as if tenderness were a sickness.
+    def show
+    end
+  end
+end
+
 Foo.machine

--- a/librubyfmt/rubyfmt_lib.rb
+++ b/librubyfmt/rubyfmt_lib.rb
@@ -45,6 +45,7 @@ class Parser < Ripper::SexpBuilderPP
       "return" => [],
       "when" => [],
       "case" => [],
+      "class" => [],
       "yield" => [],
       "break" => [],
       "super" => [],
@@ -406,11 +407,11 @@ class Parser < Ripper::SexpBuilderPP
   end
 
   def on_class(*args)
-    with_lineno { super }
+    super + [start_end_for_keyword("class")]
   end
 
   def on_sclass(*args)
-    with_lineno { super }
+    super + [start_end_for_keyword("class")]
   end
 
   def on_module(*args)

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -3527,6 +3527,8 @@ pub fn format_sclass(ps: &mut dyn ConcreteParserState, sc: SClass) {
     let body = sc.2;
     let end_line = sc.3.end_line();
 
+    ps.on_line(sc.3.start_line());
+
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -3535,29 +3537,9 @@ pub fn format_sclass(ps: &mut dyn ConcreteParserState, sc: SClass) {
             ps.emit_ident("<<".to_string());
             ps.emit_space();
             format_expression(ps, *expr);
-            ps.emit_newline();
-            ps.new_block(Box::new(|ps| {
-                ps.with_start_of_line(
-                    true,
-                    Box::new(|ps| {
-                        format_bodystmt(ps, body, end_line);
-                    }),
-                );
-            }));
+            format_constant_body(ps, body, end_line);
         }),
     );
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_end();
-        }),
-    );
-
-    ps.on_line(end_line);
-
-    if ps.at_start_of_line() {
-        ps.emit_newline();
-    }
 }
 
 pub fn format_stabby_lambda(ps: &mut dyn ConcreteParserState, sl: StabbyLambda) {


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Closes #412 

Classes and modules already use `format_constant_body` to format their class bodies in the same way. These same rules can be used for `sclass` nodes, which follow the same rules. This fixes a subtle bug that was misaligning comments at the beginning of `sclass` bodies.