### PR TITLE
Bump to `v0.11.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "rubyfmt"
-version = "0.10.0-pre"
+version = "0.11.0-pre"
 dependencies = [
  "backtrace",
  "cc",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "rubyfmt-main"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "clap",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "rubyfmt-main"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
 edition = "2018"
 

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rubyfmt"
-version = "0.10.0-pre"
+version = "0.11.0-pre"
 authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
It's been quite a while since we've made a non-prerelease release of `rubyfmt`, and since the last release in 2023, there are some non-trivial changes to the codebase and to the formatted output, so I think it's worth bumping us up a minor version. (Also, selfishly I'd love to have the current version of `rubyfmt` in `brew` so I don't have to keep downloading the release artifacts and shoving them into all of my personal projects.) Plus, if the next big chunk of work is updating this to Prism, that too will likely be another version bump, so I'd like to differentiate all of those as separate versions.

After this goes in, I think I have the permissions to make a release in the Github UI, which I _think_ will make a tag that will trigger the [release workflows](https://github.com/fables-tales/rubyfmt/blob/reese-v-11/.github/workflows/release.yaml). We haven't had a chance to really try those out I don't think, so this may be a bit of trial-and-error, but now's as good a time as any!