### PR TITLE
Fix preview-release trigger and tag lookup for releases

### DIFF
--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -1,9 +1,5 @@
 name: Preview Release
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
   push:
     # Run only on trunk pushes that aren't a new tag release
     branches: [trunk]

--- a/script/make_release
+++ b/script/make_release
@@ -7,7 +7,7 @@ if [[ $OSTYPE == "darwin"* ]]; then
 fi
 bison --version
 
-TAG=$(git describe --exact-match HEAD)
+TAG=$(git describe --tags --exact-match HEAD)
 RELEASE_DIR=${RELEASE_DIR:-"tmp/releases/${TAG}-$(uname -s)/"}
 
 ./script/test.sh


### PR DESCRIPTION
This fixes two things related to the release builds: the first is that preview releases were over-eager and running on every CI completion -- having multiple things listed under `on` is considered an OR condition, not an AND.

The second is that this changes the tag lookup to use `--tags`, because without it git will [only look for annotated tags](https://git-scm.com/docs/git-describe#:~:text=By%20default%20(without%20%2D%2Dall%20or%20%2D%2Dtags)%20git%20describe%20only%20shows%20annotated%20tags), whereas I believe creating a release creates a lightweight tag instead. Using `--tags` will look up both of them and should find the right thing, which will let us use the Github release functionality for releases.