### PR TITLE
Bump CI rust toolchain to 1.85.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.63.0
+          toolchain: 1.85.0
           components: clippy
           override: true
           profile: minimal
@@ -69,7 +69,7 @@ jobs:
     - if: runner.os == 'macOS'
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.63.0
+        toolchain: 1.85.0
         target: aarch64-apple-darwin
         default: true
         override: true
@@ -77,7 +77,7 @@ jobs:
     - if: runner.os != 'macOS'
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.63.0
+        toolchain: 1.85.0
         override: true
         profile: minimal
         target: aarch64-unknown-linux-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
           components: rustfmt
           override: true
-          profile: minimal
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -31,12 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.85.0
           components: clippy
           override: true
-          profile: minimal
       - run: cargo clippy --all --all-features -- -D warnings
 
   lint:
@@ -67,19 +65,16 @@ jobs:
       with:
         submodules: true
     - if: runner.os == 'macOS'
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: 1.85.0
         target: aarch64-apple-darwin
-        default: true
         override: true
-        profile: minimal
     - if: runner.os != 'macOS'
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: 1.85.0
         override: true
-        profile: minimal
         target: aarch64-unknown-linux-gnu
     - uses: actions/cache@v4
       with:

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -51,7 +51,7 @@ jobs:
       - if: runner.os == 'macOS'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.63.0
+          toolchain: 1.85.0
           target: aarch64-apple-darwin
           default: true
           override: true
@@ -59,7 +59,7 @@ jobs:
       - if: runner.os != 'macOS'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.63.0
+          toolchain: 1.85.0
           override: true
           profile: minimal
           target: aarch64-unknown-linux-gnu

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -49,19 +49,16 @@ jobs:
           submodules: true
           fetch-depth: 0
       - if: runner.os == 'macOS'
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.85.0
           target: aarch64-apple-darwin
-          default: true
           override: true
-          profile: minimal
       - if: runner.os != 'macOS'
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.85.0
           override: true
-          profile: minimal
           target: aarch64-unknown-linux-gnu
       - if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
       - if: runner.os == 'macOS'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.63.0
+          toolchain: 1.85.0
           target: aarch64-apple-darwin
           default: true
           override: true
@@ -39,7 +39,7 @@ jobs:
       - if: runner.os != 'macOS'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.63.0
+          toolchain: 1.85.0
           override: true
           profile: minimal
           target: aarch64-unknown-linux-gnu

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,19 +29,16 @@ jobs:
           submodules: true
           fetch-depth: 0
       - if: runner.os == 'macOS'
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.85.0
           target: aarch64-apple-darwin
-          default: true
           override: true
-          profile: minimal
       - if: runner.os != 'macOS'
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.85.0
           override: true
-          profile: minimal
           target: aarch64-unknown-linux-gnu
       - if: runner.os == 'macOS'
         run: |

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -40,7 +40,7 @@ fn main() -> Output {
     };
 
     let _ = Command::new("git")
-        .args(&["submodule", "update", "--init"])
+        .args(["submodule", "update", "--init"])
         .status();
 
     let new_checkout_sha = get_ruby_checkout_sha();
@@ -59,7 +59,7 @@ fn main() -> Output {
 
     cc::Build::new()
         .file("src/rubyfmt.c")
-        .object(ruby_checkout_path.join(&ripper))
+        .object(ruby_checkout_path.join(ripper))
         .include(ruby_checkout_path.join("include"))
         .include(ruby_checkout_path.join(format!(".ext/include/{}", arch)))
         .warnings(false)
@@ -229,7 +229,7 @@ fn check_process_success(command: &str, code: ExitStatus) -> Output {
 fn get_ruby_checkout_sha() -> String {
     String::from_utf8(
         Command::new("git")
-            .args(&["rev-parse", "HEAD"])
+            .args(["rev-parse", "HEAD"])
             .current_dir("./ruby_checkout")
             .output()
             .expect("git rev-parse shouldn't fail")

--- a/librubyfmt/src/de.rs
+++ b/librubyfmt/src/de.rs
@@ -69,7 +69,7 @@ impl<'de> de::Deserialize<'de> for VALUE {
 
         struct Visitor;
 
-        impl<'de> de::Visitor<'de> for Visitor {
+        impl de::Visitor<'_> for Visitor {
             type Value = VALUE;
 
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2519,7 +2519,7 @@ fn format_binary_inner(ps: &mut dyn ConcreteParserState, binary: Binary) {
                         }));
                     }
 
-                    let comparison_operators = vec![">", ">=", "===", "==", "<", "<=", "<=>", "!="];
+                    let comparison_operators = [">", ">=", "===", "==", "<", "<=", "<=>", "!="];
                     let is_not_comparison = !comparison_operators.iter().any(|o| o == &op.0);
 
                     let next_expr = *binary.3;
@@ -2695,7 +2695,7 @@ fn can_elide_parens_for_reserved_names(cc: &[CallChainElement]) -> bool {
         .iter()
         .any(|e| matches!(e, CallChainElement::DotTypeOrOp(..)));
     let is_bare_reserved_method_name = is_bare_call
-        && match cc.get(0) {
+        && match cc.first() {
             Some(CallChainElement::IdentOrOpOrKeywordOrConst(
                 IdentOrOpOrKeywordOrConst::Ident(Ident(_, ident, _)),
             )) => {
@@ -2709,7 +2709,7 @@ fn can_elide_parens_for_reserved_names(cc: &[CallChainElement]) -> bool {
         return true;
     }
 
-    let is_rspec_describe = match (cc.get(0), cc.get(2)) {
+    let is_rspec_describe = match (cc.first(), cc.get(2)) {
         (
             Some(CallChainElement::VarRef(VarRef(_, VarRefType::Const(Const(_, c, _))))),
             Some(CallChainElement::IdentOrOpOrKeywordOrConst(IdentOrOpOrKeywordOrConst::Ident(
@@ -2903,7 +2903,7 @@ pub fn format_method_add_block(ps: &mut dyn ConcreteParserState, mab: MethodAddB
     }
 }
 
-pub fn is_empty_bodystmt(bodystmt: &Vec<Expression>) -> bool {
+pub fn is_empty_bodystmt(bodystmt: &[Expression]) -> bool {
     bodystmt.len() == 1 && matches!(bodystmt[0], Expression::VoidStmt(..))
 }
 
@@ -3024,7 +3024,7 @@ fn get_brace_block_render_method(
     ps: &mut dyn ConcreteParserState,
     start_line: u64,
     end_line: u64,
-    body: &Vec<Expression>,
+    body: &[Expression],
 ) -> BraceBlockRenderMethod {
     let has_multiple_expressions = body.len() > 1;
     if has_multiple_expressions {
@@ -3132,12 +3132,12 @@ pub fn format_keyword(
 
 pub fn format_while(
     ps: &mut dyn ConcreteParserState,
-    conditional: Box<Expression>,
+    conditional: Expression,
     exprs: Vec<Expression>,
     kw: String,
     start_end: StartEnd,
 ) {
-    format_conditional(ps, *conditional, exprs, kw, None, Some(start_end));
+    format_conditional(ps, conditional, exprs, kw, None, Some(start_end));
 
     ps.with_start_of_line(
         true,
@@ -3751,8 +3751,8 @@ pub fn format_expression(ps: &mut dyn ConcreteParserState, expression: Expressio
         Expression::Yield(y) => format_yield(ps, y),
         Expression::Break(b) => format_keyword(ps, b.1, "break".to_string(), b.2),
         Expression::MethodAddBlock(mab) => format_method_add_block(ps, mab),
-        Expression::While(w) => format_while(ps, w.1, w.2, "while".to_string(), w.3),
-        Expression::Until(u) => format_while(ps, u.1, u.2, "until".to_string(), u.3),
+        Expression::While(w) => format_while(ps, *w.1, w.2, "while".to_string(), w.3),
+        Expression::Until(u) => format_while(ps, *u.1, u.2, "until".to_string(), u.3),
         Expression::WhileMod(wm) => format_inline_mod(ps, wm.1, wm.2, "while".to_string()),
         Expression::UntilMod(um) => format_inline_mod(ps, um.1, um.2, "until".to_string()),
         Expression::IfMod(wm) => format_multilinable_mod(ps, wm.1, wm.2, "if".to_string()),

--- a/librubyfmt/src/heredoc_string.rs
+++ b/librubyfmt/src/heredoc_string.rs
@@ -81,6 +81,6 @@ impl HeredocString {
     /// quotes, so we must strip them from the symbol when
     /// rendering the closing symbol.
     pub fn closing_symbol(&self) -> String {
-        self.symbol.replace('\'', "").replace('"', "")
+        self.symbol.replace(['\'', '"'], "")
     }
 }

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -799,8 +799,7 @@ impl ConcreteParserState for BaseParserState {
     }
 
     fn render_heredocs(&mut self, skip: bool) {
-        while !self.heredoc_strings.is_empty() {
-            let next_heredoc = self.heredoc_strings.pop().expect("we checked it's there");
+        while let Some(next_heredoc) = self.heredoc_strings.pop() {
             let want_newline = !self.last_token_is_a_newline();
             if want_newline {
                 self.push_concrete_token(ConcreteLineToken::HardNewLine);
@@ -879,12 +878,8 @@ impl BaseParserState {
             None
         } else {
             let mut hds = vec![];
-            while !self.heredoc_strings.is_empty() {
-                hds.push(
-                    self.heredoc_strings
-                        .pop()
-                        .expect("we checked it's not empty"),
-                );
+            while let Some(element) = self.heredoc_strings.pop() {
+                hds.push(element);
             }
             Some(hds)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ struct CommandlineOpts {
     /// - File paths (i.e lib/foo/bar.rb){n}
     /// - Directories (i.e. lib/foo/){n}
     /// - Input files (i.e. @/tmp/files.txt). These files must contain one file path or directory per line
+    ///
     /// rubyfmt will use these as input.{n}
     #[clap(name = "include-paths")]
     include_paths: Vec<String>,
@@ -79,7 +80,7 @@ struct CommandlineOpts {
 /* Error handling                                     */
 /******************************************************/
 
-fn handle_io_error(err: io::Error, source: &String, error_exit: ErrorExit) {
+fn handle_io_error(err: io::Error, source: &str, error_exit: ErrorExit) {
     let msg = format!("Rubyfmt experienced an IO error: {}", err);
     print_error(&msg, Some(source));
 
@@ -96,7 +97,7 @@ fn handle_ignore_error(err: ignore::Error, error_exit: ErrorExit) {
     }
 }
 
-fn handle_rubyfmt_error(err: rubyfmt::RichFormatError, source: &String, error_exit: ErrorExit) {
+fn handle_rubyfmt_error(err: rubyfmt::RichFormatError, source: &str, error_exit: ErrorExit) {
     use rubyfmt::RichFormatError::*;
     let exit_code = err.as_exit_code();
     let e = || {


### PR DESCRIPTION
What it says -- our current Rust toolchain (`1.63.0`) is a few years old at this point, so we should keep up with the times and bump to the current stable version. This also moves us from `actions-rs/toolchain@v1` (which gives us [several warnings](https://github.com/fables-tales/rubyfmt/actions/runs/13698800262/job/38307301032) and is currently archived) to `actions-rust-lang/setup-rust-toolchain@v1`, which seems to be actively maintained.

This will also get to a new enough version that we'll be able to kill off some now-unmaintained crates (see #480).