### PR TITLE
🧹  Bump regex crate to 1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
  "bit-set",
  "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -589,13 +589,14 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.9",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -612,14 +613,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ctrlc = { version = "3.2", features = ["termination"] }
 libc = "0.2.71"
 ignore = "0.4.18"
 lazy_static = "1.4.0"
-regex = "1.6.0"
+regex = "1.11.1"
 rubyfmt = { path = "./librubyfmt" }
 serde = { version = "1.0", features = ["derive"] }
 similar = "2.1.0"

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -25,7 +25,7 @@ winapi = { version = "0.3", features = ["everything"] }
 
 [build-dependencies]
 cc = "1.0"
-regex = "1.6.0"
+regex = "1.11.1"
 
 [lib]
 name = "rubyfmt"


### PR DESCRIPTION
Similar to #508, this bumps the `regex` crate to its latest version, so that we only have to compile one version of `regex-syntax`