### PR TITLE
extract ruby arch from `rbconfig.rb`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "regex",
  "ripper_deserialize",
  "serde",
  "serde_json",

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -25,6 +25,7 @@ winapi = { version = "0.3", features = ["everything"] }
 
 [build-dependencies]
 cc = "1.0"
+regex = "1.6.0"
 
 [lib]
 name = "rubyfmt"

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -79,7 +79,12 @@ fn extract_ruby_arch(ruby_checkout_path: &Path) -> String {
     let rbconfig_rb = ruby_checkout_path.join("rbconfig.rb");
     let f = File::open(rbconfig_rb).expect("cannot find rbconfig.rb");
     let f = BufReader::new(f);
-    let arch_regex = Regex::new("  CONFIG\\[\"arch\"\\] = \"(?P<arch>[^\"]+)\"")
+    // Naturally, rbconfig.rb permits all manner of Ruby syntax to be used
+    // in the values for CONFIG.  Matching arbitrary Ruby inside the value
+    // string via [^"]+ could be a recipe for very confusing error
+    // messages later.  So we deliberately limit the charcters in the
+    // value string here.
+    let arch_regex = Regex::new("  CONFIG\\[\"arch\"\\] = \"(?P<arch>[-a-z0-9_]+)\"")
         .expect("incorrect regex syntax");
     for line in f.lines() {
         let line = line.expect("could not read from rbconfig.rb");

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -1,6 +1,9 @@
+use regex::Regex;
 #[cfg(windows)]
 use std::env;
 use std::error::Error;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Command, ExitStatus};
 
@@ -48,20 +51,13 @@ fn main() -> Output {
         }
     }
 
+    let arch = extract_ruby_arch(&ruby_checkout_path);
+
     cc::Build::new()
         .file("src/rubyfmt.c")
         .object(ruby_checkout_path.join(&ripper))
         .include(ruby_checkout_path.join("include"))
-        .include(ruby_checkout_path.join(".ext/include/arm64-darwin20"))
-        .include(ruby_checkout_path.join(".ext/include/arm64-darwin21"))
-        .include(ruby_checkout_path.join(".ext/include/arm64-darwin22"))
-        .include(ruby_checkout_path.join(".ext/include/x86_64-darwin21"))
-        .include(ruby_checkout_path.join(".ext/include/x86_64-darwin20"))
-        .include(ruby_checkout_path.join(".ext/include/x86_64-darwin19"))
-        .include(ruby_checkout_path.join(".ext/include/x86_64-darwin18"))
-        .include(ruby_checkout_path.join(".ext/include/x86_64-linux"))
-        .include(ruby_checkout_path.join(".ext/include/x64-mswin64_140"))
-        .include(ruby_checkout_path.join(".ext/include/i386-mswin32_140"))
+        .include(ruby_checkout_path.join(format!(".ext/include/{}", arch)))
         .warnings(false)
         .compile("rubyfmt_c");
 
@@ -77,6 +73,27 @@ fn main() -> Output {
     println!("cargo:rustc-link-lib=dylib=crypt");
 
     Ok(())
+}
+
+fn extract_ruby_arch(ruby_checkout_path: &Path) -> String {
+    let rbconfig_rb = ruby_checkout_path.join("rbconfig.rb");
+    let f = File::open(rbconfig_rb).expect("cannot find rbconfig.rb");
+    let f = BufReader::new(f);
+    let arch_regex = Regex::new("  CONFIG\\[\"arch\"\\] = \"(?P<arch>[^\"]+)\"")
+        .expect("incorrect regex syntax");
+    for line in f.lines() {
+        let line = line.expect("could not read from rbconfig.rb");
+        let matched = arch_regex
+            .captures(&line)
+            .and_then(|c| c.name("arch"))
+            .map(|s| s.as_str());
+        match matched {
+            Some(name) => return name.to_string(),
+            _ => continue,
+        }
+    }
+
+    panic!("could not extract arch from rbconfig.rb");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

We currently pass a bunch of include paths into the compiler when compiling the C code that's part of `rubyfmt`.  This is not that pretty, and requires adding extra code for every architecture/OS combination that we build `rubyfmt` on.

A better way is to ask Ruby what its "architecture" is, and use that information to construct the include paths that we need.  This is slightly fragile, but is at least easy to make it fail loudly and early so people can figure out what's wrong if the formatting of this file changes.

cc @ilyailya