### PR TITLE
[prism] Support method modifier calls

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1097,22 +1097,45 @@ fn format_call_node(
             );
         }
         if let Some(arguments) = call_node.arguments() {
-            let delims = if is_aref {
-                BreakableDelims::for_array()
+            // For callers where the only arg is a def node,
+            // we assume that's a `public def` style modifier and don't use parens
+            if arguments.arguments().iter().count() == 1
+                && arguments
+                    .arguments()
+                    .iter()
+                    .next()
+                    .unwrap()
+                    .as_def_node()
+                    .is_some()
+            {
+                ps.emit_space();
+
+                let def_node = arguments
+                    .arguments()
+                    .iter()
+                    .next()
+                    .unwrap()
+                    .as_def_node()
+                    .unwrap();
+                format_def_node(ps, def_node);
             } else {
-                BreakableDelims::for_method_call()
+                let delims = if is_aref {
+                    BreakableDelims::for_array()
+                } else {
+                    BreakableDelims::for_method_call()
+                };
+                ps.with_start_of_line(
+                    false,
+                    Box::new(|ps| {
+                        ps.breakable_of(
+                            delims,
+                            Box::new(|ps| {
+                                format_arguments_node(ps, arguments);
+                            }),
+                        );
+                    }),
+                );
             };
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    ps.breakable_of(
-                        delims,
-                        Box::new(|ps| {
-                            format_arguments_node(ps, arguments);
-                        }),
-                    );
-                }),
-            );
         }
         if let Some(block) = call_node.block() {
             ps.emit_space();

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -325,7 +325,7 @@ fixture!(test_small_long_blockvar, "small/long_blockvar");
 fixture!(test_small_map_curly, "small/map_curly");
 // fixture!(test_small_massign, "small/massign");
 // fixture!(test_small_massign_omg, "small/massign_omg");
-// fixture!(test_small_memoist, "small/memoist");
+fixture!(test_small_memoist, "small/memoist");
 fixture!(
     test_small_method_add_block_command_call,
     "small/method_add_block_command_call"
@@ -425,10 +425,10 @@ fixture!(
     test_small_preserve_slash_u_strings,
     "small/preserve_slash_u_strings"
 );
-// fixture!(
-//     test_small_private_class_method,
-//     "small/private_class_method"
-// );
+fixture!(
+    test_small_private_class_method,
+    "small/private_class_method"
+);
 fixture!(
     test_small_private_gets_trailing_blankline,
     "small/private_gets_trailing_blankline"


### PR DESCRIPTION
This adds special handling for method modifiers like `private`/`protected`/etc., which are special-cased to always format like `private def foo` instead of using parens.