### PR TITLE
Fix aarch release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,16 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - uses: actions-rs/toolchain@v1
+    - if: runner.os == 'macOS'
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.63.0
+        target: aarch64-apple-darwin
+        default: true
+        override: true
+        profile: minimal
+    - if: runner.os != 'macOS'
+      uses: actions-rs/toolchain@v1
       with:
         toolchain: 1.63.0
         override: true

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -74,6 +74,8 @@ jobs:
           brew install automake bison
           echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
       - run: ./script/make_release
+        env:
+          TARGET: ${{ matrix.target }}
       - uses: actions/upload-artifact@v3
         with:
           name: rubyfmt-release-artifact-${{ matrix.os }}-${{ matrix.target }}
@@ -109,10 +111,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: rubyfmt-release-artifact-ubuntu-20.04-aarch64-unknown-linux-gnu
-      - run: |
-          # The arch part of this path is set with uname, but we cross-compile the arm build on
-          # an x86 machine, so we want to make sure the name is correct for the release
-          mv rubyfmt-${{ steps.get-latest-tag.outputs.tag }}-Linux-x86_64.tar.gz rubyfmt-${{ steps.get-latest-tag.outputs.tag }}-Linux-aarch64.tar.gz
       - uses: actions/download-artifact@v3
         with:
           name: rubyfmt-release-artifact-ubuntu-20.04-native

--- a/script/make_release
+++ b/script/make_release
@@ -44,7 +44,7 @@ case "$target" in
       TARGET_AR=aarch64-linux-gnu-ar \
       cargo build --release --target aarch64-unknown-linux-gnu
 
-    cargo_target_dir_prefix="aarch64-unknown-linux-gnu"
+    cargo_target_dir_prefix="aarch64-unknown-linux-gnu/"
     # This is kind of a hack, since we're assuming we're on a Linux host.
     release_tarball_os="Linux"
     release_tarball_arch="aarch64"


### PR DESCRIPTION
When I made the preview release builds, I didn't notice that the arm builds in `make_release` actually operate off of the `TARGET` env variable, so they were actually producing x86 builds. The arm builds are pretty rarely used, so we didn't notice until post-release -- this PR remedies that and produces the correct build artifact.