### PR TITLE
Remove `librubyfmt` caching from CI to fix ubuntu build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
     GEM_HOME: /tmp/.bundle
     GEM_PATH: /tmp/.bundle
     TERM: xterm256
+    FORCE_FULL_RUBY_BUILD: 1
 
 jobs:
   rustfmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ env:
     GEM_HOME: /tmp/.bundle
     GEM_PATH: /tmp/.bundle
     TERM: xterm256
-    FORCE_FULL_RUBY_BUILD: 1
 
 jobs:
   rustfmt:
@@ -88,11 +87,6 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
         key: ${{ runner.os }}-${{ matrix.target }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
-    - uses: actions/cache@v4
-      with:
-        path: |
-          librubyfmt/ruby_checkout
-        key: ${{ runner.os }}-${{ matrix.target }}-ruby-v1-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/HEAD') }}
     - if: runner.os == 'macOS'
       run: |
         brew install automake bison

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -14,7 +14,6 @@ env:
   GEM_HOME: /tmp/.bundle
   GEM_PATH: /tmp/.bundle
   TERM: xterm256
-  FORCE_FULL_RUBY_BUILD: 1
 
 jobs:
   bump-tag:
@@ -64,11 +63,6 @@ jobs:
           override: true
           profile: minimal
           target: aarch64-unknown-linux-gnu
-      - uses: actions/cache@v4
-        with:
-          path: |
-            librubyfmt/ruby_checkout
-          key: ${{ runner.os }}-${{matrix.target}}-ruby-v1-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/HEAD') }}
       - if: runner.os == 'macOS'
         run: |
           brew install automake bison

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,11 +43,6 @@ jobs:
           override: true
           profile: minimal
           target: aarch64-unknown-linux-gnu
-      - uses: actions/cache@v4
-        with:
-          path: |
-            librubyfmt/ruby_checkout
-          key: ${{ runner.os }}-${{matrix.target}}-ruby-v1-${{ hashFiles('.git/modules/librubyfmt/ruby_checkout/HEAD') }}
       - if: runner.os == 'macOS'
         run: |
           brew install automake bison

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -47,8 +47,7 @@ fn main() -> Output {
 
     // Only rerun this build if the ruby_checkout has changed
     match old_checkout_sha {
-        Some(old_sha)
-            if old_sha == new_checkout_sha && env::var("FORCE_FULL_RUBY_BUILD").is_err() => {}
+        Some(old_sha) if old_sha == new_checkout_sha => {}
         _ => {
             make_configure(&ruby_checkout_path)?;
             run_configure(&ruby_checkout_path)?;


### PR DESCRIPTION
This caching has caused various headaches over the years (including currently breaking CI, but also #458 etc.) for reasons I never quite understood. It results in mysterious CI failures, and rebuilding Ruby doesn't actually take that long in CI anyways, so I think we should rip it out to make builds easier to repro in the case where they do fail.