### PR TITLE
build just the `main` target to avoid extraneous work

### DIFF
--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -124,6 +124,7 @@ fn run_configure(ruby_checkout_path: &Path) -> Output {
 fn build_ruby(ruby_checkout_path: &Path) -> Output {
     let o = Command::new("make")
         .arg("-j")
+        .arg("main")
         .current_dir(ruby_checkout_path)
         .status()?;
     check_process_success("make", o)
@@ -133,6 +134,7 @@ fn build_ruby(ruby_checkout_path: &Path) -> Output {
 fn build_ruby(ruby_checkout_path: &Path) -> Output {
     let o = find_tool("nmake.exe")?
         .to_command()
+        .arg("main")
         .current_dir(ruby_checkout_path)
         .status()?;
     check_process_success("nmake", o)


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Per the tin.  This avoids needing to run rdoc over everything, among other things.