### PR TITLE
add aarch64 cross-compilation bits to CI and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, macos-latest]
+        include:
+          - os: ubuntu-latest
+            target: native
+          - os: ubuntu-20.04
+            target: native
+          - os: macos-latest
+            target: native
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
     steps:
     - uses: actions/checkout@v2
       with:
@@ -63,24 +71,27 @@ jobs:
         toolchain: 1.63.0
         override: true
         profile: minimal
+        target: aarch64-unknown-linux-gnu
     - uses: actions/cache@v2
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-        key: ${{ runner.os }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-${{ matrix.target }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
     - uses: actions/cache@v2
       with:
         path: |
           librubyfmt/ruby_checkout
-        key: ${{ runner.os }}-ruby-v1-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/HEAD') }}
+        key: ${{ runner.os }}-${{ matrix.target }}-ruby-v1-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/HEAD') }}
     - if: runner.os == 'macOS'
       run: |
         brew install automake bison
         echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
     - run: ./script/test.sh
+      env:
+        TARGET: ${{ matrix.target }}
     - uses: actions/upload-artifact@v3
       with:
-        name: rubyfmt-artifact-${{ matrix.os }}
-        path: target/release/rubyfmt-main
+        name: rubyfmt-artifact-${{ matrix.os }}-${{ matrix.target }}
+        path: target/${{ matrix.target == 'native' && 'release' || format('{0}/release', matrix.target) }}/rubyfmt-main
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            target: native
+          - os: macos-latest
+            target: native
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v2
         with:
@@ -36,11 +42,12 @@ jobs:
           toolchain: 1.63.0
           override: true
           profile: minimal
+          target: aarch64-unknown-linux-gnu
       - uses: actions/cache@v2
         with:
           path: |
             librubyfmt/ruby_checkout
-          key: ${{ runner.os }}-ruby-v1-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/HEAD') }}
+          key: ${{ runner.os }}-${{matrix.target}}-ruby-v1-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/HEAD') }}
       - if: runner.os == 'macOS'
         run: |
           brew install automake bison
@@ -48,7 +55,7 @@ jobs:
       - run: ./script/make_release
       - uses: actions/upload-artifact@v3
         with:
-          name: rubyfmt-release-artifact-${{ matrix.os }}
+          name: rubyfmt-release-artifact-${{ matrix.os }}-${{ matrix.target }}
           path: rubyfmt-*.tar.gz
   source-release:
     runs-on: macos-latest

--- a/script/make_release
+++ b/script/make_release
@@ -11,19 +11,55 @@ mkdir -p "${RELEASE_DIR}"
 mkdir -p "${RELEASE_DIR}/lib/"
 mkdir -p "${RELEASE_DIR}/include/"
 
-cargo build
-cargo build --release
+target="${TARGET:-native}"
 
-cp target/release/rubyfmt-main "${RELEASE_DIR}/rubyfmt"
+case "$target" in
+  native)
+    cargo build
+    cargo build --release
+
+    release_tarball_os="$(uname -s)"
+    release_tarball_arch="$(uname -a)"
+    cargo_target_dir_prefix=""
+    ;;
+  aarch64-unknown-linux-gnu)
+    sudo apt-get update
+    sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+      CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+      TARGET_CC=aarch64-linux-gnu-gcc \
+      TARGET_AR=aarch64-linux-gnu-ar \
+      cargo build --target aarch64-unknown-linux-gnu
+
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+      CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+      TARGET_CC=aarch64-linux-gnu-gcc \
+      TARGET_AR=aarch64-linux-gnu-ar \
+      cargo build --release --target aarch64-unknown-linux-gnu
+
+    cargo_target_dir_prefix="aarch64-unknown-linux-gnu"
+    # This is kind of a hack, since we're assuming we're on a Linux host.
+    release_tarball_os="Linux"
+    release_tarball_arch="aarch64"
+    ;;
+  *)
+    echo "Unknown cross-compilation target $target"
+    exit 1
+    ;;
+esac
+
+cargo_dir="target/${cargo_target_dir_prefix}"
+cp "${cargo_dir}release/rubyfmt-main" "${RELEASE_DIR}/rubyfmt"
 pwd
-cp target/debug/rubyfmt-main "${RELEASE_DIR}/rubyfmt-debug"
+cp "${cargo_dir}debug/rubyfmt-main" "${RELEASE_DIR}/rubyfmt-debug"
 pwd
 # shellcheck disable=2012
-RELEASE_LIB=$(find target/release/ | grep -i 'librubyfmt-.*\.a$')
+RELEASE_LIB=$(find ${cargo_dir}release/ | grep -i 'librubyfmt-.*\.a$')
 cp "$RELEASE_LIB" "${RELEASE_DIR}/lib/librubyfmt.a"
 pwd
 # shellcheck disable=2012
-DEBUG_LIB=$(find target/debug/ | grep -i 'librubyfmt-.*\.a$')
+DEBUG_LIB=$(find ${cargo_dir}debug/ | grep -i 'librubyfmt-.*\.a$')
 cp "$DEBUG_LIB" "${RELEASE_DIR}/lib/librubyfmt-debug.a"
 pwd
 cp librubyfmt/include/rubyfmt.h "${RELEASE_DIR}/include/rubyfmt.h"
@@ -37,4 +73,4 @@ if [ "$RES" != "a(1)" ]; then
     exit 1
 fi
 
-tar -cvz -f "rubyfmt-${TAG}-$(uname -s).tar.gz" "${RELEASE_DIR}"
+tar -cvz -f "rubyfmt-${TAG}-${release_tarball_os}-${release_tarball_arch}.tar.gz" "${RELEASE_DIR}"

--- a/script/make_release
+++ b/script/make_release
@@ -67,10 +67,16 @@ pwd
 cp RELEASE_README.md "${RELEASE_DIR}/RELEASE_README"
 
 # check the binary
-RES=$(echo 'a(1)' | "${RELEASE_DIR}/rubyfmt")
-if [ "$RES" != "a(1)" ]; then
-    echo "formatting failed"
-    exit 1
-fi
+case "$target" in
+  native)
+    RES=$(echo 'a(1)' | "${RELEASE_DIR}/rubyfmt")
+    if [ "$RES" != "a(1)" ]; then
+      echo "formatting failed"
+      exit 1
+    fi
+    ;;
+  *)
+    ;;
+esac
 
 tar -cvz -f "rubyfmt-${TAG}-${release_tarball_os}-${release_tarball_arch}.tar.gz" "${RELEASE_DIR}"

--- a/script/test.sh
+++ b/script/test.sh
@@ -4,7 +4,31 @@ set -euxo pipefail
 rm -rf tmp/
 source ./script/functions.sh
 
-cargo build --release
+target="${TARGET:-native}"
+
+case "$target" in
+  native)
+    cargo build --release
+    ;;
+  aarch64-unknown-linux-gnu)
+    sudo apt-get update
+    sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+      CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+      TARGET_CC=aarch64-linux-gnu-gcc \
+      TARGET_AR=aarch64-linux-gnu-ar \
+      cargo build --release --target aarch64-unknown-linux-gnu
+
+    # Don't try to test things: even with QEMU support, it would take a long time.
+    exit 0
+    ;;
+  *)
+    echo "Unknown cross-compilation target $target"
+    exit 1
+    ;;
+esac
+
 
 export RUBYFMT_USE_RELEASE=1
 uname -a


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

This PR adds an aarch64-linux cross compilation job to the normal set of CI jobs.  The release process is also modified to run an aarch64-linux cross compilation job and package up the resulting bits, so that we are now producing three binary tarballs:

* x86-64 linux
* x86-64 mac
* aarch64 linux

The regular CI job is obviously tested in this PR; I don't know exactly how to test the release job.

None of the aarch64 artifacts are currently tested.  I believe that doing so is within the realm of possibility, but involves another layer of complexity that I would prefer to postpone until later.  I have a high degree of confidence that if the x86-64 linux binaries pass their tests, then the aarch64 linux binaries will run without issues.

cc @ilyailya