### PR TITLE
Represent binary operators as breakables

### DIFF
--- a/fixtures/large/rspec_core_notifications_expected.rb
+++ b/fixtures/large/rspec_core_notifications_expected.rb
@@ -336,7 +336,9 @@ module RSpec::Core
           Formatters::Helpers.pluralize(failure_count, "failure")
         summary += ", #{pending_count} pending" if pending_count > 0
         if errors_outside_of_examples_count > 0
-          summary += (", " + Formatters::Helpers.pluralize(errors_outside_of_examples_count, "error") + " occurred outside of examples")
+          summary += (", " +
+            Formatters::Helpers.pluralize(errors_outside_of_examples_count, "error") +
+            " occurred outside of examples")
         end
 
         summary

--- a/fixtures/large/rspec_mocks_proxy_expected.rb
+++ b/fixtures/large/rspec_mocks_proxy_expected.rb
@@ -393,9 +393,8 @@ module RSpec
       # That's what this method (together with `original_unbound_method_handle_from_ancestor_for`)
       # does.
       def original_method_handle_for(message)
-        unbound_method = superclass_proxy && superclass_proxy.original_unbound_method_handle_from_ancestor_for(
-          message.to_sym
-        )
+        unbound_method = superclass_proxy &&
+          superclass_proxy.original_unbound_method_handle_from_ancestor_for(message.to_sym)
 
         return super unless unbound_method
         unbound_method.bind(object)
@@ -427,7 +426,8 @@ module RSpec
           # The fact that there is no method double for this message indicates
           # that it has not been redefined by rspec-mocks. We need to continue
           # looking up the ancestor chain.
-          return superclass_proxy && superclass_proxy.method_double_from_ancestor_for(message)
+          return superclass_proxy &&
+            superclass_proxy.method_double_from_ancestor_for(message)
         end
       end
 

--- a/fixtures/small/binary_operators_expected.rb
+++ b/fixtures/small/binary_operators_expected.rb
@@ -1,6 +1,7 @@
 foo || bar
 
-foo || bar
+foo ||
+  bar
 
 if foo || bar
 end
@@ -27,7 +28,9 @@ a ||
   b &&
   c
 
-a || (b && c)
+a ||
+  (b &&
+    c)
 
 a ||
   b &&

--- a/fixtures/small/breakable_binary_op_actual.rb
+++ b/fixtures/small/breakable_binary_op_actual.rb
@@ -1,0 +1,3 @@
+some_value_goes_here = if some_really_long_name_so_that_this_example_breaks_the_way_that_i_want_it_to && foo.some_other_condition? && other_thing
+    ""
+end

--- a/fixtures/small/breakable_binary_op_expected.rb
+++ b/fixtures/small/breakable_binary_op_expected.rb
@@ -1,0 +1,5 @@
+some_value_goes_here = if some_really_long_name_so_that_this_example_breaks_the_way_that_i_want_it_to &&
+    foo.some_other_condition? &&
+    other_thing
+  ""
+end

--- a/fixtures/small/comments_at_indentation_changes_expected.rb
+++ b/fixtures/small/comments_at_indentation_changes_expected.rb
@@ -14,7 +14,8 @@ Test::FakeData.make_name_and_id(
   created: now + 5
 )
 
-# We've got all these sorts of reasons
-# we need to filter these out, but
-# someone will probably document that elsewhere, not here
-RELATIVE_EXCLUDES.any? { |str| things.include?(str) } || !relative.end_with?(".rb")
+RELATIVE_EXCLUDES.any? { |str| things.include?(str) } ||
+  # We've got all these sorts of reasons
+  # we need to filter these out, but
+  # someone will probably document that elsewhere, not here
+  !relative.end_with?(".rb")

--- a/fixtures/small/multiline_method_chain_with_arguments_expected.rb
+++ b/fixtures/small/multiline_method_chain_with_arguments_expected.rb
@@ -9,9 +9,10 @@ end
 
 {
   "original_fields" => foo,
-  "alternative_fields" => (thing_one(id, api) + thing_two(
-    id,
-    api
-  ))
+  "alternative_fields" => (thing_one(id, api) +
+    thing_two(
+      id,
+      api
+    ))
     .sort
 }

--- a/fixtures/small/return_expected.rb
+++ b/fixtures/small/return_expected.rb
@@ -12,4 +12,5 @@ return [
 return a, b
 return [a, b]
 return a && b
-return a && b
+return a &&
+  b

--- a/librubyfmt/src/delimiters.rs
+++ b/librubyfmt/src/delimiters.rs
@@ -75,6 +75,13 @@ impl BreakableDelims {
         }
     }
 
+    pub fn for_binary_op() -> Self {
+        BreakableDelims {
+            single_line: DelimiterPair::new("".to_string(), "".to_string()),
+            multi_line: DelimiterPair::new("".to_string(), "".to_string()),
+        }
+    }
+
     pub fn single_line_open(&self) -> ConcreteLineToken {
         ConcreteLineToken::Delim {
             contents: self.single_line.open.clone(),

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2496,7 +2496,7 @@ pub fn format_binary(ps: &mut dyn ConcreteParserState, binary: Binary) {
 }
 
 // Performs the actual formatting for binary operators. This method assumes that it's
-// inside of a breakable, but it's separated out so that it can recurse inside of 
+// inside of a breakable, but it's separated out so that it can recurse inside of
 // nested breakables so that nested breakables stay at the same indentation level.
 fn format_binary_inner(ps: &mut dyn ConcreteParserState, binary: Binary) {
     ps.with_formatting_context(

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2469,100 +2469,76 @@ pub fn format_unless(ps: &mut dyn ConcreteParserState, unless: Unless) {
     }
 }
 
-pub fn format_binary(ps: &mut dyn ConcreteParserState, binary: Binary, must_be_multiline: bool) {
+pub fn format_binary(ps: &mut dyn ConcreteParserState, binary: Binary) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
 
-    let format_func = |ps: &mut dyn ConcreteParserState, force_multiline: bool| {
-        ps.with_formatting_context(
-            FormattingContext::Binary,
-            Box::new(|ps| {
-                ps.with_start_of_line(
-                    false,
-                    Box::new(|ps| {
-                        let op = binary.2;
+    // Use the line number of the first expression if we have it
+    if let Some(start_line) = binary.1.start_line() {
+        ps.on_line(start_line);
+    } else {
+        // If we don't have it, use the line number of the binary operator
+        // (which is always there, albeit possibly not what the user expects)
+        ps.on_line(binary.2 .1.start_line());
+    }
 
-                        // If we force multilining (for e.g. long lines), *or*
-                        // because either inner expressions are user-multilined,
-                        // multiline *all* binaries in this chain
-                        let mut is_multiline = force_multiline;
-                        if let Expression::Binary(ref b) = *binary.1 {
-                            if op.1 != (b.2).1 {
-                                is_multiline = true;
-                            }
-                        }
-                        if let Expression::Binary(ref b) = *binary.3 {
-                            if op.1 != (b.2).1 {
-                                is_multiline = true;
-                            }
-                        }
-
-                        if let Expression::Binary(b) = *binary.1 {
-                            format_binary(ps, b, is_multiline);
-                        } else {
-                            format_expression(ps, *binary.1);
-                        }
-
-                        let comparison_operators =
-                            vec![">", ">=", "===", "==", "<", "<=", "<=>", "!="];
-                        let is_not_comparison = !comparison_operators.iter().any(|o| o == &op.0);
-
-                        let next_expr = *binary.3;
-
-                        ps.emit_space();
-                        ps.emit_ident(op.0);
-                        // In some cases, previous expressions changed the space
-                        // count but haven't reset it, so we force a reset here in
-                        // case we shift comments during the _next_ expression
-                        ps.reset_space_count();
-
-                        if force_multiline && is_not_comparison {
-                            // This branch runs when we're rendering additional binaries
-                            // nested inside *already multilined* binaries, e.g. a binary
-                            // with a long line length *and* a nested conditional on the right-hand side
-                            ps.new_block(Box::new(|ps| {
-                                ps.emit_newline();
-                                ps.emit_indent();
-
-                                if let Expression::Binary(b) = next_expr {
-                                    format_binary(ps, b, is_multiline);
-                                } else {
-                                    format_expression(ps, next_expr);
-                                }
-                            }));
-                        } else {
-                            if is_multiline && is_not_comparison {
-                                // Hack, but we want to "continue" the chain of binary
-                                // operators, which previously were at a deeper indentation level.
-                                // However, we don't want the following expressions to "inherit" this
-                                // indentation while rendering, so we only use the block for indentation
-                                ps.new_block(Box::new(|ps| {
-                                    ps.emit_newline();
-                                    ps.emit_indent();
-                                }));
-                            } else {
-                                ps.emit_space();
-                            }
-                            if let Expression::Binary(b) = next_expr {
-                                format_binary(ps, b, is_multiline);
-                            } else {
-                                format_expression(ps, next_expr);
-                            }
-                        }
-                    }),
-                );
-            }),
-        );
-    };
-
-    let is_multiline = must_be_multiline
-        || ps.will_render_beyond_max_line_length(Box::new(|ps| format_func.clone()(ps, false)));
-    format_func(ps, is_multiline);
+    ps.inline_breakable_of(
+        BreakableDelims::for_binary_op(),
+        Box::new(|ps| {
+            format_binary_inner(ps, binary);
+        }),
+    );
 
     if ps.at_start_of_line() {
         ps.emit_newline();
     }
+}
+
+// Performs the actual formatting for binary operators. This method assumes that it's
+// inside of a breakable, but it's separated out so that it can recurse inside of 
+// nested breakables so that nested breakables stay at the same indentation level.
+fn format_binary_inner(ps: &mut dyn ConcreteParserState, binary: Binary) {
+    ps.with_formatting_context(
+        FormattingContext::Binary,
+        Box::new(|ps| {
+            ps.with_start_of_line(
+                false,
+                Box::new(|ps| {
+                    let op = binary.2;
+
+                    if let Expression::Binary(bin) = *binary.1 {
+                        format_binary_inner(ps, bin);
+                    } else {
+                        format_expression(ps, *binary.1);
+                    }
+
+                    let comparison_operators = vec![">", ">=", "===", "==", "<", "<=", "<=>", "!="];
+                    let is_not_comparison = !comparison_operators.iter().any(|o| o == &op.0);
+
+                    let next_expr = *binary.3;
+
+                    ps.emit_space();
+                    ps.emit_ident(op.0);
+                    if is_not_comparison {
+                        ps.emit_soft_newline();
+                        ps.emit_soft_indent();
+                    } else {
+                        ps.emit_space();
+                    }
+                    // In some cases, previous expressions changed the space
+                    // count but haven't reset it, so we force a reset here in
+                    // case we shift comments during the _next_ expression
+                    ps.reset_space_count();
+                    if let Expression::Binary(bin) = next_expr {
+                        format_binary_inner(ps, bin);
+                    } else {
+                        format_expression(ps, next_expr);
+                    }
+                }),
+            );
+        }),
+    );
 }
 
 pub fn format_float(ps: &mut dyn ConcreteParserState, float: Float) {
@@ -3754,7 +3730,7 @@ pub fn format_expression(ps: &mut dyn ConcreteParserState, expression: Expressio
         Expression::Class(class) => format_class(ps, class),
         Expression::Defs(defs) => format_defs(ps, defs),
         Expression::If(ifs) => format_if(ps, ifs),
-        Expression::Binary(binary) => format_binary(ps, binary, false),
+        Expression::Binary(binary) => format_binary(ps, binary),
         Expression::Float(float) => format_float(ps, float),
         Expression::Aref(aref) => format_aref(ps, aref),
         Expression::Char(c) => format_char(ps, c),


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

Closes #379 

This PR yanks out the hacked-together multilining strategy for binary operators and makes them breakables instead. This was largely easier than I though -- IIRC the original reason for not doing this was that call chains weren't also breakables, so that resulted in weird interactions, but since we did that in #443, this is a pretty straightforward change.

The way this works is that instead of our old hacked-together system, we can wrap the "top-level" binary in a breakable, and then for nested breakables, we just recurse into the formatting function instead of making a new breakable, which keeps the old behavior of keeping chained binary operations all at the same level.

This also fixed a number of accidental interactions that I wasn't aware of but that I think are actually bugs -- in the fixtures that we changed, this PR makes it so that binary operators now respect user-multiling in all cases, which they didn't used to do but which is consistent with the approach taken for other breakable items.