### PR TITLE
Fix const_path_ref class definitions

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -208,7 +208,10 @@ fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassN
 
     ps.emit_class_keyword();
     ps.emit_space();
-    ps.emit_ident(const_to_string(class_node.name()));
+    ps.with_start_of_line(
+        false,
+        Box::new(|ps| format_node(ps, class_node.constant_path())),
+    );
 
     if let Some(superclass) = class_node.superclass() {
         ps.at_offset(superclass.location().start_offset());

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -198,10 +198,10 @@ fixture!(test_small_blockarg, "small/blockarg");
 //     test_small_const_path_field_assignment,
 //     "small/const_path_field_assignment"
 // );
-// fixture!(
-//     test_small_const_path_ref_class_definition,
-//     "small/const_path_ref_class_definition"
-// );
+fixture!(
+    test_small_const_path_ref_class_definition,
+    "small/const_path_ref_class_definition"
+);
 // fixture!(test_small_curly_line_breaking, "small/curly_line_breaking");
 // fixture!(test_small_cursed_call_01, "small/cursed_call_01");
 // fixture!(test_small_cvar, "small/cvar");


### PR DESCRIPTION
I mistakenly used `name()` for the class name earlier, when in actuality we should be using `constant_path()` to get the parent classes as well in the case of a const path.