### PR TITLE
Make source-release action wait on tag bump

### DIFF
--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -69,6 +69,7 @@ jobs:
           path: rubyfmt-*.tar.gz
   source-release:
     runs-on: macos-latest
+    needs: [bump-tag]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
We attach a copy of the source to releases. Currently, I think that's just so that it includes what Ruby checkout we use instead of the default GH one, which doesn't checkout submodules. (We can probably delete this step once the Ruby checkout is gone.)

_Anyways,_ the job currently doesn't wait for the tag to get bumped during preview releases, so it's always called a file name that's one version behind, which is annoying. This makes it wait for the tag to bump before starting.