### PR TITLE
Fix winding lines forward multiple lines

### DIFF
--- a/fixtures/small/all_method_blocks_actual.rb
+++ b/fixtures/small/all_method_blocks_actual.rb
@@ -21,3 +21,10 @@ end
 a.b 1 do
 
 end
+
+a do
+  # Comment at the beginning
+
+
+  # Comment at the end
+end

--- a/fixtures/small/all_method_blocks_expected.rb
+++ b/fixtures/small/all_method_blocks_expected.rb
@@ -15,3 +15,10 @@ end
 
 a.b(1) do
 end
+
+a do
+  # Comment at the beginning
+
+
+  # Comment at the end
+end

--- a/fixtures/small/begin_ensure_rescue_actual.rb
+++ b/fixtures/small/begin_ensure_rescue_actual.rb
@@ -35,6 +35,17 @@ class ForIndents
     end
   end
 
+  def another_func_with_comments
+    begin
+      # We don't do anything in here
+
+      # for some good reason
+    rescue
+      # I promise it's a good reason
+
+    end
+  end
+
   def func_with_mulilines
     _lambda_to_break_stuff = lambda do |this, that, the_other|
       wreak_havoc!

--- a/fixtures/small/begin_ensure_rescue_expected.rb
+++ b/fixtures/small/begin_ensure_rescue_expected.rb
@@ -34,6 +34,17 @@ class ForIndents
     end
   end
 
+  def another_func_with_comments
+    begin
+      # We don't do anything in here
+
+      # for some good reason
+    rescue
+      # I promise it's a good reason
+
+    end
+  end
+
   def func_with_mulilines
     _lambda_to_break_stuff = lambda do |this, that, the_other|
       wreak_havoc!

--- a/librubyfmt/rubyfmt_lib.rb
+++ b/librubyfmt/rubyfmt_lib.rb
@@ -66,14 +66,8 @@ class Parser < Ripper::SexpBuilderPP
     @rbracket_stack = []
     @lbrace_stack = []
     @comments = {}
-    @last_ln = 0
     # binary contents comming after a `__END__` node
     @data_contents_start_line = nil
-  end
-
-  def on_nl(*args)
-    @last_ln = lineno+1
-    super(*args)
   end
 
   # This method has incorrect behavior inside Ripper,
@@ -113,7 +107,7 @@ class Parser < Ripper::SexpBuilderPP
         nil
       end
 
-      [res, @comments, @lines_with_any_ruby, @last_ln, data_contents]
+      [res, @comments, @lines_with_any_ruby, @file_lines.count, data_contents]
     end
   end
 


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Closes #413 

When we wind lines forward with `wind_dumping_comments_until_line`, we have a [check](https://github.com/fables-tales/rubyfmt/blob/a6afe44103eb40a641d4d792f9474e12ef49237e/librubyfmt/src/parser_state.rs#L542) to make sure we're still in the file. This check gets set by incrementing a counter on `on_nl` inside the parser, but (1) this was incorrect because `on_nl` wasn't getting called and (2) this is unnecessary since we have the file contents saved, so we can just use the line count instead.