### PR TITLE
extract ruby configuration for determining link libs

### DIFF
--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -111,7 +111,7 @@ fn extract_ruby_arch(ruby_checkout_path: &Path) -> String {
 
 fn extract_ruby_library_config(ruby_checkout_path: &Path, arch: &String) -> RubyConfig {
     let config_h = ruby_checkout_path.join(format!(".ext/include/{}/ruby/config.h", arch));
-    let f = File::open(config_h).expect(&format!("cannot find config.h for {}", arch));
+    let f = File::open(config_h).unwrap_or_else(|_| panic!("cannot find config.h for {}", arch));
     let f = BufReader::new(f);
     let config = RubyConfig {
         libz: false,


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

We currently statically determine whether `libz` and `libcrypt` should be linked into the `rubyfmt` binary.  A better approach (since Ruby can successfully be compiled without these libraries present, at the cost of functionality that `rubyfmt` doesn't use) is to query whether Ruby found these libraries on the system and output the necessary cargo directives based on that information.