### PR TITLE
🧶 Support string literals with Prism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,7 +128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.3.9",
  "serde",
 ]
 
@@ -252,6 +267,17 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -435,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minimal-lexical"
@@ -569,7 +595,7 @@ checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -579,10 +605,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 
 [[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ripper_deserialize"
@@ -618,6 +661,7 @@ name = "rubyfmt"
 version = "0.11.0-pre"
 dependencies = [
  "cc",
+ "fancy-regex",
  "jemallocator",
  "lazy_static",
  "libc",

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 [dependencies]
 serde = { version = "1.0", features=["derive"] }
 libc = "0.2.68"
+fancy-regex = "0.14.0"
 ripper_deserialize = { path = "ripper_deserialize" }
 lazy_static = "1.4.0"
 log = { version = "0.4.8", features = ["max_level_debug", "release_max_level_warn"] }

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1642,7 +1642,7 @@ pub fn format_heredoc_string_literal(
             let heredoc_type = (hd.1).0;
             let heredoc_symbol = (hd.1).1;
             let kind = HeredocKind::from_string(&heredoc_type);
-            ps.emit_heredoc_start(heredoc_symbol.clone(), kind);
+            ps.emit_heredoc_start(format!("{}{}", heredoc_type, heredoc_symbol), kind);
 
             ps.push_heredoc_content(heredoc_symbol, kind, parts, end_line);
         }),

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -113,7 +113,9 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::InstanceVariableOrWriteNode { .. } => todo!(),
         Node::InstanceVariableReadNode { .. } => todo!(),
         Node::InstanceVariableTargetNode { .. } => todo!(),
-        Node::InstanceVariableWriteNode { .. } => todo!(),
+        Node::InstanceVariableWriteNode { .. } => {
+            format_instance_variable_write_node(ps, node.as_instance_variable_write_node().unwrap())
+        }
         Node::IntegerNode { .. } => format_integer_node(ps, node.as_integer_node().unwrap()),
         Node::InterpolatedMatchLastLineNode { .. } => todo!(),
         Node::InterpolatedRegularExpressionNode { .. } => todo!(),
@@ -1173,6 +1175,30 @@ fn format_splat_node(ps: &mut dyn ConcreteParserState, splat_node: prism::SplatN
 
 fn format_ident(ps: &mut dyn ConcreteParserState, ident: String, offset: usize) {
     handle_string_at_offset(ps, ident, offset);
+}
+
+fn format_instance_variable_write_node(
+    ps: &mut dyn ConcreteParserState,
+    instance_variable_write_node: prism::InstanceVariableWriteNode,
+) {
+    if ps.at_start_of_line() {
+        ps.emit_indent();
+    }
+
+    ps.at_offset(instance_variable_write_node.location().start_offset());
+
+    ps.emit_ident(const_to_string(instance_variable_write_node.name()));
+    ps.emit_space();
+    ps.emit_op("=".to_string());
+    ps.emit_space();
+    ps.with_start_of_line(
+        false,
+        Box::new(|ps| format_node(ps, instance_variable_write_node.value())),
+    );
+
+    if ps.at_start_of_line() {
+        ps.emit_newline();
+    }
 }
 
 fn format_integer_node(ps: &mut dyn ConcreteParserState, integer_node: prism::IntegerNode) {

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3,6 +3,7 @@ use ruby_prism as prism;
 use crate::{
     delimiters::BreakableDelims,
     format::SpecialCase,
+    heredoc_string::HeredocKind,
     parser_state::{ConcreteParserState, FormattingContext, HashType, RenderFunc},
     render_targets::MultilineHandling,
     types::SourceOffset,
@@ -77,7 +78,9 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::DefNode { .. } => format_def_node(ps, node.as_def_node().unwrap()),
         Node::DefinedNode { .. } => todo!(),
         Node::ElseNode { .. } => todo!(),
-        Node::EmbeddedStatementsNode { .. } => todo!(),
+        Node::EmbeddedStatementsNode { .. } => {
+            format_embedded_statements_node(ps, node.as_embedded_statements_node().unwrap())
+        }
         Node::EmbeddedVariableNode { .. } => todo!(),
         Node::EnsureNode { .. } => todo!(),
         Node::FalseNode { .. } => todo!(),
@@ -114,7 +117,9 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::IntegerNode { .. } => format_integer_node(ps, node.as_integer_node().unwrap()),
         Node::InterpolatedMatchLastLineNode { .. } => todo!(),
         Node::InterpolatedRegularExpressionNode { .. } => todo!(),
-        Node::InterpolatedStringNode { .. } => todo!(),
+        Node::InterpolatedStringNode { .. } => {
+            format_interpolated_string_node(ps, node.as_interpolated_string_node().unwrap())
+        }
         Node::InterpolatedSymbolNode { .. } => todo!(),
         Node::InterpolatedXStringNode { .. } => todo!(),
         Node::ItLocalVariableReadNode { .. } => todo!(),
@@ -185,7 +190,7 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::SourceLineNode { .. } => todo!(),
         Node::SplatNode { .. } => format_splat_node(ps, node.as_splat_node().unwrap()),
         Node::StatementsNode { .. } => format_statements(ps, node.as_statements_node().unwrap()),
-        Node::StringNode { .. } => todo!(),
+        Node::StringNode { .. } => format_string_node(ps, node.as_string_node().unwrap()),
         Node::SuperNode { .. } => todo!(),
         Node::SymbolNode { .. } => format_symbol_node(ps, node.as_symbol_node().unwrap()),
         Node::TrueNode { .. } => todo!(),
@@ -233,6 +238,186 @@ fn format_statements(ps: &mut dyn ConcreteParserState, statements_node: prism::S
             }
         }),
     );
+}
+
+fn format_string_node(ps: &mut dyn ConcreteParserState, string_node: prism::StringNode) {
+    if ps.at_start_of_line() {
+        ps.emit_indent();
+    }
+
+    ps.at_offset(string_node.location().start_offset());
+
+    // `opening_loc()` is only `None` in the case of the inner parts of multiline strings
+    // (e.g. the inner contents of a heredoc)
+    let opener = string_node
+        .opening_loc()
+        .map(|s| loc_to_string(s).trim().to_string());
+    let closer = string_node
+        .closing_loc()
+        .map(|s| loc_to_string(s).trim().to_string());
+    let is_heredoc = opener.clone().map(|s| s.starts_with("<")).unwrap_or(false);
+
+    ps.with_start_of_line(
+        false,
+        Box::new(|ps| {
+            if is_heredoc {
+                let heredoc_symbol = opener.clone().unwrap();
+                let heredoc_kind = HeredocKind::from_string(&heredoc_symbol);
+
+                ps.emit_heredoc_start(heredoc_symbol, heredoc_kind);
+                ps.emit_newline();
+            } else {
+                // Always use double quotes over single quotes/percent literals
+                if opener.is_some() {
+                    ps.emit_double_quote();
+                }
+            }
+
+            // If opener is nil, we must be in some kind of interpolated string context, which
+            // means the contents must already be appropriately escaped -- hence we default to `true` here
+            let in_escaped_context =
+                is_heredoc || opener.clone().map(|s| s.starts_with("\"")).unwrap_or(true);
+            let string_content = if in_escaped_context {
+                loc_to_string(string_node.content_loc())
+            } else {
+                crate::string_escape::single_to_double_quoted(
+                    loc_to_string(string_node.content_loc()),
+                    opener.clone().unwrap().as_str(),
+                    closer.clone().unwrap().as_str(),
+                )
+            };
+
+            ps.emit_string_content(string_content);
+            ps.wind_dumping_comments_until_offset(string_node.content_loc().end_offset());
+
+            if is_heredoc {
+                // <<~ heredocs have their closing tag indented too
+                if opener.map(|s| s.starts_with("<<~")).unwrap_or(false) {
+                    ps.emit_indent();
+                }
+
+                ps.emit_heredoc_close(
+                    loc_to_string(string_node.closing_loc().unwrap())
+                        .trim()
+                        .to_string(),
+                );
+            } else {
+                if opener.is_some() {
+                    ps.emit_double_quote();
+                }
+            }
+        }),
+    );
+
+    ps.wind_dumping_comments_until_offset(string_node.location().end_offset());
+
+    if ps.at_start_of_line() {
+        ps.emit_newline();
+    }
+}
+
+fn format_interpolated_string_node(
+    ps: &mut dyn ConcreteParserState,
+    interpolated_string_node: prism::InterpolatedStringNode,
+) {
+    if ps.at_start_of_line() {
+        ps.emit_indent();
+    }
+
+    let is_heredoc = interpolated_string_node
+        .opening_loc()
+        .map(|s| loc_to_string(s).starts_with("<"))
+        .unwrap_or(false);
+
+    // Prism actually handles string concatenation when using "\", so it treats
+    // ```ruby
+    // "foo" \
+    //   "bar"
+    // ```
+    // as an interpolated node with the contents `"foobar"` (in two `parts` of "foo" and "bar").
+    // To detect this, we can look for any `InterpolatedStringNode` that has multiple `parts`
+    // and isn't a heredoc.
+    let is_backslash_string_interpolation = !is_heredoc
+        && interpolated_string_node
+            .parts()
+            .iter()
+            .all(|node| node.as_string_node().unwrap().opening_loc().is_some());
+
+    ps.at_offset(interpolated_string_node.location().start_offset());
+    interpolated_string_node
+        .opening_loc()
+        .map(|s| ps.emit_string_content(loc_to_string(s).trim().to_string()));
+    if is_heredoc {
+        ps.emit_newline();
+    }
+
+    ps.with_start_of_line(
+        false,
+        Box::new(|ps| {
+            let string_parts_count = interpolated_string_node.parts().iter().count();
+            for (i, part) in interpolated_string_node.parts().iter().enumerate() {
+                let end_offset = part.location().end_offset();
+                ps.at_offset(part.location().start_offset());
+
+                if i > 0 {
+                    ps.start_indent();
+
+                    if is_backslash_string_interpolation {
+                        ps.emit_newline();
+                        ps.emit_indent();
+                    }
+                }
+
+                format_node(ps, part);
+
+                // For non-backslash-concatenated multiline strings, `part` contains newlines and indentation,
+                // so we don't need to handle that ourselves.
+                if is_backslash_string_interpolation && i < string_parts_count - 1 {
+                    interpolated_string_node
+                        .closing_loc()
+                        .map(|s| ps.emit_string_content(loc_to_string(s).trim().to_string()));
+                    ps.emit_space();
+                    ps.emit_slash();
+                }
+
+                ps.at_offset(end_offset);
+                if i > 0 {
+                    ps.end_indent();
+                }
+            }
+        }),
+    );
+
+    if let Some(closing_loc) = interpolated_string_node.closing_loc() {
+        ps.emit_string_content(loc_to_string(closing_loc).trim().to_string());
+    }
+
+    if ps.at_start_of_line() {
+        ps.emit_newline();
+    }
+}
+
+fn format_embedded_statements_node(
+    ps: &mut dyn ConcreteParserState,
+    embedded_statements_node: prism::EmbeddedStatementsNode,
+) {
+    ps.emit_string_content("#{".to_string());
+    if let Some(statements) = embedded_statements_node.statements() {
+        let has_multiple_statements = statements.body().iter().count() > 1;
+        ps.with_start_of_line(
+            has_multiple_statements,
+            Box::new(|ps| {
+                if has_multiple_statements {
+                    ps.emit_newline();
+                    ps.new_block(Box::new(|ps| format_node(ps, statements.as_node())));
+                    ps.emit_indent();
+                } else {
+                    format_node(ps, statements.as_node());
+                }
+            }),
+        );
+    }
+    ps.emit_string_content("}".to_string());
 }
 
 fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassNode) {

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -326,10 +326,11 @@ fn format_interpolated_string_node(
     // To detect this, we can look for any `InterpolatedStringNode` that has multiple `parts`
     // and isn't a heredoc.
     let is_backslash_string_interpolation = !is_heredoc
-        && interpolated_string_node
-            .parts()
-            .iter()
-            .all(|node| node.as_string_node().unwrap().opening_loc().is_some());
+        && interpolated_string_node.parts().iter().all(|node| {
+            node.as_string_node()
+                .map(|s| s.opening_loc().is_some())
+                .unwrap_or(false)
+        });
 
     ps.at_offset(interpolated_string_node.location().start_offset());
     if let Some(s) = interpolated_string_node.opening_loc() {

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -243,10 +243,6 @@ fn format_statements(ps: &mut dyn ConcreteParserState, statements_node: prism::S
 }
 
 fn format_string_node(ps: &mut dyn ConcreteParserState, string_node: prism::StringNode) {
-    if ps.at_start_of_line() {
-        ps.emit_indent();
-    }
-
     ps.at_offset(string_node.location().start_offset());
 
     // `opening_loc()` is only `None` in the case of the inner parts of multiline strings
@@ -310,20 +306,12 @@ fn format_string_node(ps: &mut dyn ConcreteParserState, string_node: prism::Stri
     );
 
     ps.wind_dumping_comments_until_offset(string_node.location().end_offset());
-
-    if ps.at_start_of_line() {
-        ps.emit_newline();
-    }
 }
 
 fn format_interpolated_string_node(
     ps: &mut dyn ConcreteParserState,
     interpolated_string_node: prism::InterpolatedStringNode,
 ) {
-    if ps.at_start_of_line() {
-        ps.emit_indent();
-    }
-
     let is_heredoc = interpolated_string_node
         .opening_loc()
         .map(|s| loc_to_string(s).starts_with("<"))
@@ -390,10 +378,6 @@ fn format_interpolated_string_node(
 
     if let Some(closing_loc) = interpolated_string_node.closing_loc() {
         ps.emit_string_content(loc_to_string(closing_loc).trim().to_string());
-    }
-
-    if ps.at_start_of_line() {
-        ps.emit_newline();
     }
 }
 
@@ -1179,10 +1163,6 @@ fn format_instance_variable_write_node(
     ps: &mut dyn ConcreteParserState,
     instance_variable_write_node: prism::InstanceVariableWriteNode,
 ) {
-    if ps.at_start_of_line() {
-        ps.emit_indent();
-    }
-
     ps.at_offset(instance_variable_write_node.location().start_offset());
 
     ps.emit_ident(const_to_string(instance_variable_write_node.name()));
@@ -1193,10 +1173,6 @@ fn format_instance_variable_write_node(
         false,
         Box::new(|ps| format_node(ps, instance_variable_write_node.value())),
     );
-
-    if ps.at_start_of_line() {
-        ps.emit_newline();
-    }
 }
 
 fn format_integer_node(ps: &mut dyn ConcreteParserState, integer_node: prism::IntegerNode) {

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -303,10 +303,8 @@ fn format_string_node(ps: &mut dyn ConcreteParserState, string_node: prism::Stri
                         .trim()
                         .to_string(),
                 );
-            } else {
-                if opener.is_some() {
-                    ps.emit_double_quote();
-                }
+            } else if opener.is_some() {
+                ps.emit_double_quote();
             }
         }),
     );
@@ -346,9 +344,9 @@ fn format_interpolated_string_node(
             .all(|node| node.as_string_node().unwrap().opening_loc().is_some());
 
     ps.at_offset(interpolated_string_node.location().start_offset());
-    interpolated_string_node
-        .opening_loc()
-        .map(|s| ps.emit_string_content(loc_to_string(s).trim().to_string()));
+    if let Some(s) = interpolated_string_node.opening_loc() {
+        ps.emit_string_content(loc_to_string(s).trim().to_string());
+    }
     if is_heredoc {
         ps.emit_newline();
     }
@@ -375,9 +373,9 @@ fn format_interpolated_string_node(
                 // For non-backslash-concatenated multiline strings, `part` contains newlines and indentation,
                 // so we don't need to handle that ourselves.
                 if is_backslash_string_interpolation && i < string_parts_count - 1 {
-                    interpolated_string_node
-                        .closing_loc()
-                        .map(|s| ps.emit_string_content(loc_to_string(s).trim().to_string()));
+                    if let Some(s) = interpolated_string_node.closing_loc() {
+                        ps.emit_string_content(loc_to_string(s).trim().to_string());
+                    }
                     ps.emit_space();
                     ps.emit_slash();
                 }

--- a/librubyfmt/src/lib.rs
+++ b/librubyfmt/src/lib.rs
@@ -32,6 +32,7 @@ mod render_queue_writer;
 mod render_targets;
 mod ripper_tree_types;
 mod ruby_ops;
+mod string_escape;
 mod types;
 mod util;
 

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -99,15 +99,7 @@ impl ConcreteLineToken {
             Self::End => "end".to_string(),
             Self::HeredocClose { symbol } => symbol,
             Self::DataEnd => "__END__".to_string(),
-            Self::HeredocStart { kind, symbol } => {
-                let mut kind_str = match kind {
-                    HeredocKind::Bare => "<<".to_string(),
-                    HeredocKind::Dash => "<<-".to_string(),
-                    HeredocKind::Squiggly => "<<~".to_string(),
-                };
-                kind_str.push_str(&symbol);
-                kind_str
-            }
+            Self::HeredocStart { symbol, .. } => symbol,
             // no-op, this is purely semantic information
             // for the render queue
             Self::AfterCallChain | Self::BeginCallChainIndent | Self::EndCallChainIndent => {
@@ -124,13 +116,7 @@ impl ConcreteLineToken {
         // by an order of magnitude
         match self {
             AfterCallChain | BeginCallChainIndent | EndCallChainIndent => 0, // purely semantic tokens, don't render
-            HeredocStart { kind, symbol } => {
-                symbol.len()
-                    + match kind {
-                        HeredocKind::Bare => 2,                         // <<
-                        HeredocKind::Dash | HeredocKind::Squiggly => 3, // <<- or <<~
-                    }
-            }
+            HeredocStart { symbol, .. } => symbol.len(),
             Indent { depth } => *depth as usize,
             Keyword { keyword: contents }
             | Op { op: contents }

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -101,6 +101,7 @@ where
     fn emit_def(&mut self, def_name: String);
     fn emit_indent(&mut self);
     fn emit_heredoc_start(&mut self, symbol: String, kind: HeredocKind);
+    fn emit_heredoc_close(&mut self, symbol: String);
     fn emit_after_call_chain(&mut self);
     fn emit_data_end(&mut self);
     fn emit_data(&mut self, data: &str);
@@ -246,6 +247,10 @@ impl ConcreteParserState for BaseParserState {
 
     fn emit_heredoc_start(&mut self, symbol: String, kind: HeredocKind) {
         self.push_concrete_token(ConcreteLineToken::HeredocStart { kind, symbol });
+    }
+
+    fn emit_heredoc_close(&mut self, symbol: String) {
+        self.push_concrete_token(ConcreteLineToken::HeredocClose { symbol });
     }
 
     fn magic_handle_comments_for_multiline_arrays<'a>(
@@ -1065,10 +1070,6 @@ impl BaseParserState {
             Some(be) => be.push(t),
             None => self.render_queue.push(Self::dangerously_convert(t)),
         }
-    }
-
-    fn emit_heredoc_close(&mut self, symbol: String) {
-        self.push_concrete_token(ConcreteLineToken::HeredocClose { symbol });
     }
 
     fn render_with_blank_state<F>(ps: &mut BaseParserState, f: F) -> BaseParserState

--- a/librubyfmt/src/string_escape.rs
+++ b/librubyfmt/src/string_escape.rs
@@ -1,0 +1,135 @@
+use fancy_regex::Regex;
+
+pub fn single_to_double_quoted(content: String, start_delim: &str, end_delim: &str) -> String {
+    if start_delim == "'" || start_delim.starts_with("%q") {
+        escape_string(
+            content,
+            start_delim.chars().last().unwrap(),
+            end_delim.chars().last().unwrap(),
+        )
+    } else {
+        // For percent literals, we only care about the delimiter
+        // e.g. for `%<` we're looking for the `<`
+        let start_delim = if start_delim.chars().nth(0).unwrap() == '%' {
+            &start_delim[1..]
+        } else {
+            start_delim
+        };
+
+        let regexp = Regex::new(&format!(
+            r#"(?<!\\)(\\\\)*(\"|\\\\{}|\\\\{})"#,
+            fancy_regex::escape(start_delim),
+            fancy_regex::escape(end_delim)
+        ))
+        .unwrap();
+
+        regexp
+            .replace_all(&content, |captures: &fancy_regex::Captures| {
+                // first capture is the entire match
+                let val = captures.get(0).unwrap();
+                let val_str = val.as_str().to_string();
+                if val_str.ends_with("\"") {
+                    // Ends with a quote, which we transform to `\"`
+                    format!("{}\\\"", val_str[0..(val_str.len() - 1)].to_string())
+                } else {
+                    // drop unnecessary escape
+                    format!(
+                        "{}{}",
+                        val_str[0..(val_str.len() - 2)].to_string(),
+                        val_str.chars().last().unwrap()
+                    )
+                }
+            })
+            .to_string()
+    }
+}
+
+fn escape_string(content: String, opening_delim: char, closing_delim: char) -> String {
+    if opening_delim == '"' {
+        return content;
+    }
+
+    let chars = content.chars().into_iter().collect::<Vec<char>>();
+    let mut i = 0;
+
+    let mut output = String::new();
+
+    while let Some(i_char) = chars.get(i) {
+        match i_char {
+            '"' => {
+                output.push('\\');
+            }
+            '\\' => {
+                if let Some(next_char) = chars.get(i + 1) {
+                    match next_char {
+                        '\'' => {
+                            // String#inspect strips the leading backslash from \', despite it being a valid
+                            // escape character in double-quoted strings as well. Leaving the behavior the same
+                            // for consistency with the previous behavior.
+                            output.push('\'');
+                            i += 2;
+                            continue;
+                        }
+                        // '\\' is considered an escape sequence in both single and double quoted strings
+                        // and thus we don't need to "double-escape" it to "\\\\"
+                        '\\' => {
+                            output.push_str("\\\\");
+                            i += 2;
+                            continue;
+                        }
+                        // '\"' is a slash char and a double-quote char, not an escaped double-quote,
+                        // so here we print an escaped slash character and then an escaped quote character: `"\\\""`
+                        '"' => {
+                            output.push_str("\\\\\\\"");
+                            i += 2;
+                            continue;
+                        }
+                        delim_char
+                            if (*delim_char == opening_delim
+                                || *delim_char == closing_delim)
+                                // We only care about the "non-standard" delimiters like %() etc.
+                                // For single-quoted strings, these characters should *not* be treated as escape sequences.
+                                && opening_delim != '\'' =>
+                        {
+                            // In percent-strings, the opening and closing delimiters can be escaped to prevent terminating the string.
+                            output.push(*delim_char);
+                            i += 2;
+                            continue;
+                        }
+                        // For everything else, this is not an escape sequnce, so we need to
+                        // escape the slash and then print the next character.
+                        _ => {
+                            output.push('\\');
+                            output.push('\\');
+                            output.push(*next_char);
+                            i += 2;
+                            continue;
+                        }
+                    }
+                }
+            }
+            '#' => {
+                if let Some(next_char) = chars.get(i + 1) {
+                    match next_char {
+                        // These are shorthands for embedded variables when double-quoted,
+                        // e.g. "#@foo", "#$GLOBAL", and "#{1}", so they must be escaped
+                        '$' | '@' | '{' => {
+                            output.push('\\');
+                            output.push(*i_char);
+                            output.push(*next_char);
+                            i += 2;
+                            continue;
+                        }
+                        _ => {}
+                    };
+                }
+            }
+            _ => {}
+        };
+
+        output.push(*i_char);
+        i += 1;
+    }
+
+    output
+}

--- a/librubyfmt/src/string_escape.rs
+++ b/librubyfmt/src/string_escape.rs
@@ -10,8 +10,8 @@ pub fn single_to_double_quoted(content: String, start_delim: &str, end_delim: &s
     } else {
         // For percent literals, we only care about the delimiter
         // e.g. for `%<` we're looking for the `<`
-        let start_delim = if start_delim.chars().nth(0).unwrap() == '%' {
-            &start_delim[1..]
+        let start_delim = if let Some(stripped) = start_delim.strip_prefix('%') {
+            stripped
         } else {
             start_delim
         };
@@ -30,12 +30,12 @@ pub fn single_to_double_quoted(content: String, start_delim: &str, end_delim: &s
                 let val_str = val.as_str().to_string();
                 if val_str.ends_with("\"") {
                     // Ends with a quote, which we transform to `\"`
-                    format!("{}\\\"", val_str[0..(val_str.len() - 1)].to_string())
+                    format!("{}\\\"", &val_str[0..(val_str.len() - 1)])
                 } else {
                     // drop unnecessary escape
                     format!(
                         "{}{}",
-                        val_str[0..(val_str.len() - 2)].to_string(),
+                        &val_str[0..(val_str.len() - 2)],
                         val_str.chars().last().unwrap()
                     )
                 }
@@ -49,7 +49,7 @@ fn escape_string(content: String, opening_delim: char, closing_delim: char) -> S
         return content;
     }
 
-    let chars = content.chars().into_iter().collect::<Vec<char>>();
+    let chars = content.chars().collect::<Vec<char>>();
     let mut i = 0;
 
     let mut output = String::new();

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -95,10 +95,10 @@ fixture!(test_small_bare_assoc_multiple, "small/bare_assoc_multiple");
 // fixture!(test_small_binary_raise, "small/binary_raise");
 // fixture!(test_small_bitwise_not, "small/bitwise_not");
 // fixture!(test_small_block_argument, "small/block_argument");
-// fixture!(
-//     test_small_block_ending_with_comment,
-//     "small/block_ending_with_comment"
-// );
+fixture!(
+    test_small_block_ending_with_comment,
+    "small/block_ending_with_comment"
+);
 // fixture!(
 //     test_small_block_local_variables,
 //     "small/block_local_variables"
@@ -153,7 +153,7 @@ fixture!(test_small_cannibalization_4, "small/cannibalization_4");
 //     "small/class_methods_respect_parens"
 // );
 // fixture!(test_small_class_module, "small/class_module");
-// fixture!(test_small_coloncoloncalldot, "small/coloncoloncalldot");
+fixture!(test_small_coloncoloncalldot, "small/coloncoloncalldot");
 // fixture!(test_small_command_call_raise, "small/command_call_raise");
 // fixture!(test_small_command_paren, "small/command_paren");
 fixture!(test_small_commas_trailing, "small/commas_trailing");
@@ -173,10 +173,10 @@ fixture!(test_small_commas_trailing, "small/commas_trailing");
 //     test_small_comments_at_indentation_changes,
 //     "small/comments_at_indentation_changes"
 // );
-// fixture!(
-//     test_small_comments_inside_array,
-//     "small/comments_inside_array"
-// );
+fixture!(
+    test_small_comments_inside_array,
+    "small/comments_inside_array"
+);
 // fixture!(
 //     test_small_comments_with_breaks,
 //     "small/comments_with_breaks"
@@ -332,7 +332,7 @@ fixture!(
     "small/method_call_with_trailing_comma"
 );
 // fixture!(test_small_method_chains, "small/method_chains");
-// fixture!(test_small_missing_parens, "small/missing_parens");
+fixture!(test_small_missing_parens, "small/missing_parens");
 // fixture!(test_small_mlhs_params, "small/mlhs_params");
 // fixture!(test_small_mlhs_paren, "small/mlhs_paren");
 fixture!(test_small_more_breaks, "small/more_breaks");
@@ -360,10 +360,10 @@ fixture!(
     "small/multiline_chained_call"
 );
 // fixture!(test_small_multiline_defs, "small/multiline_defs");
-// fixture!(
-//     test_small_multiline_method_call_with_block,
-//     "small/multiline_method_call_with_block"
-// );
+fixture!(
+    test_small_multiline_method_call_with_block,
+    "small/multiline_method_call_with_block"
+);
 // fixture!(
 //     test_small_multiline_method_chain_with_arguments,
 //     "small/multiline_method_chain_with_arguments"
@@ -376,15 +376,15 @@ fixture!(
 //     test_small_multiline_single_quotes,
 //     "small/multiline_single_quotes"
 // );
-// fixture!(
-//     test_small_multiline_strings_in_parameter_list,
-//     "small/multiline_strings_in_parameter_list"
-// );
+fixture!(
+    test_small_multiline_strings_in_parameter_list,
+    "small/multiline_strings_in_parameter_list"
+);
 // fixture!(
 //     test_small_multiline_when_with_comment,
 //     "small/multiline_when_with_comment"
 // );
-// fixture!(test_small_nbsp, "small/nbsp");
+fixture!(test_small_nbsp, "small/nbsp");
 fixture!(test_small_nested_command, "small/nested_command");
 // fixture!(test_small_nested_conditionals, "small/nested_conditionals");
 // fixture!(
@@ -438,10 +438,10 @@ fixture!(test_small_raise_star, "small/raise_star");
 // fixture!(test_small_req_optional_params, "small/req_optional_params");
 // fixture!(test_small_require_rails, "small/require_rails");
 // fixture!(test_small_require_relative, "small/require_relative");
-// fixture!(
-//     test_small_requirish_followed_by_module,
-//     "small/requirish_followed_by_module"
-// );
+fixture!(
+    test_small_requirish_followed_by_module,
+    "small/requirish_followed_by_module"
+);
 // fixture!(test_small_rescue_else, "small/rescue_else");
 // fixture!(test_small_rescue_multiple, "small/rescue_multiple");
 // fixture!(test_small_rescue_no_class, "small/rescue_no_class");
@@ -466,14 +466,14 @@ fixture!(
     "small/single_line_method_call_chain"
 );
 // fixture!(test_small_single_massign, "small/single_massign");
-// fixture!(
-//     test_small_single_quoted_string_with_embexpr,
-//     "small/single_quoted_string_with_embexpr"
-// );
-// fixture!(
-//     test_small_single_quoted_string_with_slash_escape,
-//     "small/single_quoted_string_with_slash_escape"
-// );
+fixture!(
+    test_small_single_quoted_string_with_embexpr,
+    "small/single_quoted_string_with_embexpr"
+);
+fixture!(
+    test_small_single_quoted_string_with_slash_escape,
+    "small/single_quoted_string_with_slash_escape"
+);
 // fixture!(test_small_splat_case, "small/splat_case");
 fixture!(test_small_splat_in_argument, "small/splat_in_argument");
 // fixture!(test_small_splat_rescue, "small/splat_rescue");
@@ -488,18 +488,18 @@ fixture!(
     test_small_start_of_file_comments,
     "small/start_of_file_comments"
 );
-// fixture!(test_small_static_call, "small/static_call");
+fixture!(test_small_static_call, "small/static_call");
 fixture!(
     test_small_stmt_followed_by_do_block,
     "small/stmt_followed_by_do_block"
 );
-// fixture!(test_small_string_concat, "small/string_concat");
+fixture!(test_small_string_concat, "small/string_concat");
 // fixture!(
 //     test_small_string_concat_indent,
 //     "small/string_concat_indent"
 // );
 // fixture!(test_small_string_dvar, "small/string_dvar");
-// fixture!(test_small_string_escapes, "small/string_escapes");
+fixture!(test_small_string_escapes, "small/string_escapes");
 // fixture!(
 //     test_small_string_first_item_is_embed,
 //     "small/string_first_item_is_embed"
@@ -559,10 +559,10 @@ fixture!(test_small_trailing_empty_star, "small/trailing_empty_star");
 // fixture!(test_small_visibility_modifier, "small/visibility_modifier");
 // fixture!(test_small_w_array, "small/w_array");
 // fixture!(test_small_w_arrays, "small/w_arrays");
-// fixture!(
-//     test_small_weird_percent_strings,
-//     "small/weird_percent_strings"
-// );
+fixture!(
+    test_small_weird_percent_strings,
+    "small/weird_percent_strings"
+);
 // fixture!(test_small_when_indent, "small/when_indent");
 // fixture!(test_small_while, "small/while");
 // fixture!(test_small_while_block_comment, "small/while_block_comment");

--- a/tests/stress_test.rs
+++ b/tests/stress_test.rs
@@ -23,6 +23,11 @@ fn methods_prism_stress_test() {
     stress_test("ci/methods_stress_test.rb", true).unwrap()
 }
 
+#[test]
+fn string_literals_prism_stress_test() {
+    stress_test("ci/string_literals_stress_test.rb", true).unwrap()
+}
+
 /// Test helper for running "stress tests", tests that
 /// execute a ruby script before and after being formatted
 /// to confirm that its behavior/output is the same.


### PR DESCRIPTION
This PR gets us far enough to pass the string literals stress test with Prism, meaning that the Prism implementation can generally correctly handle most heredocs, single quote strings, double quote strings, and percent-literal strings. This implementation probably isn't 100% perfect, and there's likely some additional future testing that will need to be done to fully test all of this, but this represents a solid first pass at the core functionality.

This implementation attempts to be faithful to the way that strings were handled in `rubyfmt_lib.rb`, but that implementation relies heavily on `eval` and `String#inspect`, neither of which we'll have access to. This implementation essentially re-implements parts of `String#inspect`, but it's not going to be 100%, nor should it be -- `inspect` causes all sorts of (IMO) unexpected results in issues like #454 where things like English characters are mixed with emoji/kanji/etc., but this is essentially a non-issue in the prism implementation. That said, once this is more fully featured, there may be edge cases not in the fixtures, but I _think_ this will cover most cases even in its current form.