### PR TITLE
Run speed up `clippy` CI job by switching to `macos-latest` runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           args: --all -- --check
 
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
I've noticed that compilation on `macos` runners is significantly faster than on the other `ubuntu` runners, and the `clippy` job doesn't depend on the machine type at all, so switching over to `macos` gets faster results For Free<sup>TM</sup>.