### PR TITLE
Create a GH Action for automating releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,94 @@
+name: Release
+on:
+  push:
+    branches: [reese-release-action]
+    tags:
+      - "*"
+
+env:
+  BUNDLE_PATH: /tmp/.bundle
+  GEM_HOME: /tmp/.bundle
+  GEM_PATH: /tmp/.bundle
+  TERM: xterm256
+  RELEASE_DIR: out/release
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+      - if: runner.os == 'macOS'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.63.0
+          target: aarch64-apple-darwin
+          default: true
+          override: true
+          profile: minimal
+      - if: runner.os != 'macOS'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.63.0
+          override: true
+          profile: minimal
+      - uses: actions/cache@v2
+        with:
+          path: |
+            librubyfmt/ruby_checkout
+          key: ${{ runner.os }}-ruby-v1-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/HEAD') }}
+      - if: runner.os == 'macOS'
+        run: |
+          brew install automake bison
+          echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
+      - run: ./script/make_release
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rubyfmt-release-artifact-${{ matrix.os }}
+          path: rubyfmt-*.tar.gz
+  source-release:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+      - run: |
+          TAG=$(git describe HEAD)
+          RELEASE_DIR="out/release"
+          mkdir -p ${RELEASE_DIR}
+          ./script/make_source_release ${TAG}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rubyfmt-source-release
+          path: "out/release/source"
+  release:
+    runs-on: macos-latest
+    needs:
+      - build
+      - source-release
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: rubyfmt-source-release
+      - run: |
+          ls
+      - uses: actions/download-artifact@v3
+        with:
+          name: rubyfmt-release-artifact-ubuntu-latest
+      - run: |
+          ls
+      - uses: actions/download-artifact@v3
+        with:
+          name: rubyfmt-release-artifact-macos-latest
+      - run: |
+          ls
+      - if: github.ref == 'ref/heads/trunk'
+        run: |
+          echo "on trunk!"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: Release
 on:
   push:
-    branches: [reese-release-action]
     tags:
       - "*"
 
@@ -10,7 +9,6 @@ env:
   GEM_HOME: /tmp/.bundle
   GEM_PATH: /tmp/.bundle
   TERM: xterm256
-  RELEASE_DIR: out/release
 
 jobs:
   build:
@@ -77,18 +75,16 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: rubyfmt-source-release
-      - run: |
-          ls
       - uses: actions/download-artifact@v3
         with:
           name: rubyfmt-release-artifact-ubuntu-latest
-      - run: |
-          ls
       - uses: actions/download-artifact@v3
         with:
           name: rubyfmt-release-artifact-macos-latest
-      - run: |
-          ls
-      - if: github.ref == 'ref/heads/trunk'
-        run: |
-          echo "on trunk!"
+      - name: Ship It 🚢
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: rubyfmt-*.tar.gz
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/script/make_release
+++ b/script/make_release
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
-TAG=$(git describe --exact-match HEAD)
-RELEASE_DIR="tmp/releases/${TAG}-$(uname -s)/"
+TAG=$(git describe HEAD)
+RELEASE_DIR=${RELEASE_DIR:-"tmp/releases/${TAG}-$(uname -s)/"}
 
 ./script/test.sh
 rm -rf "${RELEASE_DIR}"

--- a/script/make_release
+++ b/script/make_release
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-TAG=$(git describe HEAD)
+TAG=$(git describe --exact-match HEAD)
 RELEASE_DIR=${RELEASE_DIR:-"tmp/releases/${TAG}-$(uname -s)/"}
 
 ./script/test.sh

--- a/script/make_source_release
+++ b/script/make_source_release
@@ -18,5 +18,5 @@ unzip archive.zip -d /tmp/rubyfmt_source
 cp -r librubyfmt/ruby_checkout/ /tmp/rubyfmt_source/librubyfmt/ruby_checkout/
 )
 tar -cvz -f "rubyfmt-$1-sources.tar.gz" -C "/tmp/rubyfmt_source" .
-mkdir -p "releases/$1/"
-mv "rubyfmt-$1-sources.tar.gz" "releases/$1/"
+mkdir -p "out/release/source"
+mv "rubyfmt-$1-sources.tar.gz" "out/release/source"


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
On the tin -- this adds a GH action that runs when adding tags that does the job of running `make_release` on linux/mac and tarring `make_source_release`. This is a bit tricky to verify without making a real release, but you can see my test actions like [this one](https://github.com/fables-tales/rubyfmt/actions/runs/4511168801/jobs/7943266423) that should at least show the directory structure by the end of it before we would finally ship it off. (Also note that this might require giving the GH Action token content write permissions, based on [these docs](https://github.com/softprops/action-gh-release#permissions), but I don't have permissions to do that.)