### PR TITLE
Fix names of downloaded artifacts in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,10 +76,13 @@ jobs:
           name: rubyfmt-source-release
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-ubuntu-latest
+          name: rubyfmt-release-artifact-ubuntu-20.04-native
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-macos-latest
+          name: rubyfmt-release-artifact-macos-latest-native
+      - uses: actions/download-artifact@v4
+        with:
+          name: rubyfmt-release-artifact-ubuntu-20.04-aarch64-unknown-linux-gnu
       - name: Ship It 🚢
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
I _think_ this should fix the release Github Action, although unfortunately I'm not sure of a great way to test it without running it once this is merged. That said, this is just updating the names of the downloaded artifacts to be the same as the preview releases, which currently work correctly, so I expect this part to work now.