### PR TITLE
Bump Ubuntu GH action runners 20.04->22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,11 @@ jobs:
         include:
           - os: ubuntu-latest
             target: native
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: native
           - os: macos-latest
             target: native
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -33,11 +33,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: native
           - os: macos-latest
             target: native
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v2
@@ -98,10 +98,10 @@ jobs:
           name: rubyfmt-source-release
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-ubuntu-20.04-aarch64-unknown-linux-gnu
+          name: rubyfmt-release-artifact-ubuntu-22.04-aarch64-unknown-linux-gnu
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-ubuntu-20.04-native
+          name: rubyfmt-release-artifact-ubuntu-22.04-native
       - uses: actions/download-artifact@v4
         with:
           name: rubyfmt-release-artifact-macos-latest-native

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,11 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: native
           - os: macos-latest
             target: native
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v2
@@ -78,13 +78,13 @@ jobs:
           name: rubyfmt-source-release
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-ubuntu-20.04-native
+          name: rubyfmt-release-artifact-ubuntu-22.04-native
       - uses: actions/download-artifact@v4
         with:
           name: rubyfmt-release-artifact-macos-latest-native
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-ubuntu-20.04-aarch64-unknown-linux-gnu
+          name: rubyfmt-release-artifact-ubuntu-22.04-aarch64-unknown-linux-gnu
       - name: Ship It 🚢
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
The Ubuntu 20.04 runners are going to be deprecated in the next few weeks (https://github.com/actions/runner-images/issues/11101), so we should move off of them.

cc @froydnj I recall us using 20.04 specifically because we needed that to be built for Stripe. Not sure what the current state of the world is there, but a heads up just in case the specifics here affect y'all's ability to use the release artifacts. Currently GH runners will only support 22.04 and 24.04, and our other jobs also run `ubuntu-latest` (24.04), so I just picked 22.04 to have coverage on both.