### PR TITLE
Upgrade to `actions/cache@v4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     - run: ./script/test.sh
       env:
         TARGET: ${{ matrix.target }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: rubyfmt-artifact-${{ matrix.os }}-${{ matrix.target }}
         path: target/${{ matrix.target == 'native' && 'release' || format('{0}/release', matrix.target) }}/rubyfmt-main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,13 +81,13 @@ jobs:
         override: true
         profile: minimal
         target: aarch64-unknown-linux-gnu
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
         key: ${{ runner.os }}-${{ matrix.target }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           librubyfmt/ruby_checkout

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -76,7 +76,7 @@ jobs:
       - run: ./script/make_release
         env:
           TARGET: ${{ matrix.target }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: rubyfmt-release-artifact-${{ matrix.os }}-${{ matrix.target }}
           path: rubyfmt-*.tar.gz
@@ -92,7 +92,7 @@ jobs:
           RELEASE_DIR="out/release"
           mkdir -p ${RELEASE_DIR}
           ./script/make_source_release ${TAG}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: rubyfmt-source-release
           path: "out/release/source"
@@ -105,16 +105,16 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rubyfmt-source-release
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rubyfmt-release-artifact-ubuntu-20.04-aarch64-unknown-linux-gnu
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rubyfmt-release-artifact-ubuntu-20.04-native
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rubyfmt-release-artifact-macos-latest-native
       - name: Upload Release

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -64,7 +64,7 @@ jobs:
           override: true
           profile: minimal
           target: aarch64-unknown-linux-gnu
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             librubyfmt/ruby_checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
           brew install automake bison
           echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
       - run: ./script/make_release
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: rubyfmt-release-artifact-${{ matrix.os }}-${{ matrix.target }}
           path: rubyfmt-*.tar.gz
@@ -69,7 +69,7 @@ jobs:
           RELEASE_DIR="out/release"
           mkdir -p ${RELEASE_DIR}
           ./script/make_source_release ${TAG}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: rubyfmt-source-release
           path: "out/release/source"
@@ -79,13 +79,13 @@ jobs:
       - build
       - source-release
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rubyfmt-source-release
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rubyfmt-release-artifact-ubuntu-latest
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rubyfmt-release-artifact-macos-latest
       - name: Ship It 🚢

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
           override: true
           profile: minimal
           target: aarch64-unknown-linux-gnu
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             librubyfmt/ruby_checkout


### PR DESCRIPTION
On the tin -- looks like CI is failing because our version of `actions/cache` is [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). This just subs in the new v4 supported version.