### PR TITLE
Support blocks with Prism

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -11,6 +11,8 @@ use crate::{
 
 pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
     use prism::Node;
+
+    ps.at_offset(node.location().start_offset());
     // StatementsNode is the only real "wrapper" node, meaning it purely contains
     // other statements which themselves would be at the start of a line.
     // We just ignore it here -- the alternative would be callers might need to have
@@ -192,6 +194,7 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::YieldNode { .. } => todo!(),
     }
 
+    ps.at_offset(node.location().end_offset());
     if ps.at_start_of_line() && !matches!(node, Node::StatementsNode { .. }) {
         ps.emit_newline();
     }
@@ -229,8 +232,6 @@ fn format_statements(ps: &mut dyn ConcreteParserState, statements_node: prism::S
 }
 
 fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassNode) {
-    ps.at_offset(class_node.location().start_offset());
-
     ps.emit_class_keyword();
     ps.emit_space();
     ps.with_start_of_line(
@@ -239,8 +240,6 @@ fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassN
     );
 
     if let Some(superclass) = class_node.superclass() {
-        ps.at_offset(superclass.location().start_offset());
-
         ps.emit_ident("<".to_string());
         ps.emit_space();
         ps.with_start_of_line(
@@ -272,8 +271,6 @@ fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassN
 }
 
 fn format_def_node(ps: &mut dyn ConcreteParserState, def_node: prism::DefNode) {
-    ps.at_offset(def_node.def_keyword_loc().start_offset());
-
     ps.emit_keyword("def".to_string());
     ps.emit_space();
 
@@ -486,8 +483,6 @@ fn format_call_node(
     call_node: prism::CallNode,
     skip_receiver: bool,
 ) {
-    ps.at_offset(call_node.location().start_offset());
-
     if skip_receiver || call_node.receiver().is_none() {
         handle_string_at_offset(
             ps,
@@ -659,8 +654,6 @@ fn format_assoc_node(ps: &mut dyn ConcreteParserState, assoc_node: prism::AssocN
 }
 
 fn format_array_node(ps: &mut dyn ConcreteParserState, array_node: prism::ArrayNode) {
-    ps.at_offset(array_node.location().start_offset());
-
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -684,8 +677,6 @@ fn format_parentheses_node(
     ps: &mut dyn ConcreteParserState,
     parentheses_node: prism::ParenthesesNode,
 ) {
-    ps.at_offset(parentheses_node.location().start_offset());
-
     ps.emit_open_paren();
     if let Some(body) = parentheses_node.body() {
         ps.with_start_of_line(
@@ -694,7 +685,6 @@ fn format_parentheses_node(
                 format_node(ps, body);
             }),
         );
-        ps.at_offset(parentheses_node.location().end_offset());
     }
     ps.emit_close_paren();
 }
@@ -785,8 +775,6 @@ fn format_keyword_rest_parameter_node(
     ps: &mut dyn ConcreteParserState,
     keyword_rest_parameter_node: prism::KeywordRestParameterNode,
 ) {
-    ps.at_offset(keyword_rest_parameter_node.location().start_offset());
-
     ps.emit_ident("**".to_string());
     if let Some(constant_id) = keyword_rest_parameter_node.name() {
         let name = const_to_string(constant_id);
@@ -799,8 +787,6 @@ fn format_required_keyword_parameter_node(
     ps: &mut dyn ConcreteParserState,
     required_keyword_parameter_node: prism::RequiredKeywordParameterNode,
 ) {
-    ps.at_offset(required_keyword_parameter_node.location().start_offset());
-
     let name = const_to_string(required_keyword_parameter_node.name());
     ps.bind_variable(name.clone());
     ps.emit_ident(name);
@@ -811,8 +797,6 @@ fn format_required_parameter_node(
     ps: &mut dyn ConcreteParserState,
     required_parameter_node: prism::RequiredParameterNode,
 ) {
-    ps.at_offset(required_parameter_node.location().start_offset());
-
     let name = const_to_string(required_parameter_node.name());
     ps.bind_variable(name.clone());
     ps.emit_ident(name);
@@ -822,8 +806,6 @@ fn format_local_variable_read_node(
     ps: &mut dyn ConcreteParserState,
     local_variable_read_node: prism::LocalVariableReadNode,
 ) {
-    ps.at_offset(local_variable_read_node.location().start_offset());
-
     let name = const_to_string(local_variable_read_node.name());
     ps.bind_variable(name.clone());
     ps.emit_ident(name);
@@ -833,8 +815,6 @@ fn format_local_variable_write_node(
     ps: &mut dyn ConcreteParserState,
     local_variable_write_node: prism::LocalVariableWriteNode,
 ) {
-    ps.at_offset(local_variable_write_node.location().start_offset());
-
     let name = const_to_string(local_variable_write_node.name());
     ps.bind_variable(name.clone());
     ps.emit_ident(name);
@@ -848,8 +828,6 @@ fn format_local_variable_write_node(
 }
 
 fn format_splat_node(ps: &mut dyn ConcreteParserState, splat_node: prism::SplatNode) {
-    ps.at_offset(splat_node.location().start_offset());
-
     ps.emit_ident("*".to_string());
     if let Some(node) = splat_node.expression() {
         ps.with_start_of_line(
@@ -913,8 +891,7 @@ fn format_constant_path_node(
     );
 }
 
-fn format_self_node(ps: &mut dyn ConcreteParserState, self_node: prism::SelfNode) {
-    ps.at_offset(self_node.location().start_offset());
+fn format_self_node(ps: &mut dyn ConcreteParserState, _self_node: prism::SelfNode) {
     ps.emit_ident("self".to_string());
 }
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -685,6 +685,48 @@ fn format_block_node(ps: &mut dyn ConcreteParserState, block_node: prism::BlockN
             }),
         );
     } else {
+        ps.inline_breakable_of(
+            BreakableDelims::for_brace_block(),
+            Box::new(|ps| {
+                if let Some(parameters) = block_node.parameters() {
+                    format_node(ps, parameters);
+                }
+
+                if let Some(body) = block_node.body() {
+                    let has_multiple_statements = body
+                        .as_statements_node()
+                        .map(|statements_node| statements_node.body().iter().count() > 1)
+                        .unwrap_or(false);
+                    if has_multiple_statements {
+                        ps.emit_newline();
+                        ps.with_start_of_line(
+                            true,
+                            Box::new(|ps| {
+                                format_node(ps, body);
+                            }),
+                        );
+                    } else {
+                        ps.with_start_of_line(
+                            false,
+                            Box::new(|ps| {
+                                if let Some(node) =
+                                    body.as_statements_node().unwrap().body().iter().next()
+                                {
+                                    ps.emit_soft_newline();
+                                    ps.emit_soft_indent();
+                                    format_node(ps, node);
+                                    ps.emit_soft_newline();
+                                }
+                            }),
+                        );
+                    }
+                }
+
+                // `inline_breakable_of` doesn't handle the indentation for the closing delimeter for us.
+                ps.dedent(Box::new(|ps| ps.emit_soft_indent()));
+                ps.wind_dumping_comments_until_offset(block_node.location().end_offset());
+            }),
+        );
     }
 }
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -34,10 +34,14 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::BackReferenceReadNode { .. } => todo!(),
         Node::BeginNode { .. } => todo!(),
         Node::BlockArgumentNode { .. } => todo!(),
-        Node::BlockLocalVariableNode { .. } => todo!(),
-        Node::BlockNode { .. } => todo!(),
+        Node::BlockLocalVariableNode { .. } => {
+            format_block_local_variable_node(ps, node.as_block_local_variable_node().unwrap())
+        }
+        Node::BlockNode { .. } => format_block_node(ps, node.as_block_node().unwrap()),
         Node::BlockParameterNode { .. } => todo!(),
-        Node::BlockParametersNode { .. } => todo!(),
+        Node::BlockParametersNode { .. } => {
+            format_block_parameters_node(ps, node.as_block_parameters_node().unwrap())
+        }
         Node::BreakNode { .. } => todo!(),
         Node::CallAndWriteNode { .. } => todo!(),
         Node::CallNode { .. } => format_call_node(ps, node.as_call_node().unwrap(), false),
@@ -650,6 +654,79 @@ fn format_assoc_node(ps: &mut dyn ConcreteParserState, assoc_node: prism::AssocN
             ps.emit_space();
             format_node(ps, assoc_node.value());
         }),
+    );
+}
+
+fn format_block_node(ps: &mut dyn ConcreteParserState, block_node: prism::BlockNode) {
+    if &loc_to_string(block_node.opening_loc()) == "do" {
+        ps.new_block(Box::new(|ps| {
+            ps.emit_do_keyword();
+            if let Some(block_parameters) = block_node.parameters() {
+                format_node(ps, block_parameters);
+            }
+
+            if let Some(body) = block_node.body() {
+                ps.emit_newline();
+                ps.with_start_of_line(
+                    true,
+                    Box::new(|ps| {
+                        format_node(ps, body);
+                    }),
+                );
+            }
+        }));
+
+        ps.with_start_of_line(
+            true,
+            Box::new(|ps| {
+                ps.wind_dumping_comments_until_offset(block_node.location().end_offset());
+                ps.emit_end();
+                ps.shift_comments();
+            }),
+        );
+    } else {
+    }
+}
+
+fn format_block_parameters_node(
+    ps: &mut dyn ConcreteParserState,
+    block_parameters_node: prism::BlockParametersNode,
+) {
+    ps.breakable_of(
+        BreakableDelims::for_block_params(),
+        Box::new(|ps| {
+            let has_locals = !node_list_is_empty(&block_parameters_node.locals());
+
+            if let Some(parameters) = block_parameters_node.parameters() {
+                format_parameters_node(ps, parameters);
+            }
+            if has_locals {
+                ps.emit_ident(";".to_string());
+                ps.emit_space();
+                ps.with_start_of_line(
+                    false,
+                    Box::new(|ps| {
+                        format_list_like_thing(
+                            ps,
+                            block_parameters_node.locals(),
+                            block_parameters_node.location().end_offset(),
+                            false,
+                        );
+                    }),
+                );
+            }
+        }),
+    );
+}
+
+fn format_block_local_variable_node(
+    ps: &mut dyn ConcreteParserState,
+    block_local_variable_node: prism::BlockLocalVariableNode,
+) {
+    handle_string_at_offset(
+        ps,
+        const_to_string(block_local_variable_node.name()),
+        block_local_variable_node.location().start_offset(),
     );
 }
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -141,7 +141,7 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::MatchRequiredNode { .. } => todo!(),
         Node::MatchWriteNode { .. } => todo!(),
         Node::MissingNode { .. } => todo!(),
-        Node::ModuleNode { .. } => todo!(),
+        Node::ModuleNode { .. } => format_module_node(ps, node.as_module_node().unwrap()),
         Node::MultiTargetNode { .. } => todo!(),
         Node::MultiWriteNode { .. } => todo!(),
         Node::NextNode { .. } => todo!(),
@@ -260,6 +260,34 @@ fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassN
             true,
             Box::new(|ps| {
                 if let Some(body) = class_node.body() {
+                    format_node(ps, body);
+                }
+            }),
+        )
+    }));
+
+    ps.with_start_of_line(
+        true,
+        Box::new(|ps| {
+            ps.emit_end();
+        }),
+    );
+}
+
+fn format_module_node(ps: &mut dyn ConcreteParserState, module_node: prism::ModuleNode) {
+    ps.emit_module_keyword();
+    ps.emit_space();
+    ps.with_start_of_line(
+        false,
+        Box::new(|ps| format_node(ps, module_node.constant_path())),
+    );
+    ps.emit_newline();
+
+    ps.new_block(Box::new(|ps| {
+        ps.with_start_of_line(
+            true,
+            Box::new(|ps| {
+                if let Some(body) = module_node.body() {
                     format_node(ps, body);
                 }
             }),

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -48,7 +48,7 @@ fixture!(
 // fixture!(test_small_alias_bare_kw, "small/alias_bare_kw");
 // fixture!(test_small_alias_equal, "small/alias_equal");
 // fixture!(test_small_alias_string_symbol, "small/alias_string_symbol");
-// fixture!(test_small_all_method_blocks, "small/all_method_blocks");
+fixture!(test_small_all_method_blocks, "small/all_method_blocks");
 // fixture!(test_small_and_or, "small/and_or");
 // fixture!(test_small_anonymous_blockarg, "small/anonymous_blockarg");
 // fixture!(test_small_aref_field, "small/aref_field");
@@ -241,7 +241,7 @@ fixture!(test_small_defs_kw, "small/defs_kw");
 //     "small/empty_string_literal"
 // );
 // fixture!(test_small_end_block, "small/end_block");
-// fixture!(test_small_end_data, "small/end_data");
+fixture!(test_small_end_data, "small/end_data");
 fixture!(
     test_small_end_of_file_comments,
     "small/end_of_file_comments"
@@ -322,10 +322,10 @@ fixture!(test_small_long_blockvar, "small/long_blockvar");
 // fixture!(test_small_massign, "small/massign");
 // fixture!(test_small_massign_omg, "small/massign_omg");
 // fixture!(test_small_memoist, "small/memoist");
-// fixture!(
-//     test_small_method_add_block_command_call,
-//     "small/method_add_block_command_call"
-// );
+fixture!(
+    test_small_method_add_block_command_call,
+    "small/method_add_block_command_call"
+);
 // fixture!(test_small_method_annotation, "small/method_annotation");
 fixture!(
     test_small_method_call_with_trailing_comma,
@@ -335,7 +335,7 @@ fixture!(
 // fixture!(test_small_missing_parens, "small/missing_parens");
 // fixture!(test_small_mlhs_params, "small/mlhs_params");
 // fixture!(test_small_mlhs_paren, "small/mlhs_paren");
-// fixture!(test_small_more_breaks, "small/more_breaks");
+fixture!(test_small_more_breaks, "small/more_breaks");
 // fixture!(test_small_more_methods, "small/more_methods");
 // fixture!(test_small_mrhs_add_star_2, "small/mrhs_add_star_2");
 // fixture!(test_small_mrhs_add_star, "small/mrhs_add_star");
@@ -355,10 +355,10 @@ fixture!(
 //     test_small_multiline_chain_in_block,
 //     "small/multiline_chain_in_block"
 // );
-// fixture!(
-//     test_small_multiline_chained_call,
-//     "small/multiline_chained_call"
-// );
+fixture!(
+    test_small_multiline_chained_call,
+    "small/multiline_chained_call"
+);
 // fixture!(test_small_multiline_defs, "small/multiline_defs");
 // fixture!(
 //     test_small_multiline_method_call_with_block,
@@ -489,10 +489,10 @@ fixture!(
     "small/start_of_file_comments"
 );
 // fixture!(test_small_static_call, "small/static_call");
-// fixture!(
-//     test_small_stmt_followed_by_do_block,
-//     "small/stmt_followed_by_do_block"
-// );
+fixture!(
+    test_small_stmt_followed_by_do_block,
+    "small/stmt_followed_by_do_block"
+);
 // fixture!(test_small_string_concat, "small/string_concat");
 // fixture!(
 //     test_small_string_concat_indent,
@@ -539,7 +539,7 @@ fixture!(
 //     test_small_super_with_trailing_comma,
 //     "small/super_with_trailing_comma"
 // );
-// fixture!(test_small_symbol_arg, "small/symbol_arg");
+fixture!(test_small_symbol_arg, "small/symbol_arg");
 fixture!(test_small_symbol_op, "small/symbol_op");
 // fixture!(test_small_ternary, "small/ternary");
 // fixture!(test_small_to_proc_operator, "small/to_proc_operator");

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -202,7 +202,7 @@ fixture!(
     test_small_const_path_ref_class_definition,
     "small/const_path_ref_class_definition"
 );
-// fixture!(test_small_curly_line_breaking, "small/curly_line_breaking");
+fixture!(test_small_curly_line_breaking, "small/curly_line_breaking");
 // fixture!(test_small_cursed_call_01, "small/cursed_call_01");
 // fixture!(test_small_cvar, "small/cvar");
 fixture!(test_small_cvar_symbol, "small/cvar_symbol");
@@ -229,7 +229,7 @@ fixture!(test_small_defs_kw, "small/defs_kw");
 // );
 // fixture!(test_small_empty_arg_paren, "small/empty_arg_paren");
 // fixture!(test_small_empty_array, "small/empty_array");
-// fixture!(test_small_empty_block, "small/empty_block");
+fixture!(test_small_empty_block, "small/empty_block");
 // fixture!(test_small_empty_comments, "small/empty_comments");
 // fixture!(test_small_empty_heredocs, "small/empty_heredocs");
 // fixture!(
@@ -318,7 +318,7 @@ fixture!(test_small_long_blockvar, "small/long_blockvar");
 // fixture!(test_small_many_opassigns, "small/many_opassigns");
 // fixture!(test_small_many_splats, "small/many_splats");
 // fixture!(test_small_many_weird_args, "small/many_weird_args");
-// fixture!(test_small_map_curly, "small/map_curly");
+fixture!(test_small_map_curly, "small/map_curly");
 // fixture!(test_small_massign, "small/massign");
 // fixture!(test_small_massign_omg, "small/massign_omg");
 // fixture!(test_small_memoist, "small/memoist");
@@ -431,7 +431,7 @@ fixture!(
 );
 // fixture!(test_small_procs, "small/procs");
 // fixture!(test_small_quoted_heredoc, "small/quoted_heredoc");
-// fixture!(test_small_raise_star, "small/raise_star");
+fixture!(test_small_raise_star, "small/raise_star");
 // fixture!(test_small_rationals, "small/rationals");
 // fixture!(test_small_redo, "small/redo");
 // fixture!(test_small_regexp_literal, "small/regexp_literal");

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -308,7 +308,7 @@ fixture!(test_small_kwargs_multiline, "small/kwargs_multiline");
 //     "small/list_like_things_with_comments"
 // );
 // fixture!(test_small_literals_newlines, "small/literals_newlines");
-// fixture!(test_small_long_blockvar, "small/long_blockvar");
+fixture!(test_small_long_blockvar, "small/long_blockvar");
 // fixture!(
 //     test_small_long_line_with_indentation,
 //     "small/long_line_with_indentation"


### PR DESCRIPTION
What it says -- this adds support for do/end and brace blocks (and also modules, since I needed them for a test case) with Prism. There may be some edge cases still left around, since I know brace blocks in particular are kinda a disaster in the Ripper version, but I think this gets us most of the way there, and we can iterate on those edge cases later.