### PR TITLE
Prevent internal ruby failure on invalid braces

### DIFF
--- a/librubyfmt/rubyfmt_lib.rb
+++ b/librubyfmt/rubyfmt_lib.rb
@@ -477,7 +477,11 @@ class Parser < Ripper::SexpBuilderPP
 
   def on_embexpr_end(*args)
     # Append end line to make a StartEnd
-    @embexpr_stack.last << lineno
+    #
+    # We defensively check that `#embexpr_stack` has something in it,
+    # although this should only happen while looking at invalid syntax.
+    # For example, `""}` would run this with an empty stack.
+    @embexpr_stack.last << lineno if !@embexpr_stack.empty?
     super
   end
 

--- a/tests/error_handling_test.rs
+++ b/tests/error_handling_test.rs
@@ -141,3 +141,17 @@ fn test_input_file_doesnt_exist() {
         .code(3)
         .failure();
 }
+
+// We don't really have a great way to test for regressions that caused
+// failures in rubyfmt_lib.rb, but this test is here to prevent a specific
+// regression caused by invalid syntax
+#[test]
+fn test_potential_internal_failure_stdin() {
+    Command::new(cargo_bin("rubyfmt-main"))
+        .write_stdin("\"\"}")
+        .assert()
+        // Make sure this is a `1` for syntax error instead of a
+        // `4` for internal Ruby failure
+        .code(1)
+        .failure();
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

`""}` is invalid syntax, and while running it, Ripper tries to run `on_embexpr_end` to try and handle it as if it were the closing brace of an embexpr. However, in that case, we get a `NoMethodError` for trying to append to an array that isn't there (since we didn't call `on_embexpr_beg`. This is absolutely a weird edge case, but handling it means we correctly report this as a syntax error instead of an internal ruby error.

(There might be something to do here for a more sustainable solution, which is something like if we run into an internal ruby error, call the parser directly without `rubyfmt_lib` and see if it parses correctly, but I'll leave that as an idea for a later day.)
