### PR TITLE
[prism] Format optional keyword params

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2026,8 +2026,8 @@ fn format_next_node(_ps: &mut dyn ConcreteParserState, _next_node: prism::NextNo
     todo!()
 }
 
-fn format_nil_node(_ps: &mut dyn ConcreteParserState, _nil_node: prism::NilNode) {
-    todo!()
+fn format_nil_node(ps: &mut dyn ConcreteParserState, _nil_node: prism::NilNode) {
+    ps.emit_ident("nil".to_string());
 }
 
 fn format_no_keywords_parameter_node(
@@ -2052,10 +2052,17 @@ fn format_numbered_reference_read_node(
 }
 
 fn format_optional_keyword_parameter_node(
-    _ps: &mut dyn ConcreteParserState,
-    _optional_keyword_parameter_node: prism::OptionalKeywordParameterNode,
+    ps: &mut dyn ConcreteParserState,
+    optional_keyword_parameter_node: prism::OptionalKeywordParameterNode,
 ) {
-    todo!()
+    ps.emit_ident(const_to_string(optional_keyword_parameter_node.name()));
+    ps.emit_op(": ".to_string());
+    ps.with_start_of_line(
+        false,
+        Box::new(|ps| {
+            format_node(ps, optional_keyword_parameter_node.value());
+        }),
+    );
 }
 
 fn format_optional_parameter_node(

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -186,7 +186,7 @@ fixture!(
 //     "small/comments_with_breaks"
 // );
 // fixture!(test_small_complex_numbers, "small/complex_numbers");
-// fixture!(test_small_complex_params, "small/complex_params");
+fixture!(test_small_complex_params, "small/complex_params");
 // fixture!(test_small_conditional, "small/conditional");
 // fixture!(test_small_conditional_assign, "small/conditional_assign");
 // fixture!(
@@ -226,7 +226,7 @@ fixture!(test_small_defs_kw, "small/defs_kw");
 // fixture!(test_small_dot3, "small/dot3");
 // fixture!(test_small_dotcall, "small/dotcall");
 fixture!(test_small_double_splat, "small/double_splat");
-// fixture!(test_small_double_splat_def, "small/double_splat_def");
+fixture!(test_small_double_splat_def, "small/double_splat_def");
 // fixture!(
 //     test_small_dyna_symbol_with_escapes,
 //     "small/dyna_symbol_with_escapes"
@@ -300,7 +300,7 @@ fixture!(test_small_inline_comments, "small/inline_comments");
 // fixture!(test_small_inline_rescue, "small/inline_rescue");
 fixture!(test_small_ivar_symbol, "small/ivar_symbol");
 fixture!(test_small_kw_symbol, "small/kw_symbol");
-// fixture!(test_small_kwargs, "small/kwargs");
+fixture!(test_small_kwargs, "small/kwargs");
 fixture!(test_small_kwargs_multiline, "small/kwargs_multiline");
 // fixture!(test_small_lambda, "small/lambda");
 fixture!(


### PR DESCRIPTION
This formats optional keyword params (e.g. `foo(bar: 'baz')`) in the Prism implementation, plus `nil` to pass some test cases