### PR TITLE
remove conditional compilation of `use std::env;` statement

### DIFF
--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -1,5 +1,4 @@
 use regex::Regex;
-#[cfg(windows)]
 use std::env;
 use std::error::Error;
 use std::fs::File;
@@ -31,7 +30,7 @@ fn main() -> Output {
     #[cfg(windows)]
     let ripper = "ext/ripper/ripper.obj";
 
-    let path = std::env::current_dir()?;
+    let path = env::current_dir()?;
     let ruby_checkout_path = path.join("ruby_checkout");
 
     let old_checkout_sha = if ruby_checkout_path.join(ripper).exists() {


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

This has been bugging me while working on other things, and it has a simple solution.