### PR TITLE
[ci] Add image "fingerprint" to Cargo cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,20 @@ jobs:
           toolchain: 1.85.0
           components: clippy
           override: true
+      - name: Generate system fingerprint for cache key
+        id: system-fingerprint
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            echo "SYS_FINGERPRINT=$(dpkg -l | md5sum | cut -d ' ' -f1)" >> $GITHUB_ENV
+          else
+            echo "SYS_FINGERPRINT=$(sw_vers | md5 | cut -d ' ' -f1)_$(brew list --versions | md5 | cut -d ' ' -f1)" >> $GITHUB_ENV
+          fi
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}-${{ env.SYS_FINGERPRINT }}
       - run: cargo clippy --all --all-features -- -D warnings
 
   lint:
@@ -78,12 +86,20 @@ jobs:
         toolchain: 1.85.0
         override: true
         target: aarch64-unknown-linux-gnu
+    - name: Generate system fingerprint for cache key
+      id: system-fingerprint
+      run: |
+        if [[ "$RUNNER_OS" == "Linux" ]]; then
+          echo "SYS_FINGERPRINT=$(dpkg -l | md5sum | cut -d ' ' -f1)" >> $GITHUB_ENV
+        else
+          echo "SYS_FINGERPRINT=$(sw_vers | md5 | cut -d ' ' -f1)_$(brew list --versions | md5 | cut -d ' ' -f1)" >> $GITHUB_ENV
+        fi
     - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-        key: ${{ runner.os }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}-${{ env.SYS_FINGERPRINT }}
     - if: runner.os == 'macOS'
       run: |
         brew install automake bison


### PR DESCRIPTION
One of our recent trunk builds failed because of some mysterious glibc version mismatch. Once I cleared the action cache, it started passing again, and while I couldn't track down a specific runner change that caused this, that implies to me that the underlying glibc might have been updated for the Ubuntu arm runner, but the cached version used the old version and failed when trying to link to a newer version.

To future-proof this, this PR adds a "fingerprint" to the cache key. The methodology for this is a little bit convoluted, if only because I couldn't find anything like an image sha or commit ID that's publicly available for runners, so what I did instead was to make a "fingerprint" of the OS version and a sha of all that images installed packages (with `dpkg` for linux and `brew` for mac), which hopefully should catch things like glibc changes.