### PR TITLE
Fix busted fixtures on `trunk`

### DIFF
--- a/fixtures/small/and_or_expected.rb
+++ b/fixtures/small/and_or_expected.rb
@@ -1,6 +1,7 @@
 true and false
 true or false
-false or true
+false or
+  true
 
 true and
   false or


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

On the tin -- the fixtures added in #452 and #449 conflicted with each other