### PR TITLE
Revert "Fix comment rendering for sclasses (#420)"

### DIFF
--- a/fixtures/small/sclass_actual.rb
+++ b/fixtures/small/sclass_actual.rb
@@ -3,4 +3,11 @@ class Foo
   end
 end
 
+class Bar
+  class << self
+  end
+
+  def another_method!; end
+end
+
 Foo.machine

--- a/fixtures/small/sclass_actual.rb
+++ b/fixtures/small/sclass_actual.rb
@@ -3,17 +3,4 @@ class Foo
   end
 end
 
-# The moon beams white on the peach blossoms,
-# the Milky Way moored silvering at midnight.
-class MoonBeam
-  # I wonder if the nightingale has noticed
-  # the spring spirit already alive in the branch?
-  class << self
-    # I can hardly get to sleep
-    # as if tenderness were a sickness.
-    def show
-    end
-  end
-end
-
 Foo.machine

--- a/fixtures/small/sclass_expected.rb
+++ b/fixtures/small/sclass_expected.rb
@@ -3,4 +3,12 @@ class Foo
   end
 end
 
+class Bar
+  class << self
+  end
+
+  def another_method!
+  end
+end
+
 Foo.machine

--- a/fixtures/small/sclass_expected.rb
+++ b/fixtures/small/sclass_expected.rb
@@ -3,17 +3,4 @@ class Foo
   end
 end
 
-# The moon beams white on the peach blossoms,
-# the Milky Way moored silvering at midnight.
-class MoonBeam
-  # I wonder if the nightingale has noticed
-  # the spring spirit already alive in the branch?
-  class << self
-    # I can hardly get to sleep
-    # as if tenderness were a sickness.
-    def show
-    end
-  end
-end
-
 Foo.machine

--- a/librubyfmt/rubyfmt_lib.rb
+++ b/librubyfmt/rubyfmt_lib.rb
@@ -45,7 +45,6 @@ class Parser < Ripper::SexpBuilderPP
       "return" => [],
       "when" => [],
       "case" => [],
-      "class" => [],
       "yield" => [],
       "break" => [],
       "super" => [],
@@ -407,11 +406,11 @@ class Parser < Ripper::SexpBuilderPP
   end
 
   def on_class(*args)
-    super + [start_end_for_keyword("class")]
+    with_lineno { super }
   end
 
   def on_sclass(*args)
-    super + [start_end_for_keyword("class")]
+    with_lineno { super }
   end
 
   def on_module(*args)

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -3581,8 +3581,6 @@ pub fn format_sclass(ps: &mut dyn ConcreteParserState, sc: SClass) {
     let body = sc.2;
     let end_line = sc.3.end_line();
 
-    ps.on_line(sc.3.start_line());
-
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -3591,9 +3589,29 @@ pub fn format_sclass(ps: &mut dyn ConcreteParserState, sc: SClass) {
             ps.emit_ident("<<".to_string());
             ps.emit_space();
             format_expression(ps, *expr);
-            format_constant_body(ps, body, end_line);
+            ps.emit_newline();
+            ps.new_block(Box::new(|ps| {
+                ps.with_start_of_line(
+                    true,
+                    Box::new(|ps| {
+                        format_bodystmt(ps, body, end_line);
+                    }),
+                );
+            }));
         }),
     );
+    ps.with_start_of_line(
+        true,
+        Box::new(|ps| {
+            ps.emit_end();
+        }),
+    );
+
+    ps.on_line(end_line);
+
+    if ps.at_start_of_line() {
+        ps.emit_newline();
+    }
 }
 
 pub fn format_stabby_lambda(ps: &mut dyn ConcreteParserState, sl: StabbyLambda) {

--- a/script/docker_release_linux
+++ b/script/docker_release_linux
@@ -22,6 +22,7 @@ for platform in "${platforms[@]}"; do
     chmod 666 /root/out/*
 EOF
     ) > file
+    # shellcheck disable=SC2086
     docker run --platform=$platform --cpus=4 -it -v "$(pwd)/out:/root/out" "rubyfmt-release-linux-$platform:$(git rev-parse HEAD)" bash -c "$(cat file)"
     mkdir -p "releases/$TAG"
     cp out/*.tar.gz "releases/$TAG/"


### PR DESCRIPTION
This reverts commit 3b06f3c2594571cdfc5f605be69ad74f33fa2637.

I think the testing on that PR is insufficient, because method definitions that come immediately after the sclass definition get busted. For example, this will break:

```
class Example
  class << self
    def show
    end
  end

  def another_method!; end
end
```
