### PR TITLE
Support rendering `__END__` data with Prism

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -143,7 +143,7 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::PinnedVariableNode { .. } => todo!(),
         Node::PostExecutionNode { .. } => todo!(),
         Node::PreExecutionNode { .. } => todo!(),
-        Node::ProgramNode { .. } => format_program(ps, node.as_program_node().unwrap()),
+        Node::ProgramNode { .. } => format_program(ps, node.as_program_node().unwrap(), None),
         Node::RangeNode { .. } => todo!(),
         Node::RationalNode { .. } => todo!(),
         Node::RedoNode { .. } => todo!(),
@@ -182,7 +182,11 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
     }
 }
 
-fn format_program(ps: &mut dyn ConcreteParserState, program_node: prism::ProgramNode) {
+pub fn format_program(
+    ps: &mut dyn ConcreteParserState,
+    program_node: prism::ProgramNode,
+    data_loc: Option<prism::Location>,
+) {
     ps.with_start_of_line(
         true,
         Box::new(|ps| {
@@ -191,6 +195,10 @@ fn format_program(ps: &mut dyn ConcreteParserState, program_node: prism::Program
     );
     ps.on_line(10000000000);
     ps.shift_comments();
+
+    if let Some(data) = data_loc {
+        ps.emit_data(&loc_to_string(data));
+    }
 }
 
 fn format_statements(ps: &mut dyn ConcreteParserState, statements_node: prism::StatementsNode) {

--- a/librubyfmt/src/lib.rs
+++ b/librubyfmt/src/lib.rs
@@ -98,11 +98,14 @@ pub fn format_buffer(buf: &str, use_prism: bool) -> Result<String, RichFormatErr
         if parse_result.errors().next().is_some() {
             return Err(RichFormatError::SyntaxError);
         }
+        let end_data = parse_result.data_loc();
+
         toplevel_format_program_with_prism(
             &mut output,
             parse_result.node(),
             parse_result.comments(),
             buf.as_bytes(),
+            end_data,
         )?;
     } else {
         let (tree, file_comments, end_data) = run_parser_on(buf)?;
@@ -234,11 +237,12 @@ pub fn toplevel_format_program_with_prism<W: Write>(
     tree: ruby_prism::Node,
     comments: ruby_prism::Comments,
     source: &[u8],
+    data: Option<ruby_prism::Location>,
 ) -> Result<(), RichFormatError> {
     let mut ps = BaseParserState::new(FileComments::from_prism_comments(comments, source));
     ps.flush_start_of_file_comments();
 
-    format_prism::format_node(&mut ps, tree);
+    format_prism::format_program(&mut ps, tree.as_program_node().unwrap(), data);
 
     ps.write(writer).map_err(RichFormatError::IOError)?;
     writer.flush().map_err(RichFormatError::IOError)?;


### PR DESCRIPTION
This is one of those weird things that we need to support that's not directly in the parse tree (that is, it's not actually a node). `fixtures/small/end_data_actual.rb` doesn't quite pass yet because it uses a block, which I haven't implemented yet, but I manually checked that it works as expected otherwise.