### PR TITLE
⛓️  Add basic support for call chains with Prism

### DIFF
--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -1,10 +1,10 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::mem;
 
 use crate::comment_block::CommentBlock;
 use crate::parser_state::line_difference_requires_newline;
 use crate::ruby::*;
-use crate::types::LineNumber;
+use crate::types::{LineNumber, SourceOffset};
 use crate::util::u8_to_string;
 
 /// A vector of offsets in the source code where lines start, which
@@ -67,6 +67,7 @@ pub struct FileComments {
     lines_with_ruby: BTreeSet<LineNumber>,
     last_lineno: LineNumber,
     line_index: LineIndex,
+    comment_start_offsets: HashSet<usize>,
 }
 
 impl FileComments {
@@ -78,6 +79,9 @@ impl FileComments {
                 line_index.get_line_number(comment.location().start_offset()) as u64,
                 u8_to_string(comment.text()),
             );
+            file_comments
+                .comment_start_offsets
+                .insert(comment.location().start_offset());
         }
 
         // Lookup lines that have any Ruby, which we broadly equate to
@@ -183,6 +187,18 @@ impl FileComments {
         self.other_comments
             .keys()
             .any(|key| line_range.contains(key))
+    }
+
+    pub fn has_comment_in_offsets(
+        &self,
+        start_offset: SourceOffset,
+        end_offset: SourceOffset,
+    ) -> bool {
+        let range = start_offset..end_offset;
+
+        self.comment_start_offsets
+            .iter()
+            .any(|offset| range.contains(offset))
     }
 
     pub fn extract_comments_to_line(

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use crate::delimiters::BreakableDelims;
 use crate::heredoc_string::HeredocKind;
 use crate::parser_state::{BaseParserState, ConcreteParserState, FormattingContext, RenderFunc};
+use crate::render_targets::MultilineHandling;
 use crate::ripper_tree_types::*;
 use crate::types::LineNumber;
 
@@ -2734,7 +2735,7 @@ fn format_call_chain(
     }
 
     ps.breakable_call_chain_of(
-        cc.clone(),
+        MultilineHandling::Ripper(cc.clone()),
         Box::new(|ps| format_call_chain_elements(ps, cc, last_call_use_parens)),
     );
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -192,6 +192,7 @@ fn format_program(ps: &mut dyn ConcreteParserState, program_node: prism::Program
             format_statements(ps, program_node.statements());
         }),
     );
+    ps.emit_newline();
     ps.on_line(10000000000);
     ps.shift_comments();
 }
@@ -476,7 +477,6 @@ fn format_call_node(
     }
 
     ps.at_offset(call_node.location().start_offset());
-    let end_offset = call_node.location().end_offset();
 
     if skip_receiver || call_node.receiver().is_none() {
         handle_string_at_offset(
@@ -534,11 +534,9 @@ fn format_call_node(
                                 for element in call_chain_elements {
                                     let element = element.as_call_node().unwrap();
                                     let call_operator = loc_to_string(
-                                // `call_operator_loc` is the `.`/`::`/`&.` etc.
-                                element.call_operator_loc().expect(
-                                    "We're in the middle of the chain, there must be an operator",
-                                ),
-                            );
+                                        // `call_operator_loc` is the `.`/`::`/`&.` etc.
+                                        element.call_operator_loc().expect("We're in the middle of the chain, there must be an operator"),
+                                    );
                                     if call_operator != *"::" {
                                         ps.emit_collapsing_newline();
                                         ps.emit_soft_indent();
@@ -547,14 +545,12 @@ fn format_call_node(
 
                                     ps.at_offset(element.location().start_offset());
                                     format_call_node(ps, element, true);
-                                    ps.shift_comments();
                                 }
                             }),
                         );
                         ps.end_indent_for_call_chain();
                     }),
                 );
-                ps.wind_dumping_comments_until_offset(end_offset);
             }),
         );
 
@@ -608,13 +604,23 @@ fn call_chain_elements_are_user_multilined(
         }
     }
 
-    // We have to use the end offsets here instead of the beginning, because technically
-    // all the receivers are nested inside each other at the same start offset
-    let end_line =
-        ps.get_line_number_for_offset(call_chain_elements.first().unwrap().location().end_offset());
-    !call_chain_elements[1..]
-        .iter()
-        .all(|cce| ps.get_line_number_for_offset(cce.location().end_offset()) == end_line)
+    let start_line = ps.get_line_number_for_offset(
+        call_chain_elements
+            .first()
+            .unwrap()
+            .location()
+            .start_offset(),
+    );
+    !call_chain_elements[1..].iter().all(|cce| {
+        start_line
+            == ps.get_line_number_for_offset(
+                cce.as_call_node()
+                    .unwrap()
+                    .call_operator_loc()
+                    .unwrap()
+                    .start_offset(),
+            )
+    })
 }
 
 fn format_symbol_node(ps: &mut dyn ConcreteParserState, symbol_node: prism::SymbolNode) {
@@ -1041,7 +1047,9 @@ fn format_list_like_thing(
                 ps.with_start_of_line(
                     false,
                     Box::new(|ps| {
-                        ps.emit_soft_indent();
+                        if expr.as_assoc_node().is_none() {
+                            ps.emit_soft_indent();
+                        }
                         format_node(ps, expr);
 
                         if idx != args_count - 1 {

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -507,14 +507,10 @@ fn format_call_node(
             );
         }
     } else {
-        let receiver = call_node
-            .receiver()
-            .expect("We checked for a present receiver in `format_call_node`");
         ps.with_start_of_line(
             false,
             Box::new(|ps| {
-                let mut call_chain_elements = collapse_nodes_to_call_chain(receiver);
-                call_chain_elements.push(call_node.as_node());
+                let mut call_chain_elements = collapse_nodes_to_call_chain(call_node.as_node());
                 ps.breakable_call_chain_of(
                     MultilineHandling::Prism(call_chain_elements_are_user_multilined(
                         ps,

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -563,7 +563,7 @@ fn call_chain_elements_are_user_multilined(
     call_chain_elements: Vec<&prism::Node>,
 ) -> bool {
     // Making a mutable copy since we may pop some items off later
-    let mut call_chain_elements = call_chain_elements.clone();
+    let mut call_chain_elements = call_chain_elements.as_slice();
 
     if call_chain_elements.len() > 1 {
         // If the first item in the chain is a multiline expression (like a hash or array),
@@ -596,7 +596,7 @@ fn call_chain_elements_are_user_multilined(
                 .start_offset(),
         );
         if is_literal_expression && !has_comment {
-            call_chain_elements.remove(0);
+            call_chain_elements = &call_chain_elements[1..];
         }
     }
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3,7 +3,8 @@ use ruby_prism as prism;
 use crate::{
     delimiters::BreakableDelims,
     format::SpecialCase,
-    parser_state::{ConcreteParserState, FormattingContext, RenderFunc},
+    parser_state::{ConcreteParserState, FormattingContext, HashType, RenderFunc},
+    render_targets::MultilineHandling,
     types::SourceOffset,
     util::{const_to_string, loc_to_string},
 };
@@ -16,9 +17,9 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::AlternationPatternNode { .. } => todo!(),
         Node::AndNode { .. } => todo!(),
         Node::ArgumentsNode { .. } => format_arguments_node(ps, node.as_arguments_node().unwrap()),
-        Node::ArrayNode { .. } => todo!(),
+        Node::ArrayNode { .. } => format_array_node(ps, node.as_array_node().unwrap()),
         Node::ArrayPatternNode { .. } => todo!(),
-        Node::AssocNode { .. } => todo!(),
+        Node::AssocNode { .. } => format_assoc_node(ps, node.as_assoc_node().unwrap()),
         Node::AssocSplatNode { .. } => todo!(),
         Node::BackReferenceReadNode { .. } => todo!(),
         Node::BeginNode { .. } => todo!(),
@@ -29,7 +30,7 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::BlockParametersNode { .. } => todo!(),
         Node::BreakNode { .. } => todo!(),
         Node::CallAndWriteNode { .. } => todo!(),
-        Node::CallNode { .. } => todo!(),
+        Node::CallNode { .. } => format_call_node(ps, node.as_call_node().unwrap(), false),
         Node::CallOperatorWriteNode { .. } => todo!(),
         Node::CallOrWriteNode { .. } => todo!(),
         Node::CallTargetNode { .. } => todo!(),
@@ -138,7 +139,9 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::OptionalParameterNode { .. } => todo!(),
         Node::OrNode { .. } => todo!(),
         Node::ParametersNode { .. } => todo!(),
-        Node::ParenthesesNode { .. } => todo!(),
+        Node::ParenthesesNode { .. } => {
+            format_parentheses_node(ps, node.as_parentheses_node().unwrap())
+        }
         Node::PinnedExpressionNode { .. } => todo!(),
         Node::PinnedVariableNode { .. } => todo!(),
         Node::PostExecutionNode { .. } => todo!(),
@@ -170,7 +173,7 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::StatementsNode { .. } => format_statements(ps, node.as_statements_node().unwrap()),
         Node::StringNode { .. } => todo!(),
         Node::SuperNode { .. } => todo!(),
-        Node::SymbolNode { .. } => todo!(),
+        Node::SymbolNode { .. } => format_symbol_node(ps, node.as_symbol_node().unwrap()),
         Node::TrueNode { .. } => todo!(),
         Node::UndefNode { .. } => todo!(),
         Node::UnlessNode { .. } => todo!(),
@@ -299,7 +302,12 @@ fn format_def_body(
             ps.breakable_of(
                 BreakableDelims::for_method_call(),
                 Box::new(|ps| {
-                    format_parameters_node(ps, parameters_node);
+                    ps.with_start_of_line(
+                        false,
+                        Box::new(|ps| {
+                            format_parameters_node(ps, parameters_node);
+                        }),
+                    );
                 }),
             );
         }
@@ -458,6 +466,268 @@ fn format_block_parameter_node(
     );
 }
 
+fn format_call_node(
+    ps: &mut dyn ConcreteParserState,
+    call_node: prism::CallNode,
+    skip_receiver: bool,
+) {
+    if ps.at_start_of_line() {
+        ps.emit_indent();
+    }
+
+    ps.at_offset(call_node.location().start_offset());
+    let end_offset = call_node.location().end_offset();
+
+    if skip_receiver || call_node.receiver().is_none() {
+        handle_string_at_offset(
+            ps,
+            const_to_string(call_node.name()),
+            call_node.message_loc().unwrap().start_offset(),
+        );
+        if let Some(arguments) = call_node.arguments() {
+            ps.with_start_of_line(
+                false,
+                Box::new(|ps| {
+                    ps.breakable_of(
+                        BreakableDelims::for_method_call(),
+                        Box::new(|ps| {
+                            format_arguments_node(ps, arguments);
+                        }),
+                    );
+                }),
+            );
+        }
+        if let Some(block) = call_node.block() {
+            ps.emit_space();
+            ps.with_start_of_line(
+                false,
+                Box::new(|ps| {
+                    format_node(ps, block);
+                }),
+            );
+        }
+    } else {
+        let receiver = call_node
+            .receiver()
+            .expect("We checked for a present receiver in `format_call_node`");
+        ps.with_start_of_line(
+            false,
+            Box::new(|ps| {
+                let mut call_chain_elements = collapse_nodes_to_call_chain(receiver);
+                call_chain_elements.push(call_node.as_node());
+                ps.breakable_call_chain_of(
+                    MultilineHandling::Prism(call_chain_elements_are_user_multilined(
+                        ps,
+                        call_chain_elements.iter().clone().collect(),
+                    )),
+                    Box::new(|ps| {
+                        // The first node can be *any* expression, whereas following receivers
+                        // must be additional calls -- you cannot insert literals into call chains
+                        let first_expression = call_chain_elements.remove(0);
+                        format_node(ps, first_expression);
+
+                        ps.start_indent_for_call_chain();
+
+                        ps.with_start_of_line(
+                            false,
+                            Box::new(|ps| {
+                                for element in call_chain_elements {
+                                    let element = element.as_call_node().unwrap();
+                                    let call_operator = loc_to_string(
+                                // `call_operator_loc` is the `.`/`::`/`&.` etc.
+                                element.call_operator_loc().expect(
+                                    "We're in the middle of the chain, there must be an operator",
+                                ),
+                            );
+                                    if call_operator != *"::" {
+                                        ps.emit_collapsing_newline();
+                                        ps.emit_soft_indent();
+                                    }
+                                    ps.emit_ident(call_operator);
+
+                                    ps.at_offset(element.location().start_offset());
+                                    format_call_node(ps, element, true);
+                                    ps.shift_comments();
+                                }
+                            }),
+                        );
+                        ps.end_indent_for_call_chain();
+                    }),
+                );
+                ps.wind_dumping_comments_until_offset(end_offset);
+            }),
+        );
+
+        ps.emit_after_call_chain();
+    }
+
+    if ps.at_start_of_line() {
+        ps.emit_newline();
+    }
+}
+
+fn call_chain_elements_are_user_multilined(
+    ps: &dyn ConcreteParserState,
+    call_chain_elements: Vec<&prism::Node>,
+) -> bool {
+    // Making a mutable copy since we may pop some items off later
+    let mut call_chain_elements = call_chain_elements.clone();
+
+    if call_chain_elements.len() > 1 {
+        // If the first item in the chain is a multiline expression (like a hash or array),
+        // ignore it when checking line length.
+        let is_literal_expression = !matches!(
+            call_chain_elements.first().unwrap(),
+            prism::Node::CallNode { .. }
+                | prism::Node::ConstantReadNode { .. }
+                | prism::Node::ConstantPathNode { .. }
+        );
+
+        // _However_, don't ignore this if there are comments in the call chain though; this check may
+        // cause it to single-lined, which breaks comment rendering. Specifically, we're checking
+        // for comments in between the receiver expression and the following message, e.g.
+        // ```ruby
+        // [stuff]
+        //   # spooky comment
+        //   .freeze
+        // ```
+        // For cases without the comment, we'd usually put this all on one line, but if we force
+        // it all on one line, this will break the comment insertion logic, and given the comment's
+        // placement, the user probably intended to break this onto multiple lines anyways.
+        let has_comment = ps.has_comment_in_offset_span(
+            call_chain_elements[0].location().end_offset(),
+            call_chain_elements[1]
+                .as_call_node()
+                .unwrap()
+                .message_loc()
+                .unwrap()
+                .start_offset(),
+        );
+        if is_literal_expression && !has_comment {
+            call_chain_elements.remove(0);
+        }
+    }
+
+    // We have to use the end offsets here instead of the beginning, because technically
+    // all the receivers are nested inside each other at the same start offset
+    let end_line =
+        ps.get_line_number_for_offset(call_chain_elements.first().unwrap().location().end_offset());
+    !call_chain_elements[1..]
+        .iter()
+        .all(|cce| ps.get_line_number_for_offset(cce.location().end_offset()) == end_line)
+}
+
+fn format_symbol_node(ps: &mut dyn ConcreteParserState, symbol_node: prism::SymbolNode) {
+    if ps.at_start_of_line() {
+        ps.emit_indent();
+    }
+
+    if let Some(opening_loc) = symbol_node.opening_loc() {
+        ps.emit_ident(loc_to_string(opening_loc));
+    }
+    if let Some(value_loc) = symbol_node.value_loc() {
+        ps.emit_ident(loc_to_string(value_loc));
+    }
+
+    if ps.at_start_of_line() {
+        ps.emit_newline();
+    }
+}
+
+fn format_assoc_node(ps: &mut dyn ConcreteParserState, assoc_node: prism::AssocNode) {
+    let as_symbol = if let Some(hash_type) = ps.hash_type_from_formatting_context() {
+        matches!(hash_type, HashType::SymbolKey)
+    } else {
+        // `operator_loc` is only present for hash rockets, not for symbol keys
+        assoc_node.operator_loc().is_none()
+    };
+
+    ps.with_start_of_line(
+        false,
+        Box::new(|ps| {
+            format_node(ps, assoc_node.key());
+            if as_symbol {
+                ps.emit_ident(":".to_string());
+            } else {
+                ps.emit_space();
+                ps.emit_ident("=>".to_string());
+            }
+            ps.emit_space();
+            format_node(ps, assoc_node.value());
+        }),
+    );
+}
+
+fn format_array_node(ps: &mut dyn ConcreteParserState, array_node: prism::ArrayNode) {
+    if ps.at_start_of_line() {
+        ps.emit_indent();
+    }
+
+    ps.at_offset(array_node.location().start_offset());
+
+    ps.with_start_of_line(
+        false,
+        Box::new(|ps| {
+            ps.breakable_of(
+                BreakableDelims::for_array(),
+                Box::new(|ps| {
+                    format_list_like_thing(
+                        ps,
+                        array_node.elements(),
+                        array_node.location().end_offset(),
+                        false,
+                    );
+                    ps.wind_dumping_comments_until_offset(array_node.location().end_offset());
+                }),
+            );
+        }),
+    );
+
+    if ps.at_start_of_line() {
+        ps.emit_newline();
+    }
+}
+
+fn format_parentheses_node(
+    ps: &mut dyn ConcreteParserState,
+    parentheses_node: prism::ParenthesesNode,
+) {
+    if ps.at_start_of_line() {
+        ps.emit_indent();
+    }
+
+    ps.at_offset(parentheses_node.location().start_offset());
+
+    ps.emit_open_paren();
+    if let Some(body) = parentheses_node.body() {
+        ps.with_start_of_line(
+            false,
+            Box::new(|ps| {
+                format_node(ps, body);
+            }),
+        );
+        ps.at_offset(parentheses_node.location().end_offset());
+    }
+    ps.emit_close_paren();
+
+    if ps.at_start_of_line() {
+        ps.emit_newline();
+    }
+}
+
+fn collapse_nodes_to_call_chain(node: prism::Node) -> Vec<prism::Node> {
+    let mut call_chain_elements = vec![];
+    let mut maybe_receiver = Some(node);
+    while let Some(receiver) = maybe_receiver {
+        maybe_receiver = receiver
+            .as_call_node()
+            .and_then(|call_node| call_node.receiver());
+        call_chain_elements.insert(0, receiver);
+    }
+
+    call_chain_elements
+}
+
 fn format_rest_param(
     ps: &mut dyn ConcreteParserState,
     rest_param: prism::RestParameterNode,
@@ -501,11 +771,28 @@ fn format_keyword_hash_node(
         ps.emit_indent();
     }
 
-    format_list_like_thing(
-        ps,
-        keyword_hash_node.elements(),
-        keyword_hash_node.location().end_offset(),
-        false,
+    let all_symbol_keys = keyword_hash_node
+        .elements()
+        .iter()
+        .filter_map(|node| node.as_assoc_node())
+        // The operator loc is empty for symbol keys
+        .all(|assoc| assoc.operator_loc().is_none());
+    let hash_type = if all_symbol_keys {
+        HashType::SymbolKey
+    } else {
+        HashType::HashRocket
+    };
+
+    ps.with_formatting_context(
+        FormattingContext::HashType(hash_type),
+        Box::new(|ps| {
+            format_list_like_thing(
+                ps,
+                keyword_hash_node.elements(),
+                keyword_hash_node.location().end_offset(),
+                false,
+            );
+        }),
     );
 
     if ps.at_start_of_line() {

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -6,9 +6,9 @@ use crate::heredoc_string::{HeredocKind, HeredocString};
 use crate::line_tokens::*;
 use crate::render_queue_writer::{RenderQueueWriter, MAX_LINE_LENGTH};
 use crate::render_targets::{
-    AbstractTokenTarget, BaseQueue, BreakableCallChainEntry, BreakableEntry,
+    AbstractTokenTarget, BaseQueue, BreakableCallChainEntry, BreakableEntry, MultilineHandling,
 };
-use crate::ripper_tree_types::{CallChainElement, StringContentPart};
+use crate::ripper_tree_types::StringContentPart;
 use crate::types::{ColNumber, LineNumber, SourceOffset};
 use log::debug;
 use std::io::{self, Cursor, Write};
@@ -26,6 +26,13 @@ pub enum FormattingContext {
     ArgsList,
     IfOp,
     StringEmbexpr,
+    HashType(HashType),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HashType {
+    SymbolKey,
+    HashRocket,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -123,6 +130,7 @@ where
     // queries
     fn at_start_of_line(&self) -> bool;
     fn current_formatting_context_requires_parens(&self) -> bool;
+    fn hash_type_from_formatting_context(&self) -> Option<&HashType>;
     fn current_formatting_context(&self) -> FormattingContext;
     fn get_line_number_for_offset(&self, source_offset: SourceOffset) -> LineNumber;
     fn is_absorbing_indents(&self) -> bool;
@@ -144,11 +152,7 @@ where
     fn with_start_of_line(&mut self, start_of_line: bool, f: RenderFunc);
     fn breakable_of(&mut self, delims: BreakableDelims, f: RenderFunc);
     fn inline_breakable_of(&mut self, delims: BreakableDelims, f: RenderFunc);
-    fn breakable_call_chain_of(
-        &mut self,
-        call_chain_elements: Vec<CallChainElement>,
-        f: RenderFunc,
-    );
+    fn breakable_call_chain_of(&mut self, multiline_handling: MultilineHandling, f: RenderFunc);
     fn dedent(&mut self, f: RenderFunc);
     fn reset_space_count(&mut self);
     fn with_absorbing_indent_block(&mut self, f: RenderFunc);
@@ -159,6 +163,11 @@ where
     );
     fn with_suppress_comments(&mut self, suppress: bool, f: RenderFunc);
     fn will_render_as_multiline(&mut self, f: RenderFunc) -> bool;
+    fn has_comment_in_offset_span(
+        &self,
+        start_offset: SourceOffset,
+        end_offset: SourceOffset,
+    ) -> bool;
 
     #[allow(unused)]
     fn will_render_beyond_max_line_length(&mut self, f: RenderFunc) -> bool;
@@ -290,6 +299,15 @@ impl ConcreteParserState for BaseParserState {
         s.trim().contains('\n') || s.len() > MAX_LINE_LENGTH
     }
 
+    fn has_comment_in_offset_span(
+        &self,
+        start_offset: SourceOffset,
+        end_offset: SourceOffset,
+    ) -> bool {
+        self.comments_hash
+            .has_comment_in_offsets(start_offset, end_offset)
+    }
+
     fn will_render_beyond_max_line_length<'a>(&mut self, f: RenderFunc) -> bool {
         let mut next_ps = BaseParserState::new_with_depth_stack_from(self);
         // Ignore commments when determining line length
@@ -398,12 +416,12 @@ impl ConcreteParserState for BaseParserState {
 
     fn breakable_call_chain_of<'a>(
         &mut self,
-        call_chain_elements: Vec<CallChainElement>,
+        mulitiline_handling: MultilineHandling,
         f: RenderFunc,
     ) {
         self.shift_comments();
         let mut be =
-            BreakableCallChainEntry::new(self.formatting_context.clone(), call_chain_elements);
+            BreakableCallChainEntry::new(self.formatting_context.clone(), mulitiline_handling);
         be.push_line_number(self.current_orig_line_number);
         self.breakable_entry_stack.push(Box::new(be));
 
@@ -480,7 +498,7 @@ impl ConcreteParserState for BaseParserState {
     }
 
     fn at_offset(&mut self, source_offset: SourceOffset) {
-        self.on_line(self.comments_hash.get_line_number_for_offset(source_offset));
+        self.on_line(self.get_line_number_for_offset(source_offset));
     }
 
     fn emit_indent(&mut self) {
@@ -760,6 +778,16 @@ impl ConcreteParserState for BaseParserState {
     fn current_formatting_context_requires_parens(&self) -> bool {
         self.current_formatting_context() == FormattingContext::Binary
             || self.current_formatting_context() == FormattingContext::IfOp
+    }
+
+    fn hash_type_from_formatting_context(&self) -> Option<&HashType> {
+        self.formatting_context
+            .iter()
+            .filter_map(|fc| match fc {
+                FormattingContext::HashType(hash_type) => Some(hash_type),
+                _ => None,
+            })
+            .last()
     }
 
     fn emit_dot(&mut self) {

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -1,7 +1,7 @@
 use crate::delimiters::BreakableDelims;
 use crate::line_tokens::{AbstractLineToken, ConcreteLineToken, ConcreteLineTokenAndTargets};
 use crate::parser_state::FormattingContext;
-use crate::ripper_tree_types::{CallChainElement, Expression, StringLiteral};
+use crate::ripper_tree_types::CallChainElement;
 use crate::types::LineNumber;
 use std::collections::HashSet;
 
@@ -201,11 +201,23 @@ impl BreakableEntry {
     }
 }
 
+/// This struct is a bit of a hack to support both
+/// the Ripper tree and the Prism tree at the same time.
+/// The Prism tree has more accurate offset handling that obviates
+/// the hacks put in to support Ripper, but for now we need to support
+/// and I didn't want to have to fork the implementation of BreakableCallChainEntry.
+/// Once Prism is fully featured, we should delete this Ripper handling entirely.
+#[derive(Debug, Clone)]
+pub enum MultilineHandling {
+    Ripper(Vec<CallChainElement>),
+    Prism(bool),
+}
+
 #[derive(Debug, Clone)]
 pub struct BreakableCallChainEntry {
     tokens: Vec<AbstractLineToken>,
     line_numbers: HashSet<LineNumber>,
-    call_chain: Vec<CallChainElement>,
+    multiline_handling: MultilineHandling,
     context: Vec<FormattingContext>,
 }
 
@@ -356,52 +368,53 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
             return true;
         }
 
-        let mut call_chain_to_check = self.call_chain.as_slice();
-        // We don't always want to multiline blocks if their only usage
-        // is at the end of a chain, since it's common to have chains
-        // that end with long blocks, but those blocks don't mean we should
-        // multiline the rest of the chain.
-        //
-        // example:
-        // ```
-        // items.get_all.each do
-        // end
-        // ```
-        if let Some(CallChainElement::Block(..)) = call_chain_to_check.last() {
-            call_chain_to_check = &call_chain_to_check[..call_chain_to_check.len() - 1];
+        match &self.multiline_handling {
+            MultilineHandling::Prism(is_user_multilined) => *is_user_multilined,
+            MultilineHandling::Ripper(call_chain_elements) => {
+                let mut call_chain_to_check = call_chain_elements.as_slice();
+                // We don't always want to multiline blocks if their only usage
+                // is at the end of a chain, since it's common to have chains
+                // that end with long blocks, but those blocks don't mean we should
+                // multiline the rest of the chain.
+                //
+                // example:
+                // ```
+                // items.get_all.each do
+                // end
+                // ```
+                if let Some(CallChainElement::Block(..)) = call_chain_to_check.last() {
+                    call_chain_to_check = &call_chain_to_check[..call_chain_to_check.len() - 1];
+                }
+
+                let has_leading_expression = match call_chain_to_check.first() {
+                    Some(CallChainElement::Expression(expr)) => !expr.is_constant_reference(),
+                    _ => false,
+                };
+                let has_comments = self.tokens.iter().any(|t| {
+                    matches!(
+                        t,
+                        AbstractLineToken::ConcreteLineToken(ConcreteLineToken::Comment { .. })
+                    )
+                });
+
+                // If the first item in the chain is a multiline expression (like a hash or array),
+                // ignore it when checking line length.
+                // Don't ignore this if there are comments in the call chain though; this check may
+                // cause it to single-lined, which breaks comment rendering.
+                if has_leading_expression && !has_comments {
+                    call_chain_to_check = &call_chain_to_check[1..];
+                }
+
+                let chain_is_user_multilined = call_chain_to_check
+                    .iter()
+                    .filter_map(|cc_elem| cc_elem.start_line())
+                    .collect::<HashSet<_>>()
+                    .len()
+                    > 1;
+
+                chain_is_user_multilined
+            }
         }
-
-        let has_leading_expression = match call_chain_to_check.first() {
-            Some(CallChainElement::Expression(expr)) => !expr.is_constant_reference(),
-            _ => false,
-        };
-        let has_comments = self.tokens.iter().any(|t| {
-            matches!(
-                t,
-                AbstractLineToken::ConcreteLineToken(ConcreteLineToken::Comment { .. })
-            )
-        });
-
-        // If the first item in the chain is a multiline expression (like a hash or array),
-        // ignore it when checking line length.
-        // Don't ignore this if there are comments in the call chain though; this check may
-        // cause it to single-lined, which breaks comment rendering.
-        if has_leading_expression && !has_comments {
-            call_chain_to_check = &call_chain_to_check[1..];
-        }
-
-        let chain_is_user_multilined = call_chain_to_check
-            .iter()
-            .filter_map(|cc_elem| cc_elem.start_line())
-            .collect::<HashSet<_>>()
-            .len()
-            > 1;
-
-        if chain_is_user_multilined {
-            return true;
-        }
-
-        false
     }
 
     fn any_collapsing_newline_has_heredoc_content(&self) -> bool {
@@ -412,28 +425,22 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
                 be.any_collapsing_newline_has_heredoc_content()
             }
             _ => false,
-        }) || self.call_chain.iter().any(|cce| match cce {
-            // In cases where the heredoc is the first item in the call chain,
-            // it won't get stored in an abstract token; instead, it'll be directly
-            // in the call chain as a concrete token.
-            CallChainElement::Expression(expr) => {
-                matches!(
-                    expr.as_ref(),
-                    Expression::StringLiteral(StringLiteral::Heredoc(..))
-                )
-            }
-            _ => false,
-        })
+        }) || matches!(
+            self.tokens.first(),
+            Some(AbstractLineToken::ConcreteLineToken(
+                ConcreteLineToken::HeredocStart { .. }
+            ))
+        )
     }
 }
 
 impl BreakableCallChainEntry {
-    pub fn new(context: Vec<FormattingContext>, call_chain: Vec<CallChainElement>) -> Self {
+    pub fn new(context: Vec<FormattingContext>, multiline_handling: MultilineHandling) -> Self {
         BreakableCallChainEntry {
             tokens: Vec::new(),
             line_numbers: HashSet::new(),
             context,
-            call_chain,
+            multiline_handling,
         }
     }
 
@@ -458,12 +465,11 @@ impl BreakableCallChainEntry {
     }
 
     fn begins_with_heredoc(&self) -> bool {
-        if let Some(CallChainElement::Expression(expr)) = self.call_chain.first() {
-            if let Expression::StringLiteral(string_literal) = &**expr {
-                return matches!(string_literal, StringLiteral::Heredoc(..));
-            }
-        }
-
-        false
+        matches!(
+            self.tokens.first(),
+            Some(AbstractLineToken::ConcreteLineToken(
+                ConcreteLineToken::HeredocStart { .. }
+            ))
+        )
     }
 }

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -461,10 +461,10 @@ fixture!(test_small_rest_param, "small/rest_param");
 //     "small/separated_statements_with_trailing_comment"
 // );
 // fixture!(test_small_shorthand_hash, "small/shorthand_hash");
-// fixture!(
-//     test_small_single_line_method_call_chain,
-//     "small/single_line_method_call_chain"
-// );
+fixture!(
+    test_small_single_line_method_call_chain,
+    "small/single_line_method_call_chain"
+);
 // fixture!(test_small_single_massign, "small/single_massign");
 // fixture!(
 //     test_small_single_quoted_string_with_embexpr,

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -58,7 +58,7 @@ fixture!(
 //     test_small_arg_list_with_bare_assoc_hash,
 //     "small/arg_list_with_bare_assoc_hash"
 // );
-// fixture!(test_small_arg_trailing_comma, "small/arg_trailing_comma");
+fixture!(test_small_arg_trailing_comma, "small/arg_trailing_comma");
 // fixture!(test_small_args_forwarding, "small/args_forwarding");
 // fixture!(
 //     test_small_args_forwarding_multiline,
@@ -75,7 +75,7 @@ fixture!(
 //     test_small_bare_assoc_hash_trailing_comma,
 //     "small/bare_assoc_hash_trailing_comma"
 // );
-// fixture!(test_small_bare_assoc_multiple, "small/bare_assoc_multiple");
+fixture!(test_small_bare_assoc_multiple, "small/bare_assoc_multiple");
 // fixture!(
 //     test_small_bare_rescue_comments,
 //     "small/bare_rescue_comments"
@@ -142,7 +142,7 @@ fixture!(test_small_blockarg, "small/blockarg");
 // fixture!(test_small_cannibalization_1, "small/cannibalization_1");
 // fixture!(test_small_cannibalization_2, "small/cannibalization_2");
 // fixture!(test_small_cannibalization_3, "small/cannibalization_3");
-// fixture!(test_small_cannibalization_4, "small/cannibalization_4");
+fixture!(test_small_cannibalization_4, "small/cannibalization_4");
 // fixture!(test_small_case, "small/case");
 // fixture!(test_small_case_else, "small/case_else");
 // fixture!(test_small_case_multi, "small/case_multi");
@@ -156,7 +156,7 @@ fixture!(test_small_blockarg, "small/blockarg");
 // fixture!(test_small_coloncoloncalldot, "small/coloncoloncalldot");
 // fixture!(test_small_command_call_raise, "small/command_call_raise");
 // fixture!(test_small_command_paren, "small/command_paren");
-// fixture!(test_small_commas_trailing, "small/commas_trailing");
+fixture!(test_small_commas_trailing, "small/commas_trailing");
 // fixture!(
 //     test_small_comment_in_block_inside_array,
 //     "small/comment_in_block_inside_array"
@@ -214,8 +214,8 @@ fixture!(test_small_def_with_kw, "small/def_with_kw");
 //     test_small_definitions_with_comments,
 //     "small/definitions_with_comments"
 // );
-// fixture!(test_small_defs_comment, "small/defs_comment");
-// fixture!(test_small_defs_end_comment, "small/defs_end_comment");
+fixture!(test_small_defs_comment, "small/defs_comment");
+fixture!(test_small_defs_end_comment, "small/defs_end_comment");
 fixture!(test_small_defs_kw, "small/defs_kw");
 // fixture!(test_small_disambiguated_range, "small/disambiguated_range");
 // fixture!(test_small_dot2, "small/dot2");
@@ -327,10 +327,10 @@ fixture!(test_small_defs_kw, "small/defs_kw");
 //     "small/method_add_block_command_call"
 // );
 // fixture!(test_small_method_annotation, "small/method_annotation");
-// fixture!(
-//     test_small_method_call_with_trailing_comma,
-//     "small/method_call_with_trailing_comma"
-// );
+fixture!(
+    test_small_method_call_with_trailing_comma,
+    "small/method_call_with_trailing_comma"
+);
 // fixture!(test_small_method_chains, "small/method_chains");
 // fixture!(test_small_missing_parens, "small/missing_parens");
 // fixture!(test_small_mlhs_params, "small/mlhs_params");
@@ -385,7 +385,7 @@ fixture!(test_small_defs_kw, "small/defs_kw");
 //     "small/multiline_when_with_comment"
 // );
 // fixture!(test_small_nbsp, "small/nbsp");
-// fixture!(test_small_nested_command, "small/nested_command");
+fixture!(test_small_nested_command, "small/nested_command");
 // fixture!(test_small_nested_conditionals, "small/nested_conditionals");
 // fixture!(
 //     test_small_nested_destructuring,
@@ -425,10 +425,10 @@ fixture!(test_small_op_defs, "small/op_defs");
 //     test_small_private_class_method,
 //     "small/private_class_method"
 // );
-// fixture!(
-//     test_small_private_gets_trailing_blankline,
-//     "small/private_gets_trailing_blankline"
-// );
+fixture!(
+    test_small_private_gets_trailing_blankline,
+    "small/private_gets_trailing_blankline"
+);
 // fixture!(test_small_procs, "small/procs");
 // fixture!(test_small_quoted_heredoc, "small/quoted_heredoc");
 // fixture!(test_small_raise_star, "small/raise_star");
@@ -475,7 +475,7 @@ fixture!(test_small_rest_param, "small/rest_param");
 //     "small/single_quoted_string_with_slash_escape"
 // );
 // fixture!(test_small_splat_case, "small/splat_case");
-// fixture!(test_small_splat_in_argument, "small/splat_in_argument");
+fixture!(test_small_splat_in_argument, "small/splat_in_argument");
 // fixture!(test_small_splat_rescue, "small/splat_rescue");
 // fixture!(test_small_sqb_no_parens, "small/sqb_no_parens");
 // fixture!(
@@ -483,11 +483,11 @@ fixture!(test_small_rest_param, "small/rest_param");
 //     "small/squiggly_heredoc_interpolation"
 // );
 // fixture!(test_small_stabby_lambda, "small/stabby_lambda");
-// fixture!(test_small_star, "small/star");
-// fixture!(
-//     test_small_start_of_file_comments,
-//     "small/start_of_file_comments"
-// );
+fixture!(test_small_star, "small/star");
+fixture!(
+    test_small_start_of_file_comments,
+    "small/start_of_file_comments"
+);
 // fixture!(test_small_static_call, "small/static_call");
 // fixture!(
 //     test_small_stmt_followed_by_do_block,

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -65,7 +65,7 @@ fixture!(test_small_arg_trailing_comma, "small/arg_trailing_comma");
 //     "small/args_forwarding_multiline"
 // );
 // fixture!(test_small_array_with_splat, "small/array_with_splat");
-// fixture!(test_test_small_backtick_symbolsmall_assign_field, "small/assign_field");
+// fixture!(test_small_assign_field, "small/assign_field");
 // fixture!(test_small_assoc_double_splat, "small/assoc_double_splat");
 // fixture!(test_small_backref, "small/backref");
 fixture!(test_small_backtick_symbol, "small/backtick_symbol");

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -33,7 +33,7 @@ fn test_fixture(name: &str) {
         .stdout(expected);
 }
 
-// fixture!(test_small_two_five, "small/2.5/2.5");
+fixture!(test_small_two_five, "small/2.5/2.5");
 // fixture!(test_small_two_five_lambda_do_end, "small/2.5/lambda_do_end");
 fixture!(
     test_small_two_five_unnamed_kwrest_param_def,
@@ -65,16 +65,16 @@ fixture!(test_small_arg_trailing_comma, "small/arg_trailing_comma");
 //     "small/args_forwarding_multiline"
 // );
 // fixture!(test_small_array_with_splat, "small/array_with_splat");
-// fixture!(test_small_assign_field, "small/assign_field");
+// fixture!(test_test_small_backtick_symbolsmall_assign_field, "small/assign_field");
 // fixture!(test_small_assoc_double_splat, "small/assoc_double_splat");
 // fixture!(test_small_backref, "small/backref");
-// fixture!(test_small_backtick_symbol, "small/backtick_symbol");
+fixture!(test_small_backtick_symbol, "small/backtick_symbol");
 // fixture!(test_small_backticks, "small/backticks");
 // fixture!(test_small_bare_alias, "small/bare_alias");
-// fixture!(
-//     test_small_bare_assoc_hash_trailing_comma,
-//     "small/bare_assoc_hash_trailing_comma"
-// );
+fixture!(
+    test_small_bare_assoc_hash_trailing_comma,
+    "small/bare_assoc_hash_trailing_comma"
+);
 fixture!(test_small_bare_assoc_multiple, "small/bare_assoc_multiple");
 // fixture!(
 //     test_small_bare_rescue_comments,
@@ -205,9 +205,9 @@ fixture!(test_small_commas_trailing, "small/commas_trailing");
 // fixture!(test_small_curly_line_breaking, "small/curly_line_breaking");
 // fixture!(test_small_cursed_call_01, "small/cursed_call_01");
 // fixture!(test_small_cvar, "small/cvar");
-// fixture!(test_small_cvar_symbol, "small/cvar_symbol");
+fixture!(test_small_cvar_symbol, "small/cvar_symbol");
 fixture!(test_small_def_const, "small/def_const");
-// fixture!(test_small_def_scope, "small/def_scope");
+fixture!(test_small_def_scope, "small/def_scope");
 fixture!(test_small_def_with_kw, "small/def_with_kw");
 // fixture!(test_small_defined, "small/defined");
 // fixture!(
@@ -242,16 +242,16 @@ fixture!(test_small_defs_kw, "small/defs_kw");
 // );
 // fixture!(test_small_end_block, "small/end_block");
 // fixture!(test_small_end_data, "small/end_data");
-// fixture!(
-//     test_small_end_of_file_comments,
-//     "small/end_of_file_comments"
-// );
+fixture!(
+    test_small_end_of_file_comments,
+    "small/end_of_file_comments"
+);
 // fixture!(test_small_endless_methods, "small/endless_methods");
 // fixture!(test_small_fib, "small/fib");
 // fixture!(test_small_first_rest_param, "small/first_rest_param");
 // fixture!(test_small_for_loop, "small/for_loop");
 // fixture!(test_small_gemfile, "small/gemfile");
-// fixture!(test_small_gvar_symbol, "small/gvar_symbol");
+fixture!(test_small_gvar_symbol, "small/gvar_symbol");
 // fixture!(test_small_hash_breaking, "small/hash_breaking");
 // fixture!(test_small_hash_comments, "small/hash_comments");
 // fixture!(test_small_hash_heredoc, "small/hash_heredoc");
@@ -294,10 +294,10 @@ fixture!(test_small_defs_kw, "small/defs_kw");
 // );
 // fixture!(test_small_inline_comments, "small/inline_comments");
 // fixture!(test_small_inline_rescue, "small/inline_rescue");
-// fixture!(test_small_ivar_symbol, "small/ivar_symbol");
-// fixture!(test_small_kw_symbol, "small/kw_symbol");
+fixture!(test_small_ivar_symbol, "small/ivar_symbol");
+fixture!(test_small_kw_symbol, "small/kw_symbol");
 // fixture!(test_small_kwargs, "small/kwargs");
-// fixture!(test_small_kwargs_multiline, "small/kwargs_multiline");
+fixture!(test_small_kwargs_multiline, "small/kwargs_multiline");
 // fixture!(test_small_lambda, "small/lambda");
 // fixture!(
 //     test_small_line_broken_top_const_field,
@@ -540,7 +540,7 @@ fixture!(
 //     "small/super_with_trailing_comma"
 // );
 // fixture!(test_small_symbol_arg, "small/symbol_arg");
-// fixture!(test_small_symbol_op, "small/symbol_op");
+fixture!(test_small_symbol_op, "small/symbol_op");
 // fixture!(test_small_ternary, "small/ternary");
 // fixture!(test_small_to_proc_operator, "small/to_proc_operator");
 // fixture!(

--- a/tests/stress_test.rs
+++ b/tests/stress_test.rs
@@ -5,23 +5,28 @@ use tempfile::NamedTempFile;
 
 #[test]
 fn methods_stress_test() {
-    stress_test("ci/methods_stress_test.rb").unwrap()
+    stress_test("ci/methods_stress_test.rb", false).unwrap()
 }
 
 #[test]
 fn arrays_stress_test() {
-    stress_test("ci/array_literals_stress_test.rb").unwrap()
+    stress_test("ci/array_literals_stress_test.rb", false).unwrap()
 }
 
 #[test]
 fn string_literals_stress_test() {
-    stress_test("ci/string_literals_stress_test.rb").unwrap()
+    stress_test("ci/string_literals_stress_test.rb", false).unwrap()
+}
+
+#[test]
+fn methods_prism_stress_test() {
+    stress_test("ci/methods_stress_test.rb", true).unwrap()
 }
 
 /// Test helper for running "stress tests", tests that
 /// execute a ruby script before and after being formatted
 /// to confirm that its behavior/output is the same.
-fn stress_test(path: &str) -> Result<(), ()> {
+fn stress_test(path: &str, prism: bool) -> Result<(), ()> {
     let methods_expected = {
         let output = Command::new("ruby").arg(path).output().unwrap();
         assert!(output.status.success());
@@ -29,11 +34,14 @@ fn stress_test(path: &str) -> Result<(), ()> {
     };
 
     let methods_actual = {
-        let rubyfmt_output = Command::cargo_bin("rubyfmt-main")
-            .unwrap()
-            .arg(path)
-            .output()
-            .unwrap();
+        let mut command = Command::cargo_bin("rubyfmt-main").unwrap();
+        command.arg(path);
+
+        if prism {
+            command.arg("--prism");
+        }
+
+        let rubyfmt_output = command.output().unwrap();
 
         assert!(rubyfmt_output.status.success());
 


### PR DESCRIPTION
This adds support for call chains, as well as various other node types needed to get some important fixtures (like the methods stress test and `fixtures/small/single_line_method_call_chain_actual.rb`). I also did some manual checking in some other fixture files, but those depend on other complex nodes (strings, blocks mostly) that I wanted to split into their own PRs.

The primary difference between the Ripper version and this one is that this one "precalculates" user-multilining instead of calculating it when rendering the breakable. This is primarily to avoid having to hold on to copies of the Prism nodes into the render queue. Maintaining both versions is done with an intermediate struct that adds a little bit of clunkiness for now, but it makes it easy to be able to rip out once the Ripper implementation.