### PR TITLE
Handle source encoding literals in Prism

### DIFF
--- a/fixtures/small/source_keywords_actual.rb
+++ b/fixtures/small/source_keywords_actual.rb
@@ -1,0 +1,5 @@
+__ENCODING__
+
+__FILE__
+
+__LINE__

--- a/fixtures/small/source_keywords_expected.rb
+++ b/fixtures/small/source_keywords_expected.rb
@@ -1,0 +1,5 @@
+__ENCODING__
+
+__FILE__
+
+__LINE__

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2085,24 +2085,36 @@ fn format_singleton_class_node(
 }
 
 fn format_source_encoding_node(
-    _ps: &mut dyn ConcreteParserState,
-    _source_encoding_node: prism::SourceEncodingNode,
+    ps: &mut dyn ConcreteParserState,
+    source_encoding_node: prism::SourceEncodingNode,
 ) {
-    todo!()
+    handle_string_at_offset(
+        ps,
+        "__ENCODING__".to_string(),
+        source_encoding_node.location().start_offset(),
+    );
 }
 
 fn format_source_file_node(
-    _ps: &mut dyn ConcreteParserState,
-    _source_file_node: prism::SourceFileNode,
+    ps: &mut dyn ConcreteParserState,
+    source_file_node: prism::SourceFileNode,
 ) {
-    todo!()
+    handle_string_at_offset(
+        ps,
+        "__FILE__".to_string(),
+        source_file_node.location().start_offset(),
+    );
 }
 
 fn format_source_line_node(
-    _ps: &mut dyn ConcreteParserState,
-    _source_line_node: prism::SourceLineNode,
+    ps: &mut dyn ConcreteParserState,
+    source_line_node: prism::SourceLineNode,
 ) {
-    todo!()
+    handle_string_at_offset(
+        ps,
+        "__LINE__".to_string(),
+        source_line_node.location().start_offset(),
+    );
 }
 
 fn format_super_node(_ps: &mut dyn ConcreteParserState, _super_node: prism::SuperNode) {

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -468,6 +468,7 @@ fixture!(
     test_small_single_quoted_string_with_embexpr,
     "small/single_quoted_string_with_embexpr"
 );
+fixture!(test_small_source_keywords, "small/source_keywords");
 fixture!(
     test_small_single_quoted_string_with_slash_escape,
     "small/single_quoted_string_with_slash_escape"

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -470,6 +470,7 @@ fixture!(
     test_small_single_quoted_string_with_embexpr,
     "small/single_quoted_string_with_embexpr"
 );
+fixture!(test_small_source_keywords, "small/source_keywords");
 fixture!(
     test_small_single_quoted_string_with_slash_escape,
     "small/single_quoted_string_with_slash_escape"


### PR DESCRIPTION
On the tin -- in Ripper `__ENCODING__`, `__FILE__`, and `__LINE__` are just keywords (`kw` nodes), but in Prism these are their own nodes, so this PR handles those nodes.