### PR TITLE
Add a Cargo cache to the clippy CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
           toolchain: 1.85.0
           components: clippy
           override: true
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo clippy --all --all-features -- -D warnings
 
   lint:


### PR DESCRIPTION
The `clippy` CI action is currently the slowest by a good minute, and most of that time seems to just be spent compiling. The main difference I see is that the `clippy` action doesn't cache Cargo deps, whereas everything else does, so hopefully this will shave down that compilation time to be within the same ballpark as every other action.