### PR TITLE
Silence warnings from ruby checkout build

### DIFF
--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -62,6 +62,7 @@ fn main() -> Output {
         .include(ruby_checkout_path.join(".ext/include/x86_64-linux"))
         .include(ruby_checkout_path.join(".ext/include/x64-mswin64_140"))
         .include(ruby_checkout_path.join(".ext/include/i386-mswin32_140"))
+        .warnings(false)
         .compile("rubyfmt_c");
 
     println!(


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

On the tin -- the current `ruby_checkout` build step produces a ton of warnings that are irrelevant for `rubyfmt`, and it makes it way more cumbersome to develop, so this silences them.