### PR TITLE
Support anonymous block arguments

### DIFF
--- a/fixtures/small/anonymous_blockarg_actual.rb
+++ b/fixtures/small/anonymous_blockarg_actual.rb
@@ -1,0 +1,3 @@
+def foo(a, b, &)
+  bar a, b, &
+end

--- a/fixtures/small/anonymous_blockarg_expected.rb
+++ b/fixtures/small/anonymous_blockarg_expected.rb
@@ -1,0 +1,3 @@
+def foo(a, b, &)
+  bar(a, b, &)
+end

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2069,10 +2069,11 @@ pub fn format_next(ps: &mut dyn ConcreteParserState, next: Next) {
                     }
                 }
                 ArgsAddBlockOrExpressionList::ArgsAddBlock(aab) => match aab.2 {
-                    ToProcExpr::Present(_) => {
+                    Some(ToProcExpr::Present(_)) => {
                         panic!("got a block in a next, should be impossible");
                     }
-                    ToProcExpr::NotPresent(_) => {
+                    None => unreachable!("got an anonymous block in a next, should be impossible"),
+                    Some(ToProcExpr::NotPresent(_)) => {
                         ps.emit_space();
                         format_list_like_thing(
                             ps,
@@ -3105,7 +3106,7 @@ pub fn format_keyword(
                 ArgsAddBlockInner::ArgsAddStarOrExpressionListOrArgsForward(
                     ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(vec![]),
                 ),
-                ToProcExpr::NotPresent(false),
+                Some(ToProcExpr::NotPresent(false)),
                 start_end.clone(),
             )
         }
@@ -3601,6 +3602,10 @@ pub fn format_to_proc(ps: &mut dyn ConcreteParserState, e: Box<Expression>) {
     ps.with_start_of_line(false, Box::new(|ps| format_expression(ps, *e)));
 }
 
+pub fn format_anon_block_arg(ps: &mut dyn ConcreteParserState) {
+    ps.emit_ident("&".to_string());
+}
+
 pub fn format_zsuper(ps: &mut dyn ConcreteParserState, start_end: StartEnd) {
     format_keyword(
         ps,
@@ -3766,6 +3771,7 @@ pub fn format_expression(ps: &mut dyn ConcreteParserState, expression: Expressio
         Expression::OpAssign(op) => format_opassign(ps, op),
         Expression::Unless(u) => format_unless(ps, u),
         Expression::ToProc(ToProc(_, e)) => format_to_proc(ps, e),
+        Expression::AnonBlockArg(AnonBlockArg(_, _)) => format_anon_block_arg(ps),
         Expression::ZSuper(ZSuper(_, se)) => format_zsuper(ps, se),
         Expression::Yield0(Yield0(_, se)) => format_yield0(ps, se),
         Expression::Return(ret) => format_return(ps, ret),

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -251,8 +251,10 @@ pub fn format_block_arg(
                 Box::new(|ps| {
                     ps.emit_soft_indent();
                     ps.emit_ident("&".to_string());
-                    bind_ident(ps, &ba.1);
-                    format_ident(ps, ba.1);
+                    if let Some(ident) = ba.1 {
+                        bind_ident(ps, &ident);
+                        format_ident(ps, ident);
+                    }
                 }),
             );
 

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1298,7 +1298,7 @@ pub struct KwRestParam(pub kw_rest_param_tag, pub Option<Ident>);
 
 def_tag!(blockarg_tag, "blockarg");
 #[derive(Deserialize, Debug, Clone)]
-pub struct BlockArg(pub blockarg_tag, pub Ident);
+pub struct BlockArg(pub blockarg_tag, pub Option<Ident>);
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct LineCol(pub LineNumber, pub u64);

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -79,9 +79,17 @@ def_tag!(undeserializable, "oiqjweoifjqwoeifjwqoiefjqwoiej");
 #[derive(Deserialize, Debug, Clone)]
 pub struct ToProc(pub undeserializable, pub Box<Expression>);
 
+def_tag!(
+    undeserializable_anon_block_arg,
+    "oiqjweoifjqwoeifjwqoiefjqwoiej_anon_block_arg"
+);
+#[derive(Deserialize, Debug, Clone)]
+pub struct AnonBlockArg(pub undeserializable_anon_block_arg, pub u64);
+
 #[derive(RipperDeserialize, Debug, Clone)]
 pub enum Expression {
     ToProc(ToProc),
+    AnonBlockArg(AnonBlockArg),
     Class(Class),
     If(If),
     Unary(Unary),
@@ -296,6 +304,9 @@ impl Expression {
             // Arefs only have an accurate closing line and not a starting line,
             // so don't use it here
             Expression::Aref(Aref(_, expr, ..)) => expr.start_line(),
+            // Anonymous block arguments have no location information, so we use the end of the
+            // original enclosing `args_add_block` node.
+            Expression::AnonBlockArg(AnonBlockArg(.., line_start)) => Some(*line_start),
         }
     }
 }
@@ -1350,26 +1361,27 @@ pub fn normalize_args_add_block_or_expression_list(
 pub fn normalize_args_add_block(aab: ArgsAddBlock) -> ArgsAddStarOrExpressionListOrArgsForward {
     // .1 is expression list
     // .2 is block
-    match aab.2 {
-        ToProcExpr::NotPresent(_) => (aab.1).into_args_add_star_or_expression_list(),
-        ToProcExpr::Present(e) => {
-            let trailing_expr_as_vec = vec![Expression::ToProc(ToProc(undeserializable, e))];
 
-            match (aab.1).into_args_add_star_or_expression_list() {
-                ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(items) => {
-                    ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(
-                        vec![items, trailing_expr_as_vec].concat(),
-                    )
-                }
-                ArgsAddStarOrExpressionListOrArgsForward::ArgsAddStar(aas) => {
-                    let mut new_aas = aas;
-                    new_aas.3 = vec![new_aas.3, trailing_expr_as_vec].concat();
-                    ArgsAddStarOrExpressionListOrArgsForward::ArgsAddStar(new_aas)
-                }
-                ArgsAddStarOrExpressionListOrArgsForward::ArgsForward(af) => {
-                    ArgsAddStarOrExpressionListOrArgsForward::ArgsForward(af)
-                }
-            }
+    let trailing_expr = match aab.2 {
+        Some(ToProcExpr::NotPresent(_)) => {
+            return (aab.1).into_args_add_star_or_expression_list();
+        }
+        Some(ToProcExpr::Present(e)) => Expression::ToProc(ToProc(undeserializable, e)),
+        // anonymous block
+        None => Expression::AnonBlockArg(AnonBlockArg(undeserializable_anon_block_arg, aab.3.end_line())),
+    };
+
+    match (aab.1).into_args_add_star_or_expression_list() {
+        ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(mut items) => {
+            items.push(trailing_expr);
+            ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(items)
+        }
+        ArgsAddStarOrExpressionListOrArgsForward::ArgsAddStar(mut aas) => {
+            aas.3.push(trailing_expr);
+            ArgsAddStarOrExpressionListOrArgsForward::ArgsAddStar(aas)
+        }
+        ArgsAddStarOrExpressionListOrArgsForward::ArgsForward(af) => {
+            ArgsAddStarOrExpressionListOrArgsForward::ArgsForward(af)
         }
     }
 }
@@ -1420,7 +1432,7 @@ def_tag!(args_add_block_tag, "args_add_block");
 pub struct ArgsAddBlock(
     pub args_add_block_tag,
     pub ArgsAddBlockInner,
-    pub ToProcExpr,
+    pub Option<ToProcExpr>,
     pub StartEnd,
 );
 

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1368,7 +1368,10 @@ pub fn normalize_args_add_block(aab: ArgsAddBlock) -> ArgsAddStarOrExpressionLis
         }
         Some(ToProcExpr::Present(e)) => Expression::ToProc(ToProc(undeserializable, e)),
         // anonymous block
-        None => Expression::AnonBlockArg(AnonBlockArg(undeserializable_anon_block_arg, aab.3.end_line())),
+        None => Expression::AnonBlockArg(AnonBlockArg(
+            undeserializable_anon_block_arg,
+            aab.3.end_line(),
+        )),
     };
 
     match (aab.1).into_args_add_star_or_expression_list() {


### PR DESCRIPTION
Add support for handling method definitions and sends that use anonymous block arguments.

With this PR, the following input:

```ruby
def foo(a, b, &)
  bar a, b, &
end
```

is formatted as the following:

```ruby
def foo(a, b, &)
  bar(a, b, &)
end
```
