### PR TITLE
Remove a ton of extraneous debug output

### DIFF
--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -1,8 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::mem;
 
-use log::debug;
-
 use crate::comment_block::CommentBlock;
 use crate::parser_state::line_difference_requires_newline;
 use crate::ruby::*;
@@ -156,7 +154,6 @@ impl FileComments {
     }
 
     pub fn is_empty_line(&self, line_number: LineNumber) -> bool {
-        debug!("{:?}", self.lines_with_ruby);
         !self.lines_with_ruby.contains(&line_number)
     }
 

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -5,7 +5,6 @@ use crate::heredoc_string::HeredocKind;
 use crate::parser_state::{BaseParserState, ConcreteParserState, FormattingContext, RenderFunc};
 use crate::ripper_tree_types::*;
 use crate::types::LineNumber;
-use log::debug;
 
 pub fn format_def(ps: &mut dyn ConcreteParserState, def: Def) {
     let def_expression = (def.1).to_def_parts();
@@ -721,7 +720,6 @@ pub fn use_parens_for_method_call(
     context: FormattingContext,
 ) -> bool {
     let name = method.get_name();
-    debug!("name: {:?}", name);
 
     // If the calling method is a const, the parens become
     // semantically important, e.g.
@@ -751,7 +749,6 @@ pub fn use_parens_for_method_call(
     }
 
     if name == "yield" {
-        debug!("yield paren: {:?}", original_used_parens);
         return ps.current_formatting_context_requires_parens() || original_used_parens;
     }
 
@@ -834,7 +831,6 @@ pub fn format_method_call(ps: &mut dyn ConcreteParserState, method_call: MethodC
 
     let MethodCall(_, mut chain, method, original_used_parens, args, start_end) = method_call;
 
-    debug!("method call!!");
     let use_parens = use_parens_for_method_call(
         ps,
         &chain,
@@ -3707,7 +3703,6 @@ pub fn format_bare_return_args(
 
 pub fn format_expression(ps: &mut dyn ConcreteParserState, expression: Expression) {
     let expression = normalize(expression);
-    debug!("normalized expression: {:?}", expression);
     match expression {
         Expression::Def(def) => format_def(ps, def),
         Expression::MethodCall(mc) => format_method_call(ps, mc),
@@ -3785,7 +3780,6 @@ pub fn format_expression(ps: &mut dyn ConcreteParserState, expression: Expressio
 
 pub fn format_program(ps: &mut BaseParserState, program: Program, end_data: Option<&str>) {
     ps.flush_start_of_file_comments();
-    debug!("{:?}", program);
     for expression in program.1 {
         format_expression(ps, expression);
     }

--- a/librubyfmt/src/lib.rs
+++ b/librubyfmt/src/lib.rs
@@ -40,8 +40,6 @@ use parser_state::BaseParserState;
 use ruby_ops::{load_rubyfmt, ParseError, Parser, RipperTree};
 
 #[cfg(debug_assertions)]
-use log::debug;
-#[cfg(debug_assertions)]
 use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
 
 extern "C" {
@@ -266,6 +264,5 @@ pub fn init_logger() {
             ColorChoice::Auto,
         )
         .expect("making a term logger");
-        debug!("logger works");
     }
 }

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -472,15 +472,10 @@ impl ConcreteParserState for BaseParserState {
         if line_difference_requires_newline(line_number, self.current_orig_line_number)
             && self.insert_user_newlines
         {
-            debug!("extra line");
             self.insert_extra_newline_at_last_newline();
         }
 
         self.current_orig_line_number = line_number;
-        debug!(
-            "set current orig line number: {}",
-            self.current_orig_line_number
-        );
     }
 
     fn at_offset(&mut self, source_offset: SourceOffset) {
@@ -537,19 +532,10 @@ impl ConcreteParserState for BaseParserState {
     }
 
     fn emit_ident(&mut self, ident: String) {
-        if ident == "example" {
-            debug!("--------- boogaloo ------------");
-            debug!("ps: {:?}", self);
-            debug!("---------------------");
-        }
         self.push_concrete_token(ConcreteLineToken::DirectPart { part: ident });
     }
 
     fn emit_newline(&mut self) {
-        debug!("---------------------");
-        debug!("ps: {:?}", self);
-        debug!("---------------------");
-
         self.shift_comments();
         self.push_concrete_token(ConcreteLineToken::HardNewLine);
         self.render_heredocs(false);
@@ -572,7 +558,6 @@ impl ConcreteParserState for BaseParserState {
 
         self.on_line(self.current_orig_line_number + 1);
         let should_iter = |ps: &BaseParserState, ln| {
-            debug!("{}", ln);
             // If we have a max line number, it will be the last token
             // of an expression (e.g. the `end` of a `do`/`end` block), so it's
             // fine if we wind forward to that line
@@ -598,7 +583,6 @@ impl ConcreteParserState for BaseParserState {
                     .is_empty_line(self.current_orig_line_number + 1)
                 && self.comments_to_insert.is_some()
             {
-                debug!("{}", self.current_orig_line_number);
                 let mr = self.comments_to_insert.as_mut().expect("it's not nil");
                 if mr.len() == 0 {
                     break;
@@ -606,7 +590,6 @@ impl ConcreteParserState for BaseParserState {
                 mr.add_line("".to_string());
             }
             self.on_line(self.current_orig_line_number + 1);
-            debug!("{}", self.current_orig_line_number);
         }
     }
 
@@ -901,7 +884,6 @@ impl BaseParserState {
             self.insert_comment_collection(comments);
             if !trailing_comment {
                 self.current_orig_line_number += len as u64;
-                debug!("pe coln: {}", len);
             }
         }
     }
@@ -1002,7 +984,6 @@ impl BaseParserState {
                     self.push_concrete_token(comment);
                 }
                 self.current_orig_line_number = len as LineNumber;
-                debug!("rq: {:?}", self.render_queue);
             }
         }
     }

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::wrong_self_convention)]
 
-#[cfg(debug_assertions)]
-use log::debug;
 use ripper_deserialize::RipperDeserialize;
 use serde::*;
 
@@ -49,16 +47,8 @@ macro_rules! def_tag {
                         E: de::Error,
                     {
                         if s == $tag {
-                            #[cfg(debug_assertions)]
-                            {
-                                debug!("accepted at {:?} {:?}", s, $tag);
-                            }
                             Ok(())
                         } else {
-                            #[cfg(debug_assertions)]
-                            {
-                                debug!("rejected at {:?} {:?}", s, $tag);
-                            }
                             Err(E::custom("mismatched tag"))
                         }
                     }

--- a/librubyfmt/src/ruby.rs
+++ b/librubyfmt/src/ruby.rs
@@ -1,5 +1,4 @@
 #![allow(non_camel_case_types, dead_code)]
-use log::debug;
 use std::ffi::CString;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -117,25 +116,6 @@ pub unsafe fn eval_str(s: &str) -> Result<VALUE, ()> {
         Err(())
     } else {
         Ok(v)
-    }
-}
-
-extern "C" fn real_debug_inspect(v: VALUE) -> VALUE {
-    unsafe {
-        let inspect = rb_funcall(v, intern!("inspect"), 0);
-        debug!("{}", ruby_string_to_str(inspect));
-        Qnil
-    }
-}
-
-pub fn debug_inspect(v: VALUE) {
-    unsafe {
-        let mut state = 0;
-        rb_protect(real_debug_inspect as _, v, &mut state);
-        if state != 0 {
-            let s = current_exception_as_rust_string();
-            panic!("blew us: {}", s);
-        }
     }
 }
 


### PR DESCRIPTION
This debug output has been in here for a long time, and most of it is totally unnecessary. For a long time I just tuned it out, but now that we've moved all the tests to `cargo test` (which prints the stdout/stderr on failure), the debug output is now more of a hinderance than a help. I've left in the handful of things that I think are valuable, but I've deleted anything that I have literally never used before.