### PR TITLE
Move bindgen vars into scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,6 @@ jobs:
         brew install automake bison
         brew link bison --force
         echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
-    - if: matrix.target == 'aarch64-unknown-linux-gnu'
-      run: |
-        echo "BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu=--sysroot=/usr/aarch64-linux-gnu" >> $GITHUB_ENV
     - run: ./script/test.sh
       env:
         TARGET: ${{ matrix.target }}

--- a/script/make_release
+++ b/script/make_release
@@ -32,13 +32,15 @@ case "$target" in
     sudo apt-get update
     sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross
 
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    env BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu="--sysroot=/usr/aarch64-linux-gnu" \
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
       CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
       TARGET_CC=aarch64-linux-gnu-gcc \
       TARGET_AR=aarch64-linux-gnu-ar \
       cargo build --target aarch64-unknown-linux-gnu
 
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    env BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu="--sysroot=/usr/aarch64-linux-gnu" \
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
       CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
       TARGET_CC=aarch64-linux-gnu-gcc \
       TARGET_AR=aarch64-linux-gnu-ar \

--- a/script/test.sh
+++ b/script/test.sh
@@ -14,7 +14,8 @@ case "$target" in
     sudo apt-get update
     sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross
 
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    env BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu="--sysroot=/usr/aarch64-linux-gnu" \
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
       CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
       TARGET_CC=aarch64-linux-gnu-gcc \
       TARGET_AR=aarch64-linux-gnu-ar \


### PR DESCRIPTION
`BINDGEN_EXTRA_CLANG_ARGS` needs to be added every time cross-compilation happens, so this PR moves it into all of the cross-compilation script call sites, which should fix the failing preview build.