### PR TITLE
Format super nodes with Prism

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -737,8 +737,7 @@ fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassN
     );
 
     if let Some(superclass) = class_node.superclass() {
-        ps.emit_ident("<".to_string());
-        ps.emit_space();
+        ps.emit_ident(" < ".to_string());
         ps.with_start_of_line(
             false,
             Box::new(|ps| {
@@ -1677,10 +1676,37 @@ fn format_forwarding_parameter_node(
 }
 
 fn format_forwarding_super_node(
-    _ps: &mut dyn ConcreteParserState,
-    _forwarding_super_node: prism::ForwardingSuperNode,
+    ps: &mut dyn ConcreteParserState,
+    forwarding_super_node: prism::ForwardingSuperNode,
 ) {
-    todo!()
+    ps.emit_ident("super".to_string());
+    if let Some(block) = forwarding_super_node.block() {
+        ps.emit_space();
+        format_block_node(ps, block);
+    }
+}
+
+fn format_super_node(ps: &mut dyn ConcreteParserState, super_node: prism::SuperNode) {
+    ps.emit_ident("super".to_string());
+    // Note that we always emit parens for SuperNodes,
+    // since they're distinct from ForwardingSuperNode which never use parens
+    ps.with_start_of_line(
+        false,
+        Box::new(|ps| {
+            ps.breakable_of(
+                BreakableDelims::for_method_call(),
+                Box::new(|ps| {
+                    if let Some(arguments) = super_node.arguments() {
+                        format_arguments_node(ps, arguments);
+                    }
+                }),
+            );
+        }),
+    );
+    if let Some(block) = super_node.block() {
+        ps.emit_space();
+        ps.with_start_of_line(false, Box::new(|ps| format_node(ps, block)));
+    }
 }
 
 fn format_global_variable_and_write_node(
@@ -2135,10 +2161,6 @@ fn format_source_line_node(
         "__LINE__".to_string(),
         source_line_node.location().start_offset(),
     );
-}
-
-fn format_super_node(_ps: &mut dyn ConcreteParserState, _super_node: prism::SuperNode) {
-    todo!()
 }
 
 fn format_self_node(ps: &mut dyn ConcreteParserState, _self_node: prism::SelfNode) {

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -145,7 +145,7 @@ fixture!(test_small_blockarg, "small/blockarg");
 // fixture!(test_small_breaks, "small/breaks");
 // fixture!(test_small_cannibalization_1, "small/cannibalization_1");
 // fixture!(test_small_cannibalization_2, "small/cannibalization_2");
-// fixture!(test_small_cannibalization_3, "small/cannibalization_3");
+fixture!(test_small_cannibalization_3, "small/cannibalization_3");
 fixture!(test_small_cannibalization_4, "small/cannibalization_4");
 // fixture!(test_small_case, "small/case");
 // fixture!(test_small_case_else, "small/case_else");
@@ -236,10 +236,10 @@ fixture!(test_small_double_splat, "small/double_splat");
 fixture!(test_small_empty_block, "small/empty_block");
 // fixture!(test_small_empty_comments, "small/empty_comments");
 // fixture!(test_small_empty_heredocs, "small/empty_heredocs");
-// fixture!(
-//     test_small_empty_module_comments,
-//     "small/empty_module_comments"
-// );
+fixture!(
+    test_small_empty_module_comments,
+    "small/empty_module_comments"
+);
 fixture!(
     test_small_empty_string_literal,
     "small/empty_string_literal"
@@ -525,25 +525,25 @@ fixture!(test_small_string_escapes, "small/string_escapes");
 //     test_small_string_with_embexpr_dyna_symbol,
 //     "small/string_with_embexpr_dyna_symbol"
 // );
-// fixture!(test_small_super_comment, "small/super_comment");
-// fixture!(test_small_super_in_call_chain, "small/super_in_call_chain");
-// fixture!(
-//     test_small_super_keyword_comment_ordering,
-//     "small/super_keyword_comment_ordering"
-// );
-// fixture!(
-//     test_small_super_keyword_comment_ordering_spaces,
-//     "small/super_keyword_comment_ordering_spaces"
-// );
-// fixture!(test_small_super_with_block, "small/super_with_block");
-// fixture!(
-//     test_small_super_with_empty_paren,
-//     "small/super_with_empty_paren"
-// );
-// fixture!(
-//     test_small_super_with_trailing_comma,
-//     "small/super_with_trailing_comma"
-// );
+fixture!(test_small_super_comment, "small/super_comment");
+fixture!(test_small_super_in_call_chain, "small/super_in_call_chain");
+fixture!(
+    test_small_super_keyword_comment_ordering,
+    "small/super_keyword_comment_ordering"
+);
+fixture!(
+    test_small_super_keyword_comment_ordering_spaces,
+    "small/super_keyword_comment_ordering_spaces"
+);
+fixture!(test_small_super_with_block, "small/super_with_block");
+fixture!(
+    test_small_super_with_empty_paren,
+    "small/super_with_empty_paren"
+);
+fixture!(
+    test_small_super_with_trailing_comma,
+    "small/super_with_trailing_comma"
+);
 fixture!(test_small_symbol_arg, "small/symbol_arg");
 fixture!(test_small_symbol_op, "small/symbol_op");
 // fixture!(test_small_ternary, "small/ternary");
@@ -587,7 +587,7 @@ fixture!(
 //     "small/yield_keyword_comment_ordering_spaces"
 // );
 // fixture!(test_small_yield_with_paren, "small/yield_with_paren");
-// fixture!(test_small_zsuper, "small/zsuper");
+fixture!(test_small_zsuper, "small/zsuper");
 
 // /*
 //    Large Fixtures


### PR DESCRIPTION
What it says -- this adds support for `super` nodes, which in Prism are two separate node types: `ForwardingSuperNode` which is `super` without parens, and `SuperNode` which is `super()` with parens (and possibly arguments etc.)