### PR TITLE
Migrate to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 name = "rubyfmt-main"
 version = "0.11.0"
 authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 name = "rubyfmt-main"
 version = "0.11.0"
 authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rubyfmt"
 version = "0.11.0-pre"
 authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rubyfmt"
 version = "0.11.0-pre"
 authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/librubyfmt/ripper_deserialize/Cargo.toml
+++ b/librubyfmt/ripper_deserialize/Cargo.toml
@@ -3,7 +3,7 @@ name = "ripper_deserialize"
 version = "0.1.0"
 authors = ["Siân Griffin <sean@seantheprogrammer.com>"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 syn = { version = "2" }

--- a/librubyfmt/ripper_deserialize/Cargo.toml
+++ b/librubyfmt/ripper_deserialize/Cargo.toml
@@ -3,7 +3,7 @@ name = "ripper_deserialize"
 version = "0.1.0"
 authors = ["Siân Griffin <sean@seantheprogrammer.com>"]
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 syn = { version = "2" }

--- a/librubyfmt/ripper_deserialize/src/lib.rs
+++ b/librubyfmt/ripper_deserialize/src/lib.rs
@@ -6,8 +6,8 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::spanned::Spanned;
 use syn::Ident;
+use syn::spanned::Spanned;
 
 #[proc_macro_derive(RipperDeserialize, attributes(tag))]
 pub fn derive_deserialize(input: TokenStream) -> TokenStream {

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -813,7 +813,7 @@ pub fn format_dot(ps: &mut dyn ConcreteParserState, dot: DotTypeOrOp) {
             }
         }
         DotTypeOrOp::Period(p) => {
-            ps.on_line(p.2 .0);
+            ps.on_line(p.2.0);
             ps.emit_dot();
         }
         DotTypeOrOp::ColonColon(_) => {
@@ -1164,7 +1164,7 @@ pub fn format_begin(ps: &mut dyn ConcreteParserState, begin: Begin) {
     }
 
     let end_line = begin.1.end_line();
-    ps.on_line(begin.1 .0);
+    ps.on_line(begin.1.0);
 
     ps.emit_begin();
 
@@ -2438,7 +2438,7 @@ pub fn format_if(ps: &mut dyn ConcreteParserState, ifs: If) {
     ps.with_start_of_line(
         true,
         Box::new(|ps| {
-            ps.wind_dumping_comments_until_line(vifs.4 .1);
+            ps.wind_dumping_comments_until_line(vifs.4.1);
             ps.emit_end();
         }),
     );
@@ -2480,7 +2480,7 @@ pub fn format_binary(ps: &mut dyn ConcreteParserState, binary: Binary) {
     } else {
         // If we don't have it, use the line number of the binary operator
         // (which is always there, albeit possibly not what the user expects)
-        ps.on_line(binary.2 .1.start_line());
+        ps.on_line(binary.2.1.start_line());
     }
 
     ps.inline_breakable_of(
@@ -3325,7 +3325,7 @@ pub fn format_case(ps: &mut dyn ConcreteParserState, case: Case) {
         ps.wind_dumping_comments_until_line(end_line);
         ps.emit_newline();
     }
-    ps.on_line(case.3 .1);
+    ps.on_line(case.3.1);
 }
 
 pub fn format_retry(ps: &mut dyn ConcreteParserState, r: Retry) {

--- a/librubyfmt/src/lib.rs
+++ b/librubyfmt/src/lib.rs
@@ -38,12 +38,12 @@ mod util;
 
 use file_comments::FileComments;
 use parser_state::BaseParserState;
-use ruby_ops::{load_rubyfmt, ParseError, Parser, RipperTree};
+use ruby_ops::{ParseError, Parser, RipperTree, load_rubyfmt};
 
 #[cfg(debug_assertions)]
 use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
 
-extern "C" {
+unsafe extern "C" {
     pub fn Init_ripper();
     pub fn rb_gc_disable();
 }
@@ -116,7 +116,7 @@ pub fn format_buffer(buf: &str, use_prism: bool) -> Result<String, RichFormatErr
     Ok(String::from_utf8(output.into_inner()).expect("we never write invalid UTF-8"))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn rubyfmt_init() -> libc::c_int {
     init_logger();
     let res = ruby_ops::setup_ruby();
@@ -142,37 +142,37 @@ pub extern "C" fn rubyfmt_init() -> libc::c_int {
 /// available in the passed buffer pointer. It will also fail if the passed
 /// data isn't utf8.
 /// Please don't pass non-utf8 too small buffers.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn rubyfmt_format_buffer(
     ptr: *const u8,
     len: usize,
     err: *mut i64,
 ) -> *mut RubyfmtString {
-    let input = str::from_utf8_unchecked(slice::from_raw_parts(ptr, len));
+    let input = unsafe { str::from_utf8_unchecked(slice::from_raw_parts(ptr, len)) };
     let output = format_buffer(input, false);
     match output {
         Ok(o) => {
-            *err = FormatError::OK as i64;
+            unsafe { *err = FormatError::OK as i64 };
             Box::into_raw(Box::new(RubyfmtString(o.into_boxed_str())))
         }
         Err(e) => {
-            *err = e.as_format_error() as i64;
+            unsafe { *err = e.as_format_error() as i64 };
             std::ptr::null::<RubyfmtString>() as _
         }
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn rubyfmt_string_ptr(s: &RubyfmtString) -> *const u8 {
     s.0.as_ptr()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn rubyfmt_string_len(s: &RubyfmtString) -> usize {
     s.0.len()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn rubyfmt_string_free(rubyfmt_string: *mut RubyfmtString) {
     unsafe {
         drop(Box::from_raw(rubyfmt_string));
@@ -181,9 +181,10 @@ extern "C" fn rubyfmt_string_free(rubyfmt_string: *mut RubyfmtString) {
 
 // Safety: This function expects a functioning Ruby VM
 unsafe fn load_ripper() -> Result<(), ()> {
-    // trick ruby in to thinking ripper is already loaded
-    ruby::eval_str(
-        r#"
+    unsafe {
+        // trick ruby in to thinking ripper is already loaded
+        ruby::eval_str(
+            r#"
     $LOADED_FEATURES << "ripper.bundle"
     $LOADED_FEATURES << "ripper.so"
     $LOADED_FEATURES << "ripper.rb"
@@ -192,27 +193,28 @@ unsafe fn load_ripper() -> Result<(), ()> {
     $LOADED_FEATURES << "ripper/filter.rb"
     $LOADED_FEATURES << "ripper/lexer.rb"
     "#,
-    )?;
+        )?;
 
-    // init the ripper C module
-    Init_ripper();
+        // init the ripper C module
+        Init_ripper();
 
-    //load each ripper program
-    ruby::eval_str(include_str!("../ruby_checkout/ext/ripper/lib/ripper.rb"))?;
-    ruby::eval_str(include_str!(
-        "../ruby_checkout/ext/ripper/lib/ripper/core.rb"
-    ))?;
-    ruby::eval_str(include_str!(
-        "../ruby_checkout/ext/ripper/lib/ripper/lexer.rb"
-    ))?;
-    ruby::eval_str(include_str!(
-        "../ruby_checkout/ext/ripper/lib/ripper/filter.rb"
-    ))?;
-    ruby::eval_str(include_str!(
-        "../ruby_checkout/ext/ripper/lib/ripper/sexp.rb"
-    ))?;
+        //load each ripper program
+        ruby::eval_str(include_str!("../ruby_checkout/ext/ripper/lib/ripper.rb"))?;
+        ruby::eval_str(include_str!(
+            "../ruby_checkout/ext/ripper/lib/ripper/core.rb"
+        ))?;
+        ruby::eval_str(include_str!(
+            "../ruby_checkout/ext/ripper/lib/ripper/lexer.rb"
+        ))?;
+        ruby::eval_str(include_str!(
+            "../ruby_checkout/ext/ripper/lib/ripper/filter.rb"
+        ))?;
+        ruby::eval_str(include_str!(
+            "../ruby_checkout/ext/ripper/lib/ripper/sexp.rb"
+        ))?;
 
-    rb_gc_disable();
+        rb_gc_disable();
+    }
     Ok(())
 }
 

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -1,10 +1,10 @@
 use crate::comment_block::{CommentBlock, Merge};
 use crate::delimiters::BreakableDelims;
 use crate::file_comments::FileComments;
-use crate::format::{format_inner_string, StringType};
+use crate::format::{StringType, format_inner_string};
 use crate::heredoc_string::{HeredocKind, HeredocString};
 use crate::line_tokens::*;
-use crate::render_queue_writer::{RenderQueueWriter, MAX_LINE_LENGTH};
+use crate::render_queue_writer::{MAX_LINE_LENGTH, RenderQueueWriter};
 use crate::render_targets::{
     AbstractTokenTarget, BaseQueue, BreakableCallChainEntry, BreakableEntry, MultilineHandling,
 };

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -123,14 +123,24 @@ impl RenderQueueWriter {
             }
 
             if let Some(
-                [&ConcreteLineToken::HeredocClose { .. }, &ConcreteLineToken::HardNewLine, &ConcreteLineToken::Indent { .. }, &ConcreteLineToken::HardNewLine],
+                [
+                    &ConcreteLineToken::HeredocClose { .. },
+                    &ConcreteLineToken::HardNewLine,
+                    &ConcreteLineToken::Indent { .. },
+                    &ConcreteLineToken::HardNewLine,
+                ],
             ) = accum.last::<4>()
             {
                 accum.pop_heredoc_mistake();
             }
 
             if let Some(
-                [&ConcreteLineToken::End, &ConcreteLineToken::HardNewLine, &ConcreteLineToken::Indent { .. }, x],
+                [
+                    &ConcreteLineToken::End,
+                    &ConcreteLineToken::HardNewLine,
+                    &ConcreteLineToken::Indent { .. },
+                    x,
+                ],
             ) = accum.last::<4>()
             {
                 if x.is_in_need_of_a_trailing_blankline() {
@@ -147,7 +157,15 @@ impl RenderQueueWriter {
             }
 
             if let Some(
-                [&ConcreteLineToken::End, &ConcreteLineToken::AfterCallChain, &ConcreteLineToken::HardNewLine, &ConcreteLineToken::Indent { .. }, x, maybe_space, maybe_def],
+                [
+                    &ConcreteLineToken::End,
+                    &ConcreteLineToken::AfterCallChain,
+                    &ConcreteLineToken::HardNewLine,
+                    &ConcreteLineToken::Indent { .. },
+                    x,
+                    maybe_space,
+                    maybe_def,
+                ],
             ) = accum.last::<7>()
             {
                 match x {
@@ -176,16 +194,30 @@ impl RenderQueueWriter {
             }
 
             if let Some(
-                [&ConcreteLineToken::HeredocClose { .. }, &ConcreteLineToken::HardNewLine, &ConcreteLineToken::Indent { .. }, &ConcreteLineToken::Indent { .. }, &ConcreteLineToken::Delim { .. }
-                | &ConcreteLineToken::Dot
-                | &ConcreteLineToken::DirectPart { .. }],
+                [
+                    &ConcreteLineToken::HeredocClose { .. },
+                    &ConcreteLineToken::HardNewLine,
+                    &ConcreteLineToken::Indent { .. },
+                    &ConcreteLineToken::Indent { .. },
+                    &ConcreteLineToken::Delim { .. }
+                    | &ConcreteLineToken::Dot
+                    | &ConcreteLineToken::DirectPart { .. },
+                ],
             ) = accum.last::<5>()
             {
                 accum.fix_heredoc_duplicate_indent_mistake();
             }
 
             if let Some(
-                [&ConcreteLineToken::HeredocClose { .. }, &ConcreteLineToken::HardNewLine, &ConcreteLineToken::Indent { .. }, &ConcreteLineToken::Delim { .. }, &ConcreteLineToken::Comma, &ConcreteLineToken::HardNewLine, &ConcreteLineToken::HardNewLine],
+                [
+                    &ConcreteLineToken::HeredocClose { .. },
+                    &ConcreteLineToken::HardNewLine,
+                    &ConcreteLineToken::Indent { .. },
+                    &ConcreteLineToken::Delim { .. },
+                    &ConcreteLineToken::Comma,
+                    &ConcreteLineToken::HardNewLine,
+                    &ConcreteLineToken::HardNewLine,
+                ],
             ) = accum.last::<7>()
             {
                 accum.fix_heredoc_arg_newline_mistake();

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -283,9 +283,7 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
                     tokens.pop();
                 }
             } else if let AbstractLineToken::BreakableEntry(BreakableEntry {
-                delims,
-                ref mut tokens,
-                ..
+                delims, tokens, ..
             }) = token
             {
                 if *delims == BreakableDelims::for_brace_block() {

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1720,7 +1720,7 @@ impl CallChainElement {
     pub fn start_line(&self) -> Option<u64> {
         match self {
             CallChainElement::IdentOrOpOrKeywordOrConst(ident) => {
-                Some(ident.clone().to_def_parts().1 .0)
+                Some(ident.clone().to_def_parts().1.0)
             }
             CallChainElement::Block(block) => Some(block.start_line()),
             CallChainElement::VarRef(VarRef(.., var_ref_type)) => Some(var_ref_type.start_line()),

--- a/librubyfmt/src/ruby.rs
+++ b/librubyfmt/src/ruby.rs
@@ -49,7 +49,7 @@ pub enum ruby_value_type {
 #[allow(non_upper_case_globals)]
 pub const Qnil: VALUE = VALUE(4);
 
-extern "C" {
+unsafe extern "C" {
     // stuff that we need to compile out rubyfmt
     pub fn ruby_setup() -> libc::c_int;
     pub fn ruby_cleanup(_: libc::c_int);
@@ -111,12 +111,8 @@ macro_rules! intern {
 pub unsafe fn eval_str(s: &str) -> Result<VALUE, ()> {
     let rubyfmt_program_as_c = CString::new(s).expect("unexpected nul byte in Ruby code");
     let mut state = 0;
-    let v = rb_eval_string_protect(rubyfmt_program_as_c.as_ptr(), &mut state);
-    if state != 0 {
-        Err(())
-    } else {
-        Ok(v)
-    }
+    let v = unsafe { rb_eval_string_protect(rubyfmt_program_as_c.as_ptr(), &mut state) };
+    if state != 0 { Err(()) } else { Ok(v) }
 }
 
 pub fn raise(s: &str) {
@@ -133,7 +129,7 @@ pub fn raise(s: &str) {
 /// Ruby array. The Ruby array must not be modified while the returned slice
 /// is live.
 pub unsafe fn ruby_array_to_slice<'a>(ary: VALUE) -> &'a [VALUE] {
-    std::slice::from_raw_parts(rubyfmt_rb_ary_ptr(ary), rubyfmt_rb_ary_len(ary) as _)
+    unsafe { std::slice::from_raw_parts(rubyfmt_rb_ary_ptr(ary), rubyfmt_rb_ary_len(ary) as _) }
 }
 
 /// # Safety
@@ -143,7 +139,8 @@ pub unsafe fn ruby_array_to_slice<'a>(ary: VALUE) -> &'a [VALUE] {
 /// Ruby string. The Ruby string must not be modified while the returned str
 /// is live.
 pub unsafe fn ruby_string_to_str<'a>(s: VALUE) -> &'a str {
-    let bytes =
-        std::slice::from_raw_parts(rubyfmt_rstring_ptr(s) as _, rubyfmt_rstring_len(s) as _);
+    let bytes = unsafe {
+        std::slice::from_raw_parts(rubyfmt_rstring_ptr(s) as _, rubyfmt_rstring_len(s) as _)
+    };
     std::str::from_utf8(bytes).expect("invalid UTF-8")
 }

--- a/librubyfmt/src/ruby_ops.rs
+++ b/librubyfmt/src/ruby_ops.rs
@@ -4,18 +4,14 @@ use crate::ruby::*;
 pub fn setup_ruby() -> Result<(), ()> {
     unsafe {
         let res = ruby_setup();
-        if res == 0 {
-            Ok(())
-        } else {
-            Err(())
-        }
+        if res == 0 { Ok(()) } else { Err(()) }
     }
 }
 
 // Safety: This function expects an initialized Ruby VM
 pub unsafe fn load_rubyfmt() -> Result<(), ()> {
     let rubyfmt_program = include_str!("../rubyfmt_lib.rb");
-    eval_str(rubyfmt_program)?;
+    unsafe { eval_str(rubyfmt_program) }?;
     Ok(())
 }
 
@@ -30,7 +26,7 @@ pub enum ParseError {
 
 impl Parser {
     unsafe extern "C" fn real_run_parser(parser_instance: VALUE) -> VALUE {
-        rb_funcall(parser_instance, intern!("parse"), 0)
+        unsafe { rb_funcall(parser_instance, intern!("parse"), 0) }
     }
 
     pub fn new(buf: &str) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,10 @@ use regex::Regex;
 use rubyfmt::init_logger;
 use similar::TextDiff;
 use std::ffi::OsStr;
-use std::fs::{read_to_string, File, OpenOptions};
+use std::fs::{File, OpenOptions, read_to_string};
 use std::io::{self, BufRead, BufReader, IsTerminal, Read, Write};
 use std::path::Path;
-use std::process::{exit, Command};
+use std::process::{Command, exit};
 use std::sync::{Arc, Mutex};
 
 #[macro_use]

--- a/tests/cli_interface_test.rs
+++ b/tests/cli_interface_test.rs
@@ -3,7 +3,7 @@ use std::{
     fs::{self, create_dir, read_to_string},
     io::Write,
 };
-use tempfile::{tempdir, NamedTempFile};
+use tempfile::{NamedTempFile, tempdir};
 
 #[test]
 fn test_simple_stdout() {

--- a/tests/error_handling_test.rs
+++ b/tests/error_handling_test.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use assert_cmd::{cargo::cargo_bin, Command};
+use assert_cmd::{Command, cargo::cargo_bin};
 use tempfile::NamedTempFile;
 
 #[test]


### PR DESCRIPTION
`rubyfmt` has always been on the 2018 edition, but getting on to the 2024 edition is mostly just a matter of adding some `unsafe` blocks (which I just accepted from the autocorrect) and then reformatting.

The impetus for this is mostly just that it fixes some issues in `rustfmt` that have always annoyed me (like the chained tuple formatting as `foo.0 .1` with that awkward space), plus it'll make it easier for us to adopt features in future rust versions as they get stabilized.