### PR TITLE
Fix future clippy violations

### DIFF
--- a/librubyfmt/src/de.rs
+++ b/librubyfmt/src/de.rs
@@ -69,7 +69,7 @@ impl<'de> de::Deserialize<'de> for VALUE {
 
         struct Visitor;
 
-        impl<'de> de::Visitor<'de> for Visitor {
+        impl de::Visitor<'_> for Visitor {
             type Value = VALUE;
 
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2519,7 +2519,7 @@ fn format_binary_inner(ps: &mut dyn ConcreteParserState, binary: Binary) {
                         }));
                     }
 
-                    let comparison_operators = vec![">", ">=", "===", "==", "<", "<=", "<=>", "!="];
+                    let comparison_operators = [">", ">=", "===", "==", "<", "<=", "<=>", "!="];
                     let is_not_comparison = !comparison_operators.iter().any(|o| o == &op.0);
 
                     let next_expr = *binary.3;
@@ -2695,7 +2695,7 @@ fn can_elide_parens_for_reserved_names(cc: &[CallChainElement]) -> bool {
         .iter()
         .any(|e| matches!(e, CallChainElement::DotTypeOrOp(..)));
     let is_bare_reserved_method_name = is_bare_call
-        && match cc.get(0) {
+        && match cc.first() {
             Some(CallChainElement::IdentOrOpOrKeywordOrConst(
                 IdentOrOpOrKeywordOrConst::Ident(Ident(_, ident, _)),
             )) => {
@@ -2709,7 +2709,7 @@ fn can_elide_parens_for_reserved_names(cc: &[CallChainElement]) -> bool {
         return true;
     }
 
-    let is_rspec_describe = match (cc.get(0), cc.get(2)) {
+    let is_rspec_describe = match (cc.first(), cc.get(2)) {
         (
             Some(CallChainElement::VarRef(VarRef(_, VarRefType::Const(Const(_, c, _))))),
             Some(CallChainElement::IdentOrOpOrKeywordOrConst(IdentOrOpOrKeywordOrConst::Ident(
@@ -2903,7 +2903,7 @@ pub fn format_method_add_block(ps: &mut dyn ConcreteParserState, mab: MethodAddB
     }
 }
 
-pub fn is_empty_bodystmt(bodystmt: &Vec<Expression>) -> bool {
+pub fn is_empty_bodystmt(bodystmt: &[Expression]) -> bool {
     bodystmt.len() == 1 && matches!(bodystmt[0], Expression::VoidStmt(..))
 }
 
@@ -3024,7 +3024,7 @@ fn get_brace_block_render_method(
     ps: &mut dyn ConcreteParserState,
     start_line: u64,
     end_line: u64,
-    body: &Vec<Expression>,
+    body: &[Expression],
 ) -> BraceBlockRenderMethod {
     let has_multiple_expressions = body.len() > 1;
     if has_multiple_expressions {
@@ -3132,12 +3132,12 @@ pub fn format_keyword(
 
 pub fn format_while(
     ps: &mut dyn ConcreteParserState,
-    conditional: Box<Expression>,
+    conditional: Expression,
     exprs: Vec<Expression>,
     kw: String,
     start_end: StartEnd,
 ) {
-    format_conditional(ps, *conditional, exprs, kw, None, Some(start_end));
+    format_conditional(ps, conditional, exprs, kw, None, Some(start_end));
 
     ps.with_start_of_line(
         true,
@@ -3751,8 +3751,8 @@ pub fn format_expression(ps: &mut dyn ConcreteParserState, expression: Expressio
         Expression::Yield(y) => format_yield(ps, y),
         Expression::Break(b) => format_keyword(ps, b.1, "break".to_string(), b.2),
         Expression::MethodAddBlock(mab) => format_method_add_block(ps, mab),
-        Expression::While(w) => format_while(ps, w.1, w.2, "while".to_string(), w.3),
-        Expression::Until(u) => format_while(ps, u.1, u.2, "until".to_string(), u.3),
+        Expression::While(w) => format_while(ps, *w.1, w.2, "while".to_string(), w.3),
+        Expression::Until(u) => format_while(ps, *u.1, u.2, "until".to_string(), u.3),
         Expression::WhileMod(wm) => format_inline_mod(ps, wm.1, wm.2, "while".to_string()),
         Expression::UntilMod(um) => format_inline_mod(ps, um.1, um.2, "until".to_string()),
         Expression::IfMod(wm) => format_multilinable_mod(ps, wm.1, wm.2, "if".to_string()),

--- a/librubyfmt/src/heredoc_string.rs
+++ b/librubyfmt/src/heredoc_string.rs
@@ -81,6 +81,6 @@ impl HeredocString {
     /// quotes, so we must strip them from the symbol when
     /// rendering the closing symbol.
     pub fn closing_symbol(&self) -> String {
-        self.symbol.replace('\'', "").replace('"', "")
+        self.symbol.replace(['\'', '"'], "")
     }
 }

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -799,8 +799,7 @@ impl ConcreteParserState for BaseParserState {
     }
 
     fn render_heredocs(&mut self, skip: bool) {
-        while !self.heredoc_strings.is_empty() {
-            let next_heredoc = self.heredoc_strings.pop().expect("we checked it's there");
+        while let Some(next_heredoc) = self.heredoc_strings.pop() {
             let want_newline = !self.last_token_is_a_newline();
             if want_newline {
                 self.push_concrete_token(ConcreteLineToken::HardNewLine);
@@ -879,12 +878,8 @@ impl BaseParserState {
             None
         } else {
             let mut hds = vec![];
-            while !self.heredoc_strings.is_empty() {
-                hds.push(
-                    self.heredoc_strings
-                        .pop()
-                        .expect("we checked it's not empty"),
-                );
+            while let Some(element) = self.heredoc_strings.pop() {
+                hds.push(element);
             }
             Some(hds)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ struct CommandlineOpts {
     /// - File paths (i.e lib/foo/bar.rb){n}
     /// - Directories (i.e. lib/foo/){n}
     /// - Input files (i.e. @/tmp/files.txt). These files must contain one file path or directory per line
+    ///
     /// rubyfmt will use these as input.{n}
     #[clap(name = "include-paths")]
     include_paths: Vec<String>,
@@ -79,7 +80,7 @@ struct CommandlineOpts {
 /* Error handling                                     */
 /******************************************************/
 
-fn handle_io_error(err: io::Error, source: &String, error_exit: ErrorExit) {
+fn handle_io_error(err: io::Error, source: &str, error_exit: ErrorExit) {
     let msg = format!("Rubyfmt experienced an IO error: {}", err);
     print_error(&msg, Some(source));
 
@@ -96,7 +97,7 @@ fn handle_ignore_error(err: ignore::Error, error_exit: ErrorExit) {
     }
 }
 
-fn handle_rubyfmt_error(err: rubyfmt::RichFormatError, source: &String, error_exit: ErrorExit) {
+fn handle_rubyfmt_error(err: rubyfmt::RichFormatError, source: &str, error_exit: ErrorExit) {
     use rubyfmt::RichFormatError::*;
     let exit_code = err.as_exit_code();
     let e = || {


### PR DESCRIPTION
These changes will be lint violations in Rust version `1.85.0`. We should update that version, although a naive bump causes some linking issues that I haven't dug into yet. In the meantime, we can go ahead and land some lint violations to make the future PR much simpler.