### PR TITLE
Use github hosted ARM runners and remove cross-compilation infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: native
           - os: ubuntu-22.04
-            target: native
           - os: macos-latest
-            target: native
-          - os: ubuntu-22.04
-            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-22.04-arm
     steps:
     - uses: actions/checkout@v2
       with:
@@ -81,17 +77,15 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-        key: ${{ runner.os }}-${{ matrix.target }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
     - if: runner.os == 'macOS'
       run: |
         brew install automake bison
         brew link bison --force
         echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
     - run: ./script/test.sh
-      env:
-        TARGET: ${{ matrix.target }}
     - uses: actions/upload-artifact@v4
       with:
-        name: rubyfmt-artifact-${{ matrix.os }}-${{ matrix.target }}
-        path: target/${{ matrix.target == 'native' && 'release' || format('{0}/release', matrix.target) }}/rubyfmt-main
+        name: rubyfmt-artifact-${{ matrix.os }}
+        path: target/release/rubyfmt-main
 

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -34,11 +34,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            target: native
           - os: macos-latest
-            target: native
-          - os: ubuntu-22.04
-            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v2
         with:
@@ -61,11 +58,9 @@ jobs:
           brew install automake bison
           echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
       - run: ./script/make_release
-        env:
-          TARGET: ${{ matrix.target }}
       - uses: actions/upload-artifact@v4
         with:
-          name: rubyfmt-release-artifact-${{ matrix.os }}-${{ matrix.target }}
+          name: rubyfmt-release-artifact-${{ matrix.os }}
           path: rubyfmt-*.tar.gz
   source-release:
     runs-on: macos-latest
@@ -98,13 +93,13 @@ jobs:
           name: rubyfmt-source-release
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-ubuntu-22.04-aarch64-unknown-linux-gnu
+          name: rubyfmt-release-artifact-ubuntu-22.04-arm
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-ubuntu-22.04-native
+          name: rubyfmt-release-artifact-ubuntu-22.04
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-macos-latest-native
+          name: rubyfmt-release-artifact-macos-latest
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,11 +18,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            target: native
           - os: macos-latest
-            target: native
-          - os: ubuntu-22.04
-            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v2
         with:
@@ -45,11 +42,9 @@ jobs:
           brew install automake bison
           echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
       - run: ./script/make_release
-        env:
-          TARGET: ${{ matrix.target }}
       - uses: actions/upload-artifact@v4
         with:
-          name: rubyfmt-release-artifact-${{ matrix.os }}-${{ matrix.target }}
+          name: rubyfmt-release-artifact-${{ matrix.os }}
           path: rubyfmt-*.tar.gz
   source-release:
     runs-on: macos-latest
@@ -78,13 +73,13 @@ jobs:
           name: rubyfmt-source-release
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-ubuntu-22.04-native
+          name: rubyfmt-release-artifact-ubuntu-22.04
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-macos-latest-native
+          name: rubyfmt-release-artifact-macos-latest
       - uses: actions/download-artifact@v4
         with:
-          name: rubyfmt-release-artifact-ubuntu-22.04-aarch64-unknown-linux-gnu
+          name: rubyfmt-release-artifact-ubuntu-22.04-arm
       - name: Ship It 🚢
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/librubyfmt/build.rs
+++ b/librubyfmt/build.rs
@@ -154,22 +154,6 @@ fn run_configure(ruby_checkout_path: &Path) -> Output {
 
     command.arg("--without-gmp").arg("--disable-jit-support");
 
-    // This is gross, because it's very limited, but it is the simplest
-    // thing we can do, and calling other build systems inside build systems
-    // is destined to be gross anyway.
-    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-    if env::var("CARGO_CFG_TARGET_ARCH")
-        .map(|v| v == "aarch64")
-        .unwrap_or(false)
-    {
-        command
-            .arg("--target=aarch64-unknown-linux-gnu")
-            .arg("--host=x86_64")
-            .env("CC", "aarch64-linux-gnu-gcc")
-            .env("AR", "aarch64-linux-gnu-ar")
-            .env("RANLIB", "aarch64-linux-gnu-ranlib");
-    }
-
     let o = command.current_dir(ruby_checkout_path).status()?;
     check_process_success("./configure", o)
 }

--- a/script/make_release
+++ b/script/make_release
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 # if darwin, add PATH="/usr/local/opt/bison/bin:$PATH"
 if [[ $OSTYPE == "darwin"* ]]; then
-    export PATH="/opt/homebrew/opt/bison/bin:$PATH"
+  export PATH="/opt/homebrew/opt/bison/bin:$PATH"
 fi
 bison --version
 
@@ -15,45 +15,12 @@ rm -rf "${RELEASE_DIR}"
 
 mkdir -p "${RELEASE_DIR}"
 
-target="${TARGET:-native}"
+cargo build
+cargo build --release
 
-case "$target" in
-  native)
-    cargo build
-    cargo build --release
-
-    release_tarball_os="$(uname -s)"
-    release_tarball_arch="$(uname -m)"
-    cargo_target_dir_prefix=""
-    ;;
-  aarch64-unknown-linux-gnu)
-    sudo apt-get update
-    sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross
-
-    env BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu="--sysroot=/usr/aarch64-linux-gnu" \
-      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-      CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
-      TARGET_CC=aarch64-linux-gnu-gcc \
-      TARGET_AR=aarch64-linux-gnu-ar \
-      cargo build --target aarch64-unknown-linux-gnu
-
-    env BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu="--sysroot=/usr/aarch64-linux-gnu" \
-      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-      CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
-      TARGET_CC=aarch64-linux-gnu-gcc \
-      TARGET_AR=aarch64-linux-gnu-ar \
-      cargo build --release --target aarch64-unknown-linux-gnu
-
-    cargo_target_dir_prefix="aarch64-unknown-linux-gnu/"
-    # This is kind of a hack, since we're assuming we're on a Linux host.
-    release_tarball_os="Linux"
-    release_tarball_arch="aarch64"
-    ;;
-  *)
-    echo "Unknown cross-compilation target $target"
-    exit 1
-    ;;
-esac
+release_tarball_os="$(uname -s)"
+release_tarball_arch="$(uname -m)"
+cargo_target_dir_prefix=""
 
 cargo_dir="target/${cargo_target_dir_prefix}"
 cp "${cargo_dir}release/rubyfmt-main" "${RELEASE_DIR}/rubyfmt"
@@ -63,16 +30,10 @@ pwd
 cp RELEASE_README.md "${RELEASE_DIR}/RELEASE_README"
 
 # check the binary
-case "$target" in
-  native)
-    RES=$(echo 'a(1)' | "${RELEASE_DIR}/rubyfmt")
-    if [ "$RES" != "a(1)" ]; then
-      echo "formatting failed"
-      exit 1
-    fi
-    ;;
-  *)
-    ;;
-esac
+RES=$(echo 'a(1)' | "${RELEASE_DIR}/rubyfmt")
+if [ "$RES" != "a(1)" ]; then
+  echo "formatting failed"
+  exit 1
+fi
 
 tar -cvz -f "rubyfmt-${TAG}-${release_tarball_os}-${release_tarball_arch}.tar.gz" "${RELEASE_DIR}"

--- a/script/test.sh
+++ b/script/test.sh
@@ -4,31 +4,5 @@ set -euxo pipefail
 rm -rf tmp/
 source ./script/functions.sh
 
-target="${TARGET:-native}"
-
-case "$target" in
-  native)
-    cargo build --release
-    ;;
-  aarch64-unknown-linux-gnu)
-    sudo apt-get update
-    sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross
-
-    env BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu="--sysroot=/usr/aarch64-linux-gnu" \
-      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-      CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
-      TARGET_CC=aarch64-linux-gnu-gcc \
-      TARGET_AR=aarch64-linux-gnu-ar \
-      cargo build --release --target aarch64-unknown-linux-gnu
-
-    # Don't try to test things: even with QEMU support, it would take a long time.
-    exit 0
-    ;;
-  *)
-    echo "Unknown cross-compilation target $target"
-    exit 1
-    ;;
-esac
-
 uname -a
 cargo test --release


### PR DESCRIPTION
A while back when we needed ARM builds at Stripe, there wasn't yet a Github-hosted ARM runner, so #436 added bits to cross-compile from x86 Linux. Last year, GH created an [ARM Linux runner](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-22-image.md) that is [now available to the public](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/), so we can just use that!

The main benefit for us, aside from tooling simplicity, is that our previous cross-compilation infra didn't actually run tests on arm, so we were sort of just assuming that the cross-compiled binaries worked correctly (which, thankfully, they always did!). This let's us actually run tests on ARM, which is an extra layer of security.

This PR removes all the cross-compilation bits and instead replaces them with a plain ol' `ubuntu-22.04-arm` runner. I can't really test the preview-release and release actions, but all that changed is the artifact names, which I think will be easy enough to fix if things go south.