### PR TITLE
[prism] Fix line winding for method definition parens

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -856,27 +856,12 @@ fn format_def_node(ps: &mut dyn ConcreteParserState, def_node: prism::DefNode) {
         }),
     );
 
-    format_def_body(
-        ps,
-        def_node.parameters(),
-        def_node.body(),
-        def_node
-            .end_keyword_loc()
-            .map(|loc| loc.end_offset())
-            .unwrap(),
-        def_node.end_keyword_loc().is_some(),
-    );
+    format_def_body(ps, def_node);
 }
 
-fn format_def_body(
-    ps: &mut dyn ConcreteParserState,
-    parameters_node: Option<prism::ParametersNode>,
-    bodystmt: Option<prism::Node>,
-    end_offset: SourceOffset,
-    has_end_keyword: bool,
-) {
+fn format_def_body(ps: &mut dyn ConcreteParserState, def_node: prism::DefNode) {
     ps.new_scope(Box::new(|ps| {
-        if let Some(parameters_node) = parameters_node {
+        if let Some(parameters_node) = def_node.parameters() {
             ps.breakable_of(
                 BreakableDelims::for_method_call(),
                 Box::new(|ps| {
@@ -884,6 +869,11 @@ fn format_def_body(
                         false,
                         Box::new(|ps| {
                             format_parameters_node(ps, parameters_node);
+                            // If the parameters have parens, wind to the closing paren, since it may
+                            // be on its own line past the end of the params
+                            if let Some(rparen_loc) = def_node.rparen_loc() {
+                                ps.at_offset(rparen_loc.end_offset());
+                            }
                         }),
                     );
                 }),
@@ -893,13 +883,13 @@ fn format_def_body(
         ps.with_formatting_context(
             FormattingContext::Def,
             Box::new(|ps| {
-                if has_end_keyword {
+                if def_node.end_keyword_loc().is_some() {
                     ps.new_block(Box::new(|ps| {
                         ps.emit_newline();
                         ps.with_start_of_line(
                             true,
                             Box::new(|ps| {
-                                if let Some(body) = bodystmt {
+                                if let Some(body) = def_node.body() {
                                     format_node(ps, body);
                                 }
                             }),
@@ -913,7 +903,7 @@ fn format_def_body(
                     ps.with_start_of_line(
                         false,
                         Box::new(|ps| {
-                            if let Some(body) = bodystmt {
+                            if let Some(body) = def_node.body() {
                                 format_node(ps, body);
                             }
                         }),
@@ -923,11 +913,11 @@ fn format_def_body(
         );
     }));
 
-    if has_end_keyword {
+    if let Some(end_keyword_loc) = def_node.end_keyword_loc() {
         ps.with_start_of_line(
             true,
             Box::new(|ps| {
-                ps.wind_dumping_comments_until_offset(end_offset);
+                ps.wind_dumping_comments_until_offset(end_keyword_loc.end_offset());
                 ps.emit_end();
             }),
         );

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -214,10 +214,10 @@ fixture!(test_small_def_const, "small/def_const");
 fixture!(test_small_def_scope, "small/def_scope");
 fixture!(test_small_def_with_kw, "small/def_with_kw");
 // fixture!(test_small_defined, "small/defined");
-// fixture!(
-//     test_small_definitions_with_comments,
-//     "small/definitions_with_comments"
-// );
+fixture!(
+    test_small_definitions_with_comments,
+    "small/definitions_with_comments"
+);
 fixture!(test_small_defs_comment, "small/defs_comment");
 fixture!(test_small_defs_end_comment, "small/defs_end_comment");
 fixture!(test_small_defs_kw, "small/defs_kw");
@@ -372,10 +372,10 @@ fixture!(
 //     test_small_multiline_method_chain_with_arguments,
 //     "small/multiline_method_chain_with_arguments"
 // );
-// fixture!(
-//     test_small_multiline_method_params,
-//     "small/multiline_method_params"
-// );
+fixture!(
+    test_small_multiline_method_params,
+    "small/multiline_method_params"
+);
 fixture!(
     test_small_multiline_single_quotes,
     "small/multiline_single_quotes"


### PR DESCRIPTION
For method definitions, I originally had us update the offset at the end of the `ParametersNode`, but that offset != the offset of the closing parenthesis if there is one, e.g.

```ruby
def foo(
  a: # <--- We were winding here
) # <--- But we should wind to here
````

So this updates the implementation to also look for the closing paren if there is one.