### PR TITLE
do less work for indenting comment blocks

### DIFF
--- a/librubyfmt/src/comment_block.rs
+++ b/librubyfmt/src/comment_block.rs
@@ -36,11 +36,12 @@ impl CommentBlock {
     }
 
     pub fn apply_spaces(mut self, indent_depth: ColNumber) -> Self {
+        let indent = str::repeat(" ", indent_depth as _);
         for comment in &mut self.comments {
             // Ignore empty strings -- these represent blank lines between
             // groups of comments
             if !comment.is_empty() {
-                *comment = str::repeat(" ", indent_depth as _) + comment
+                comment.insert_str(0, &indent);
             }
         }
         self


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

This is a small optimization, but I think the code reads more nicely as a result.

(Yes, I know we do one more allocation if there are no comments in the file; I don't think that's really a problem and have a plan to solve it in a followup PR.)