### PR TITLE
Properly track line numbers for keyword binary operators

### DIFF
--- a/fixtures/small/and_or_actual.rb
+++ b/fixtures/small/and_or_actual.rb
@@ -1,0 +1,12 @@
+true and false
+true or false
+false or
+  true
+
+true and
+  false or
+    maybe? and
+    some_other_things!
+
+
+do_stuff! if should_do_thing_one? and should_do_thing_two?

--- a/fixtures/small/and_or_expected.rb
+++ b/fixtures/small/and_or_expected.rb
@@ -1,0 +1,10 @@
+true and false
+true or false
+false or true
+
+true and
+  false or
+  maybe? and
+  some_other_things!
+
+do_stuff! if should_do_thing_one? and should_do_thing_two?

--- a/librubyfmt/rubyfmt_lib.rb
+++ b/librubyfmt/rubyfmt_lib.rb
@@ -9,6 +9,8 @@ end
 
 class Parser < Ripper::SexpBuilderPP
   ARRAY_SYMBOLS = {qsymbols: "%i", qwords: "%w", symbols: "%I", words: "%W"}.freeze
+  OPERATOR_KEYWORDS = ["and", "or"].freeze
+
 
   def self.is_percent_array?(rest)
     return false if rest.nil?
@@ -355,6 +357,13 @@ class Parser < Ripper::SexpBuilderPP
     if stack = @kw_stacks[kw]
       stack << lineno
     end
+
+    # `or` and `and` should register their locations like other binary operators
+    if OPERATOR_KEYWORDS.include?(kw)
+      @op_locations << lineno
+      return super + [[lineno, lineno]]
+    end
+
     super
   end
 


### PR DESCRIPTION
Closes #447 

`and` and `or` behave like binary operators, but for some reason they don't trigger an `on_op` call inside Ripper, so we fail to deserialize them because the line numbers are `nil`. This updates the ruby lib to register the line numbers appropriately for these keywords.