### PR TITLE
Format rational and imaginary number literals with Prism

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1780,8 +1780,8 @@ fn format_if_node(_ps: &mut dyn ConcreteParserState, _if_node: prism::IfNode) {
     todo!()
 }
 
-fn format_imaginary_node(_ps: &mut dyn ConcreteParserState, _imaginary_node: prism::ImaginaryNode) {
-    todo!()
+fn format_imaginary_node(ps: &mut dyn ConcreteParserState, imaginary_node: prism::ImaginaryNode) {
+    ps.emit_ident(loc_to_string(imaginary_node.location()));
 }
 
 fn format_implicit_node(_ps: &mut dyn ConcreteParserState, _implicit_node: prism::ImplicitNode) {
@@ -2089,8 +2089,8 @@ fn format_range_node(_ps: &mut dyn ConcreteParserState, _range_node: prism::Rang
     todo!()
 }
 
-fn format_rational_node(_ps: &mut dyn ConcreteParserState, _rational_node: prism::RationalNode) {
-    todo!()
+fn format_rational_node(ps: &mut dyn ConcreteParserState, rational_node: prism::RationalNode) {
+    ps.emit_ident(loc_to_string(rational_node.location()));
 }
 
 fn format_redo_node(_ps: &mut dyn ConcreteParserState, _redo_node: prism::RedoNode) {

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -185,7 +185,7 @@ fixture!(
 //     test_small_comments_with_breaks,
 //     "small/comments_with_breaks"
 // );
-// fixture!(test_small_complex_numbers, "small/complex_numbers");
+fixture!(test_small_complex_numbers, "small/complex_numbers");
 // fixture!(test_small_complex_params, "small/complex_params");
 // fixture!(test_small_conditional, "small/conditional");
 // fixture!(test_small_conditional_assign, "small/conditional_assign");
@@ -436,7 +436,7 @@ fixture!(
 // fixture!(test_small_procs, "small/procs");
 // fixture!(test_small_quoted_heredoc, "small/quoted_heredoc");
 fixture!(test_small_raise_star, "small/raise_star");
-// fixture!(test_small_rationals, "small/rationals");
+fixture!(test_small_rationals, "small/rationals");
 // fixture!(test_small_redo, "small/redo");
 // fixture!(test_small_regexp_literal, "small/regexp_literal");
 // fixture!(test_small_req_optional_params, "small/req_optional_params");


### PR DESCRIPTION
On the tin -- this handles rational (`1.0r`) and imaginary numbers (`1.0i`) literals