### PR TITLE
Set `$TARGET` properly in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,8 @@ jobs:
           brew install automake bison
           echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
       - run: ./script/make_release
+        env:
+          TARGET: ${{ matrix.target }}
       - uses: actions/upload-artifact@v4
         with:
           name: rubyfmt-release-artifact-${{ matrix.os }}-${{ matrix.target }}


### PR DESCRIPTION
For arm Linux builds, we tell `make_release` what the target arch is [through an environment variable](https://github.com/fables-tales/rubyfmt/blob/ac9db85adfaba3083938227db1a787690551a84c/script/make_release#L20), since we have to cross-compile those binaries and thus it can't be inferred from the machine type. This was configured [correctly](https://github.com/fables-tales/rubyfmt/blob/ac9db85adfaba3083938227db1a787690551a84c/.github/workflows/preview-release.yaml#L64C9-L65) for preview releases but not for full releases, so this PR remedies that.