### PR TITLE
Fix busted preview-release build by forcing full ruby builds

### DIFF
--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -6,7 +6,7 @@ on:
       - completed
   push:
     # Run only on trunk pushes that aren't a new tag release
-    branches: [trunk]
+    branches: [trunk, reese-preview-release]
     tags-ignore: "*"
 
 env:
@@ -14,6 +14,7 @@ env:
   GEM_HOME: /tmp/.bundle
   GEM_PATH: /tmp/.bundle
   TERM: xterm256
+  FORCE_FULL_RUBY_BUILD: 1
 
 jobs:
   bump-tag:
@@ -118,11 +119,11 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: rubyfmt-release-artifact-macos-latest-native
-      - name: Upload Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: rubyfmt-*.tar.gz
-          fail_on_unmatched_files: true
-          generate_release_notes: true
-          prerelease: true
-          tag_name: ${{ steps.get-latest-tag.outputs.tag }}
+      # - name: Upload Release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     files: rubyfmt-*.tar.gz
+      #     fail_on_unmatched_files: true
+      #     generate_release_notes: true
+      #     prerelease: true
+      #     tag_name: ${{ steps.get-latest-tag.outputs.tag }}

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -6,7 +6,7 @@ on:
       - completed
   push:
     # Run only on trunk pushes that aren't a new tag release
-    branches: [trunk, reese-preview-release]
+    branches: [trunk]
     tags-ignore: "*"
 
 env:
@@ -119,11 +119,11 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: rubyfmt-release-artifact-macos-latest-native
-      # - name: Upload Release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     files: rubyfmt-*.tar.gz
-      #     fail_on_unmatched_files: true
-      #     generate_release_notes: true
-      #     prerelease: true
-      #     tag_name: ${{ steps.get-latest-tag.outputs.tag }}
+      - name: Upload Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: rubyfmt-*.tar.gz
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          prerelease: true
+          tag_name: ${{ steps.get-latest-tag.outputs.tag }}

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -46,7 +46,6 @@ fn main() -> Output {
     let new_checkout_sha = get_ruby_checkout_sha();
 
     // Only rerun this build if the ruby_checkout has changed
-    // boop
     match old_checkout_sha {
         Some(old_sha)
             if old_sha == new_checkout_sha && env::var("FORCE_FULL_RUBY_BUILD").is_err() => {}

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -47,7 +47,8 @@ fn main() -> Output {
 
     // Only rerun this build if the ruby_checkout has changed
     match old_checkout_sha {
-        Some(old_sha) if old_sha == new_checkout_sha => {}
+        Some(old_sha)
+            if old_sha == new_checkout_sha && !env::var("FORCE_FULL_RUBY_BUILD").is_ok() => {}
         _ => {
             make_configure(&ruby_checkout_path)?;
             run_configure(&ruby_checkout_path)?;

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -46,9 +46,10 @@ fn main() -> Output {
     let new_checkout_sha = get_ruby_checkout_sha();
 
     // Only rerun this build if the ruby_checkout has changed
+    // boop
     match old_checkout_sha {
         Some(old_sha)
-            if old_sha == new_checkout_sha && !env::var("FORCE_FULL_RUBY_BUILD").is_ok() => {}
+            if old_sha == new_checkout_sha && env::var("FORCE_FULL_RUBY_BUILD").is_err() => {}
         _ => {
             make_configure(&ruby_checkout_path)?;
             run_configure(&ruby_checkout_path)?;


### PR DESCRIPTION
This PR fixes the `preview-release` build by removing the `ruby_checkout` caching. This was causing issues with the ruby build, but removing it fixes any apparent discrepancies in the build that was causing issues. This probably makes it a bit slower, but I don't think speed is of the utmost priority since it's only run post-merge anyways 🤷 

I verified this works by running it on this branch: [result](https://github.com/fables-tales/rubyfmt/actions/runs/7467397394/job/20320840420)
