### PR TITLE
Fix class and module end comment placement in Prism impls

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -737,8 +737,7 @@ fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassN
     );
 
     if let Some(superclass) = class_node.superclass() {
-        ps.emit_ident("<".to_string());
-        ps.emit_space();
+        ps.emit_ident(" < ".to_string());
         ps.with_start_of_line(
             false,
             Box::new(|ps| {
@@ -746,12 +745,12 @@ fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassN
             }),
         );
     }
-    ps.emit_newline();
 
     ps.new_block(Box::new(|ps| {
         ps.with_start_of_line(
             true,
             Box::new(|ps| {
+                ps.emit_newline();
                 if let Some(body) = class_node.body() {
                     format_node(ps, body);
                 }
@@ -816,12 +815,12 @@ fn format_module_node(ps: &mut dyn ConcreteParserState, module_node: prism::Modu
         false,
         Box::new(|ps| format_node(ps, module_node.constant_path())),
     );
-    ps.emit_newline();
 
     ps.new_block(Box::new(|ps| {
         ps.with_start_of_line(
             true,
             Box::new(|ps| {
+                ps.emit_newline();
                 if let Some(body) = module_node.body() {
                     format_node(ps, body);
                 }

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -151,7 +151,7 @@ fixture!(test_small_cannibalization_4, "small/cannibalization_4");
 // fixture!(test_small_case_else, "small/case_else");
 // fixture!(test_small_case_multi, "small/case_multi");
 // fixture!(test_small_character_literal, "small/character_literal");
-// fixture!(test_small_class_comment, "small/class_comment");
+fixture!(test_small_class_comment, "small/class_comment");
 // fixture!(
 //     test_small_class_methods_respect_parens,
 //     "small/class_methods_respect_parens"
@@ -165,14 +165,14 @@ fixture!(test_small_commas_trailing, "small/commas_trailing");
 //     test_small_comment_in_block_inside_array,
 //     "small/comment_in_block_inside_array"
 // );
-// fixture!(
-//     test_small_comment_in_module_are_tight,
-//     "small/comment_in_module_are_tight"
-// );
-// fixture!(
-//     test_small_comment_on_inheritence,
-//     "small/comment_on_inheritence"
-// );
+fixture!(
+    test_small_comment_in_module_are_tight,
+    "small/comment_in_module_are_tight"
+);
+fixture!(
+    test_small_comment_on_inheritence,
+    "small/comment_on_inheritence"
+);
 // fixture!(
 //     test_small_comments_at_indentation_changes,
 //     "small/comments_at_indentation_changes"
@@ -236,10 +236,10 @@ fixture!(test_small_double_splat, "small/double_splat");
 fixture!(test_small_empty_block, "small/empty_block");
 // fixture!(test_small_empty_comments, "small/empty_comments");
 // fixture!(test_small_empty_heredocs, "small/empty_heredocs");
-// fixture!(
-//     test_small_empty_module_comments,
-//     "small/empty_module_comments"
-// );
+fixture!(
+    test_small_empty_module_comments,
+    "small/empty_module_comments"
+);
 fixture!(
     test_small_empty_string_literal,
     "small/empty_string_literal"


### PR DESCRIPTION
This corrects the comment placement for comments at the end of class and module implementations by emitting the body's newline at the correct indentation level, since that indentation level is stored and used to determine the indentation level for comments.