### PR TITLE
Fix comments in empty blocks in Prism impl

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1286,8 +1286,12 @@ fn format_block_node(ps: &mut dyn ConcreteParserState, block_node: prism::BlockN
                 format_node(ps, block_parameters);
             }
 
+            // Even if there's no body, we still need a newline for
+            // comments to render appropriately. `ps.emit_end` will handle
+            // checking for this newline and deduping it appropriately.
+            ps.emit_newline();
+
             if let Some(body) = block_node.body() {
-                ps.emit_newline();
                 ps.with_start_of_line(
                     true,
                     Box::new(|ps| {
@@ -1319,7 +1323,7 @@ fn format_block_node(ps: &mut dyn ConcreteParserState, block_node: prism::BlockN
                         .map(|statements_node| statements_node.body().iter().count() > 1)
                         .unwrap_or(false);
                     if has_multiple_statements {
-                        ps.emit_newline();
+                        ps.emit_soft_newline();
                         ps.with_start_of_line(
                             true,
                             Box::new(|ps| {
@@ -1341,11 +1345,21 @@ fn format_block_node(ps: &mut dyn ConcreteParserState, block_node: prism::BlockN
                             }),
                         );
                     }
+                } else if ps.has_comment_in_offset_span(
+                    block_node.opening_loc().start_offset(),
+                    block_node.closing_loc().end_offset(),
+                ) {
+                    // Even if there's no `body` node -- that is, there are no statements in the block --
+                    // we still need to look for comments and multiline if they're present.
+                    // Note that this is a soft newline, which are special-cased in breakables to correctly handle
+                    // comments, so we use one here instead of a hard newline.
+                    ps.emit_soft_newline();
                 }
 
                 // `inline_breakable_of` doesn't handle the indentation for the closing delimeter for us.
                 ps.dedent(Box::new(|ps| ps.emit_soft_indent()));
                 ps.wind_dumping_comments_until_offset(block_node.location().end_offset());
+                ps.shift_comments();
             }),
         );
     }

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -113,10 +113,10 @@ fixture!(
 // );
 // fixture!(test_small_block_spacing, "small/block_spacing");
 fixture!(test_small_blockarg, "small/blockarg");
-// fixture!(
-//     test_small_blocks_with_only_comments,
-//     "small/blocks_with_only_comments"
-// );
+fixture!(
+    test_small_blocks_with_only_comments,
+    "small/blocks_with_only_comments"
+);
 // fixture!(
 //     test_small_brace_blocks_with_no_args,
 //     "small/brace_blocks_with_no_args"


### PR DESCRIPTION
Blocks whose contents are only comments run into all sorts of weird edge cases, particularly with respect to [brace blocks](https://github.com/fables-tales/rubyfmt/blob/373338d1c356d7906c16a9d136549b36b24599e5/librubyfmt/src/format.rs#L2964-L2970). This PR handles those edge cases better, at least well enough to pass the fixtures we put specifically for those edge cases