### PR TITLE
Don't double-indent multiline expressions in binary operations

### DIFF
--- a/fixtures/small/binary_operators_actual.rb
+++ b/fixtures/small/binary_operators_actual.rb
@@ -49,3 +49,17 @@ def bees!
   # Maybe there should be the same amount of bees
   equal_amount_of_bees?
 end
+
+MyClass.calculate_stuff / 2
+MyClass
+  .calculate_stuff / 2
+{1 => "", 2 => ""}.keys.sum / 5
+{1 => "",
+  2 => ""}.keys.sum / 5
+
+Foo.new(
+  a: Calculator.calculate_stuff
+    .map { _1.do_things! }
+    .sum +
+     1000.to_f
+)

--- a/fixtures/small/binary_operators_expected.rb
+++ b/fixtures/small/binary_operators_expected.rb
@@ -54,3 +54,22 @@ def bees!
     # Maybe there should be the same amount of bees
     equal_amount_of_bees?
 end
+
+MyClass.calculate_stuff / 2
+MyClass
+  .calculate_stuff /
+  2
+{1 => "", 2 => ""}.keys.sum / 5
+{
+  1 => "",
+  2 => ""
+}.keys.sum /
+  5
+
+Foo.new(
+  a: Calculator
+    .calculate_stuff
+    .map { _1.do_things! }
+    .sum +
+    1000.to_f
+)

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2506,11 +2506,14 @@ fn format_binary_inner(ps: &mut dyn ConcreteParserState, binary: Binary) {
                 false,
                 Box::new(|ps| {
                     let op = binary.2;
+                    let left_hand_side = *binary.1;
 
-                    if let Expression::Binary(bin) = *binary.1 {
+                    if let Expression::Binary(bin) = left_hand_side {
                         format_binary_inner(ps, bin);
                     } else {
-                        format_expression(ps, *binary.1);
+                        ps.dedent(Box::new(|ps| {
+                            format_expression(ps, left_hand_side);
+                        }));
                     }
 
                     let comparison_operators = vec![">", ">=", "===", "==", "<", "<=", "<=>", "!="];


### PR DESCRIPTION
Now that binary expressions are modeled as breakables, they (correctly) add an indentation level when they split to multiple lines. However, we usually don't actually start that indentation until _after_ the initial LHS expression, so we need to account for this and dedent the LHS to prevent double-indenting.

Before:
```ruby
{
  a: Foo
      .calculate_stuff / # Too deep!
    2
}
```

After:
```ruby
{
  a: Foo
    .calculate_stuff / # Lookin' good
    2
}
```