### PR TITLE
Handle `ConstantWriteNode` in Prism

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1965,10 +1965,15 @@ fn format_constant_target_node(
 }
 
 fn format_constant_write_node(
-    _ps: &mut dyn ConcreteParserState,
-    _constant_write_node: prism::ConstantWriteNode,
+    ps: &mut dyn ConcreteParserState,
+    constant_write_node: prism::ConstantWriteNode,
 ) {
-    todo!()
+    ps.emit_ident(const_to_string(constant_write_node.name()));
+    ps.emit_op(" = ".to_string());
+    ps.with_start_of_line(
+        false,
+        Box::new(|ps| format_node(ps, constant_write_node.value())),
+    );
 }
 
 fn format_lambda_node(_ps: &mut dyn ConcreteParserState, _lambda_node: prism::LambdaNode) {

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -278,10 +278,10 @@ fixture!(test_small_gvar_symbol, "small/gvar_symbol");
 // );
 // fixture!(test_small_heredoc_method_call, "small/heredoc_method_call");
 fixture!(test_small_heredoc_with_call, "small/heredoc_with_call");
-// fixture!(
-//     test_small_heredoc_with_leading_newline,
-//     "small/heredoc_with_leading_newline"
-// );
+fixture!(
+    test_small_heredoc_with_leading_newline,
+    "small/heredoc_with_leading_newline"
+);
 // fixture!(test_small_heredocs, "small/heredocs");
 // fixture!(
 //     test_small_heredocs_ending_blocks,
@@ -296,7 +296,7 @@ fixture!(test_small_heredoc_with_call, "small/heredoc_with_call");
 //     test_small_if_without_extra_parts,
 //     "small/if_without_extra_parts"
 // );
-// fixture!(test_small_inline_comments, "small/inline_comments");
+fixture!(test_small_inline_comments, "small/inline_comments");
 // fixture!(test_small_inline_rescue, "small/inline_rescue");
 fixture!(test_small_ivar_symbol, "small/ivar_symbol");
 fixture!(test_small_kw_symbol, "small/kw_symbol");
@@ -655,7 +655,7 @@ fixture!(test_small_zsuper, "small/zsuper");
 //     test_concurrent_ruby_truffleruby_map_backend,
 //     "large/concurrent-ruby/truffleruby_map_backend"
 // );
-// fixture!(
-//     test_concurrent_ruby_version,
-//     "large/concurrent-ruby/version"
-// );
+fixture!(
+    test_concurrent_ruby_version,
+    "large/concurrent-ruby/version"
+);


### PR DESCRIPTION
On the tin -- there's a bunch of nodes that are basically the same thing (all of the *WriteNode), but I'm just doing them as they come up and are relevant for individual fixtures -- that will also help find any nodes that we don't have fixtures for.
