### PR TITLE
Automatically create prelease releases on master builds

### DIFF
--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -1,8 +1,13 @@
-name: Release
+name: Preview Release
 on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
   push:
-    tags:
-      - "*"
+    # Run only on trunk pushes that aren't a new tag release
+    branches: [trunk]
+    tags-ignore: "*"
 
 env:
   BUNDLE_PATH: /tmp/.bundle
@@ -74,24 +79,39 @@ jobs:
           name: rubyfmt-source-release
           path: "out/release/source"
   release:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs:
       - build
       - source-release
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v3
         with:
           name: rubyfmt-source-release
       - uses: actions/download-artifact@v3
         with:
-          name: rubyfmt-release-artifact-ubuntu-latest
+          name: rubyfmt-release-artifact-ubuntu-20.04-native
       - uses: actions/download-artifact@v3
         with:
-          name: rubyfmt-release-artifact-macos-latest
-      - name: Ship It 🚢
+          name: rubyfmt-release-artifact-ubuntu-20.04-aarch64-unknown-linux-gnu
+      - uses: actions/download-artifact@v3
+        with:
+          name: rubyfmt-release-artifact-macos-latest-native
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+      - uses: actions-ecosystem/action-bump-semver@v1
+        id: bump-semver
+        with:
+          current_version: ${{ steps.get-latest-tag.outputs.tag }}
+          level: prepatch
+      - uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: ${{ steps.bump-semver.outputs.new_version }}
+      - name: Upload Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: rubyfmt-*.tar.gz
           fail_on_unmatched_files: true
           generate_release_notes: true
+          prerelease: true
+          tag_name: ${{steps.bump-semver.outputs.new_version}}

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -6,7 +6,7 @@ on:
       - completed
   push:
     # Run only on trunk pushes that aren't a new tag release
-    branches: "*"
+    branches: [trunk]
     tags-ignore: "*"
 
 env:
@@ -114,13 +114,11 @@ jobs:
           name: rubyfmt-release-artifact-macos-latest-native
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
-      - run: |
-          echo "${{ steps.get-latest-tag.outputs.tag }}"
-      # - name: Upload Release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     files: rubyfmt-*.tar.gz
-      #     fail_on_unmatched_files: true
-      #     generate_release_notes: true
-      #     prerelease: true
-      #     tag_name: ${{ steps.get-latest-tag.outputs.tag }}
+      - name: Upload Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: rubyfmt-*.tar.gz
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          prerelease: true
+          tag_name: ${{ steps.get-latest-tag.outputs.tag }}

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -100,20 +100,24 @@ jobs:
       - source-release
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
       - uses: actions/download-artifact@v3
         with:
           name: rubyfmt-source-release
       - uses: actions/download-artifact@v3
         with:
+          name: rubyfmt-release-artifact-ubuntu-20.04-aarch64-unknown-linux-gnu
+      - run: |
+          # The arch part of this path is set with uname, but we cross-compile the arm build on
+          # an x86 machine, so we want to make sure the name is correct for the release
+          mv rubyfmt-${{ steps.get-latest-tag.outputs.tag }}-Linux-x86_64.tar.gz rubyfmt-${{ steps.get-latest-tag.outputs.tag }}-Linux-aarch64.tar.gz
+      - uses: actions/download-artifact@v3
+        with:
           name: rubyfmt-release-artifact-ubuntu-20.04-native
       - uses: actions/download-artifact@v3
         with:
-          name: rubyfmt-release-artifact-ubuntu-20.04-aarch64-unknown-linux-gnu
-      - uses: actions/download-artifact@v3
-        with:
           name: rubyfmt-release-artifact-macos-latest-native
-      - uses: actions-ecosystem/action-get-latest-tag@v1
-        id: get-latest-tag
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -6,7 +6,7 @@ on:
       - completed
   push:
     # Run only on trunk pushes that aren't a new tag release
-    branches: [trunk]
+    branches: "*"
     tags-ignore: "*"
 
 env:

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -6,7 +6,7 @@ on:
       - completed
   push:
     # Run only on trunk pushes that aren't a new tag release
-    branches: "*"
+    branches: [trunk]
     tags-ignore: "*"
 
 env:

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -6,7 +6,7 @@ on:
       - completed
   push:
     # Run only on trunk pushes that aren't a new tag release
-    branches: [trunk]
+    branches: "*"
     tags-ignore: "*"
 
 env:
@@ -16,8 +16,23 @@ env:
   TERM: xterm256
 
 jobs:
+  bump-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+      - uses: actions-ecosystem/action-bump-semver@v1
+        id: bump-semver
+        with:
+          current_version: ${{ steps.get-latest-tag.outputs.tag }}
+          level: prepatch
+      - uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: ${{ steps.bump-semver.outputs.new_version }}
   build:
     runs-on: ${{ matrix.os }}
+    needs: [bump-tag]
     strategy:
       fail-fast: false
       matrix:
@@ -99,19 +114,13 @@ jobs:
           name: rubyfmt-release-artifact-macos-latest-native
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
-      - uses: actions-ecosystem/action-bump-semver@v1
-        id: bump-semver
-        with:
-          current_version: ${{ steps.get-latest-tag.outputs.tag }}
-          level: prepatch
-      - uses: actions-ecosystem/action-push-tag@v1
-        with:
-          tag: ${{ steps.bump-semver.outputs.new_version }}
-      - name: Upload Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: rubyfmt-*.tar.gz
-          fail_on_unmatched_files: true
-          generate_release_notes: true
-          prerelease: true
-          tag_name: ${{steps.bump-semver.outputs.new_version}}
+      - run: |
+          echo "${{ steps.get-latest-tag.outputs.tag }}"
+      # - name: Upload Release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     files: rubyfmt-*.tar.gz
+      #     fail_on_unmatched_files: true
+      #     generate_release_notes: true
+      #     prerelease: true
+      #     tag_name: ${{ steps.get-latest-tag.outputs.tag }}

--- a/script/make_release
+++ b/script/make_release
@@ -7,7 +7,7 @@ if [[ $OSTYPE == "darwin"* ]]; then
 fi
 bison --version
 
-TAG=$(git describe --tags --abbrev=0)
+TAG=$(git describe --exact-match HEAD)
 RELEASE_DIR=${RELEASE_DIR:-"tmp/releases/${TAG}-$(uname -s)/"}
 
 ./script/test.sh

--- a/script/make_release
+++ b/script/make_release
@@ -7,7 +7,7 @@ if [[ $OSTYPE == "darwin"* ]]; then
 fi
 bison --version
 
-TAG=$(git describe --exact-match HEAD)
+TAG=$(git describe --tags --abbrev=0)
 RELEASE_DIR=${RELEASE_DIR:-"tmp/releases/${TAG}-$(uname -s)/"}
 
 ./script/test.sh


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
This adds a new GH action that runs on non-tagged master builds. It basically makes sure tests still pass, then it bumps the version tag to a new pre-patch version and runs all the release scripts to create a `prerelease` build. (Note that this doesn't generate an arm Darwin build -- I tried to add the runner for it and got some complaint about billing so I assume that's only a paid thing -- but it builds the x86 and arm Linux builds, which is mostly what I care about.)

The reason to do this is that it makes it far easier to iteratively pull and use new rubymt versions as we make changes. In the past, manual version bumps cause a lot of toil, so we didn't bump our rubyfmt very often. In an ideal world, we would bump even on patch versions to stay as close to `HEAD` as possible. Since they're prereleases, this won't cause updates to homebrew or anything -- it's only available by pulling the GH release, and we can still cut manual tag releases for homebrew releases as needed.