### PR TITLE
🧹  Clean up some stray `dbg!` in tests

### DIFF
--- a/tests/cli_interface_test.rs
+++ b/tests/cli_interface_test.rs
@@ -629,7 +629,7 @@ fn test_includes_gitignored() {
     writeln!(file_two, "a 4, 5, 6").unwrap();
     fs::write(
         dir.path().join(".gitignore"),
-        dbg!(file_two.path().file_name().unwrap().to_str().unwrap()),
+        file_two.path().file_name().unwrap().to_str().unwrap(),
     )
     .unwrap();
     assert_eq!(
@@ -708,7 +708,7 @@ fn test_respects_gitignore() {
     writeln!(file_two, "a 4, 5, 6").unwrap();
     fs::write(
         dir.path().join(".gitignore"),
-        dbg!(file_two.path().file_name().unwrap().to_str().unwrap()),
+        file_two.path().file_name().unwrap().to_str().unwrap(),
     )
     .unwrap();
 


### PR DESCRIPTION
On the tin -- just left these behind when I originally converted them to Rust.