### PR TITLE
[prism] Fix some issues with heredoc rendering

### DIFF
--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1544,7 +1544,7 @@ pub enum StringType {
     Regexp,
 }
 
-pub fn format_inner_string(
+fn format_inner_string(
     ps: &mut dyn ConcreteParserState,
     parts: Vec<StringContentPart>,
     tipe: StringType,
@@ -1644,7 +1644,15 @@ pub fn format_heredoc_string_literal(
             let kind = HeredocKind::from_string(&heredoc_type);
             ps.emit_heredoc_start(format!("{}{}", heredoc_type, heredoc_symbol), kind);
 
-            ps.push_heredoc_content(heredoc_symbol, kind, parts, end_line);
+            ps.push_heredoc_content(
+                heredoc_symbol,
+                kind,
+                end_line,
+                Box::new(|n: &mut BaseParserState| {
+                    n.disable_user_newlines();
+                    format_inner_string(n, parts, StringType::Heredoc);
+                }),
+            );
         }),
     );
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4,10 +4,10 @@ use crate::{
     delimiters::BreakableDelims,
     format::SpecialCase,
     heredoc_string::HeredocKind,
-    parser_state::{ConcreteParserState, FormattingContext, HashType, RenderFunc},
+    parser_state::{BaseParserState, ConcreteParserState, FormattingContext, HashType, RenderFunc},
     render_targets::MultilineHandling,
     types::SourceOffset,
-    util::{const_to_string, loc_to_string},
+    util::{const_to_string, loc_to_string, u8_to_string},
 };
 
 pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
@@ -506,20 +506,37 @@ fn format_string_node(ps: &mut dyn ConcreteParserState, string_node: prism::Stri
         .map(|s| loc_to_string(s).trim().to_string());
     let is_heredoc = opener.clone().map(|s| s.starts_with("<")).unwrap_or(false);
 
+    if is_heredoc {
+        let heredoc_kind = HeredocKind::from_string(opener.clone().unwrap().as_str());
+        ps.emit_heredoc_start(opener.unwrap(), heredoc_kind);
+        ps.push_heredoc_content(
+            closer.unwrap(),
+            heredoc_kind,
+            ps.get_line_number_for_offset(
+                string_node
+                    .closing_loc()
+                    .expect("Heredocs must have a loc for the closing tag")
+                    // We use the start line here because sometimes (but not always!)
+                    // the closing_loc includes a trailing newline, which would put
+                    // us one line too far up
+                    .start_offset(),
+            ),
+            Box::new(|n: &mut BaseParserState| {
+                n.disable_user_newlines();
+                let mut content = u8_to_string(string_node.unescaped()).to_string();
+                content = content.strip_suffix('\n').unwrap_or(&content).to_string();
+                n.emit_string_content(content);
+            }),
+        );
+        return;
+    }
+
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
-            if is_heredoc {
-                let heredoc_symbol = opener.clone().unwrap();
-                let heredoc_kind = HeredocKind::from_string(&heredoc_symbol);
-
-                ps.emit_heredoc_start(heredoc_symbol, heredoc_kind);
-                ps.emit_newline();
-            } else {
-                // Always use double quotes over single quotes/percent literals
-                if opener.is_some() {
-                    ps.emit_double_quote();
-                }
+            // Always use double quotes over single quotes/percent literals
+            if opener.is_some() {
+                ps.emit_double_quote();
             }
 
             // If opener is nil, we must be in some kind of interpolated string context, which
@@ -539,18 +556,7 @@ fn format_string_node(ps: &mut dyn ConcreteParserState, string_node: prism::Stri
             ps.emit_string_content(string_content);
             ps.wind_dumping_comments_until_offset(string_node.content_loc().end_offset());
 
-            if is_heredoc {
-                // <<~ heredocs have their closing tag indented too
-                if opener.map(|s| s.starts_with("<<~")).unwrap_or(false) {
-                    ps.emit_indent();
-                }
-
-                ps.emit_heredoc_close(
-                    loc_to_string(string_node.closing_loc().unwrap())
-                        .trim()
-                        .to_string(),
-                );
-            } else if opener.is_some() {
+            if opener.is_some() {
                 ps.emit_double_quote();
             }
         }),
@@ -563,10 +569,10 @@ fn format_interpolated_string_node(
     ps: &mut dyn ConcreteParserState,
     interpolated_string_node: prism::InterpolatedStringNode,
 ) {
-    let is_heredoc = interpolated_string_node
+    let opener = interpolated_string_node
         .opening_loc()
-        .map(|s| loc_to_string(s).starts_with("<"))
-        .unwrap_or(false);
+        .map(|s| loc_to_string(s).trim().to_string());
+    let is_heredoc = opener.as_ref().map(|s| s.starts_with("<")).unwrap_or(false);
 
     // Prism actually handles string concatenation when using "\", so it treats
     // ```ruby
@@ -584,11 +590,16 @@ fn format_interpolated_string_node(
         });
 
     ps.at_offset(interpolated_string_node.location().start_offset());
-    if let Some(s) = interpolated_string_node.opening_loc() {
-        ps.emit_string_content(loc_to_string(s).trim().to_string());
-    }
+
     if is_heredoc {
-        ps.emit_newline();
+        format_heredoc(ps, &interpolated_string_node, opener);
+        // The rest of this machinery is handled in format_inner_string
+        // From here on out, assume we're not in a heredoc
+        return;
+    }
+
+    if let Some(s) = &opener {
+        ps.emit_string_content(s.clone());
     }
 
     ps.with_start_of_line(
@@ -596,16 +607,16 @@ fn format_interpolated_string_node(
         Box::new(|ps| {
             let string_parts_count = interpolated_string_node.parts().iter().count();
             for (i, part) in interpolated_string_node.parts().iter().enumerate() {
+                let start_offset = part.location().start_offset();
                 let end_offset = part.location().end_offset();
-                ps.at_offset(part.location().start_offset());
 
-                if i > 0 {
+                ps.at_offset(start_offset);
+                let indent_for_consecutive_strings = is_backslash_string_interpolation && i > 0;
+
+                if indent_for_consecutive_strings {
                     ps.start_indent();
-
-                    if is_backslash_string_interpolation {
-                        ps.emit_newline();
-                        ps.emit_indent();
-                    }
+                    ps.emit_newline();
+                    ps.emit_indent();
                 }
 
                 format_node(ps, part);
@@ -621,7 +632,7 @@ fn format_interpolated_string_node(
                 }
 
                 ps.at_offset(end_offset);
-                if i > 0 {
+                if indent_for_consecutive_strings {
                     ps.end_indent();
                 }
             }
@@ -630,6 +641,82 @@ fn format_interpolated_string_node(
 
     if let Some(closing_loc) = interpolated_string_node.closing_loc() {
         ps.emit_string_content(loc_to_string(closing_loc).trim().to_string());
+    }
+}
+
+fn format_heredoc(
+    ps: &mut dyn ConcreteParserState,
+    interpolated_string_node: &ruby_prism::InterpolatedStringNode<'_>,
+    opener: Option<String>,
+) {
+    let heredoc_symbol = opener.unwrap().to_string();
+    let heredoc_kind = HeredocKind::from_string(&heredoc_symbol);
+    ps.emit_heredoc_start(heredoc_symbol, heredoc_kind);
+
+    let parts = interpolated_string_node.parts();
+
+    ps.push_heredoc_content(
+        interpolated_string_node
+            .closing_loc()
+            .map(|s| loc_to_string(s).trim().to_string())
+            .unwrap(),
+        heredoc_kind,
+        ps.get_line_number_for_offset(
+            interpolated_string_node
+                .closing_loc()
+                .expect("Heredocs must have a loc for the closing tag")
+                .start_offset(),
+        ),
+        Box::new(|n: &mut BaseParserState| {
+            n.disable_user_newlines();
+            format_inner_string(n, parts, true);
+        }),
+    );
+    ps.wind_dumping_comments_until_offset(interpolated_string_node.location().end_offset());
+}
+
+fn format_inner_string(ps: &mut dyn ConcreteParserState, parts: prism::NodeList, is_heredoc: bool) {
+    let mut peekable = parts.iter().peekable();
+    while let Some(part) = peekable.next() {
+        match part {
+            prism::Node::StringNode { .. } => {
+                let part = part.as_string_node().unwrap();
+                // We use the `unescaped` contents here since they
+                // have the appropriate leading whitespace stripped for <<~ heredocs
+                let mut contents = u8_to_string(part.unescaped());
+
+                if is_heredoc {
+                    if peekable.peek().is_none() && contents.ends_with('\n') {
+                        contents.pop();
+                    }
+                }
+
+                ps.at_offset(part.location().end_offset());
+                ps.emit_string_content(contents);
+            }
+            prism::Node::InterpolatedStringNode { .. } => {
+                ps.at_offset(part.location().start_offset());
+                format_interpolated_string_node(ps, part.as_interpolated_string_node().unwrap());
+
+                let on_line_skip = is_heredoc
+                    && match peekable.peek() {
+                        Some(prism::Node::StringNode { .. }) => loc_to_string(
+                            peekable
+                                .peek()
+                                .unwrap()
+                                .as_string_node()
+                                .unwrap()
+                                .content_loc(),
+                        )
+                        .starts_with('\n'),
+                        _ => false,
+                    };
+                if on_line_skip {
+                    ps.render_heredocs(true)
+                }
+            }
+            _ => ps.with_start_of_line(false, Box::new(|ps| format_node(ps, part))),
+        }
     }
 }
 
@@ -681,17 +768,24 @@ fn format_embedded_statements_node(
 ) {
     ps.emit_string_content("#{".to_string());
     if let Some(statements) = embedded_statements_node.statements() {
-        let has_multiple_statements = statements.body().iter().count() > 1;
-        ps.with_start_of_line(
-            has_multiple_statements,
+        ps.with_formatting_context(
+            FormattingContext::StringEmbexpr,
             Box::new(|ps| {
-                if has_multiple_statements {
-                    ps.emit_newline();
-                    ps.new_block(Box::new(|ps| format_node(ps, statements.as_node())));
-                    ps.emit_indent();
-                } else {
-                    format_node(ps, statements.as_node());
-                }
+                let has_multiple_statements = statements.body().iter().count() > 1;
+                ps.with_start_of_line(
+                    has_multiple_statements,
+                    Box::new(|ps| {
+                        if has_multiple_statements {
+                            ps.emit_newline();
+                            ps.new_block(Box::new(|ps| format_node(ps, statements.as_node())));
+                            ps.emit_indent();
+                        } else {
+                            if let Some(statement) = statements.body().iter().next() {
+                                format_node(ps, statement);
+                            }
+                        }
+                    }),
+                );
             }),
         );
     }
@@ -1161,6 +1255,11 @@ fn format_call_node(
                         // must be additional calls -- you cannot insert literals into call chains
                         let first_expression = call_chain_elements.remove(0);
                         format_node(ps, first_expression);
+                        // Eagerly render heredocs if they're in the first expression.
+                        // We want the full heredoc to get rendered _before_ we emit the
+                        // BeginCallChainIndent token so that it gets correctly indented
+                        // (or in the case of it being the first expression, _not_ indented).
+                        ps.render_heredocs(true);
 
                         ps.start_indent_for_call_chain();
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -697,10 +697,8 @@ fn format_inner_string(
                 // have the appropriate leading whitespace stripped for <<~ heredocs
                 let mut contents = u8_to_string(part.unescaped());
 
-                if is_heredoc {
-                    if peekable.peek().is_none() && contents.ends_with('\n') {
-                        contents.pop();
-                    }
+                if is_heredoc && peekable.peek().is_none() && contents.ends_with('\n') {
+                    contents.pop();
                 }
 
                 ps.at_offset(part.location().end_offset());
@@ -797,10 +795,8 @@ fn format_embedded_statements_node(
                             ps.emit_newline();
                             ps.new_block(Box::new(|ps| format_node(ps, statements.as_node())));
                             ps.emit_indent();
-                        } else {
-                            if let Some(statement) = statements.body().iter().next() {
-                                format_node(ps, statement);
-                            }
+                        } else if let Some(statement) = statements.body().iter().next() {
+                            format_node(ps, statement);
                         }
                     }),
                 );

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -507,26 +507,12 @@ fn format_string_node(ps: &mut dyn ConcreteParserState, string_node: prism::Stri
     let is_heredoc = opener.clone().map(|s| s.starts_with("<")).unwrap_or(false);
 
     if is_heredoc {
-        let heredoc_kind = HeredocKind::from_string(opener.clone().unwrap().as_str());
-        ps.emit_heredoc_start(opener.unwrap(), heredoc_kind);
-        ps.push_heredoc_content(
-            closer.unwrap(),
-            heredoc_kind,
-            ps.get_line_number_for_offset(
-                string_node
-                    .closing_loc()
-                    .expect("Heredocs must have a loc for the closing tag")
-                    // We use the start line here because sometimes (but not always!)
-                    // the closing_loc includes a trailing newline, which would put
-                    // us one line too far up
-                    .start_offset(),
-            ),
-            Box::new(|n: &mut BaseParserState| {
-                n.disable_user_newlines();
-                let mut content = u8_to_string(string_node.unescaped()).to_string();
-                content = content.strip_suffix('\n').unwrap_or(&content).to_string();
-                n.emit_string_content(content);
-            }),
+        format_heredoc(
+            ps,
+            HeredocNodeType::Plain(string_node),
+            opener
+                .expect("Heredocs must have an opening loc for the opening tag (<<FOO etc.)")
+                .to_string(),
         );
         return;
     }
@@ -592,7 +578,13 @@ fn format_interpolated_string_node(
     ps.at_offset(interpolated_string_node.location().start_offset());
 
     if is_heredoc {
-        format_heredoc(ps, &interpolated_string_node, opener);
+        format_heredoc(
+            ps,
+            HeredocNodeType::Interpolated(interpolated_string_node),
+            opener
+                .expect("Heredocs must have an opening loc for the opening tag (<<FOO etc.)")
+                .to_string(),
+        );
         // The rest of this machinery is handled in format_inner_string
         // From here on out, assume we're not in a heredoc
         return;
@@ -644,38 +636,60 @@ fn format_interpolated_string_node(
     }
 }
 
+enum HeredocNodeType<'h> {
+    Plain(prism::StringNode<'h>),
+    Interpolated(prism::InterpolatedStringNode<'h>),
+}
+
+impl HeredocNodeType<'_> {
+    fn parts(&self) -> Vec<prism::Node> {
+        match self {
+            HeredocNodeType::Plain(string_node) => vec![string_node.as_node()],
+            HeredocNodeType::Interpolated(interpolated_string_node) => {
+                interpolated_string_node.parts().iter().collect::<Vec<_>>()
+            }
+        }
+    }
+
+    fn closing_loc(&self) -> prism::Location {
+        match self {
+            HeredocNodeType::Plain(string_node) => string_node
+                .closing_loc()
+                .expect("This is a heredoc, it must have a loc for the closing tag"),
+            HeredocNodeType::Interpolated(interpolated_string_node) => interpolated_string_node
+                .closing_loc()
+                .expect("This is a heredoc, it must have a loc for the closing tag"),
+        }
+    }
+}
+
 fn format_heredoc(
     ps: &mut dyn ConcreteParserState,
-    interpolated_string_node: &ruby_prism::InterpolatedStringNode<'_>,
-    opener: Option<String>,
+    heredoc: HeredocNodeType,
+    heredoc_symbol: String,
 ) {
-    let heredoc_symbol = opener.unwrap().to_string();
     let heredoc_kind = HeredocKind::from_string(&heredoc_symbol);
     ps.emit_heredoc_start(heredoc_symbol, heredoc_kind);
 
-    let parts = interpolated_string_node.parts();
+    let parts = heredoc.parts();
 
     ps.push_heredoc_content(
-        interpolated_string_node
-            .closing_loc()
-            .map(|s| loc_to_string(s).trim().to_string())
-            .unwrap(),
+        loc_to_string(heredoc.closing_loc()).trim().to_string(),
         heredoc_kind,
-        ps.get_line_number_for_offset(
-            interpolated_string_node
-                .closing_loc()
-                .expect("Heredocs must have a loc for the closing tag")
-                .start_offset(),
-        ),
+        ps.get_line_number_for_offset(heredoc.closing_loc().start_offset()),
         Box::new(|n: &mut BaseParserState| {
             n.disable_user_newlines();
             format_inner_string(n, parts, true);
         }),
     );
-    ps.wind_dumping_comments_until_offset(interpolated_string_node.location().end_offset());
+    ps.wind_dumping_comments_until_offset(heredoc.closing_loc().start_offset());
 }
 
-fn format_inner_string(ps: &mut dyn ConcreteParserState, parts: prism::NodeList, is_heredoc: bool) {
+fn format_inner_string(
+    ps: &mut dyn ConcreteParserState,
+    parts: Vec<prism::Node>,
+    is_heredoc: bool,
+) {
     let mut peekable = parts.iter().peekable();
     while let Some(part) = peekable.next() {
         match part {
@@ -715,7 +729,13 @@ fn format_inner_string(ps: &mut dyn ConcreteParserState, parts: prism::NodeList,
                     ps.render_heredocs(true)
                 }
             }
-            _ => ps.with_start_of_line(false, Box::new(|ps| format_node(ps, part))),
+            prism::Node::EmbeddedStatementsNode { .. } => {
+                format_embedded_statements_node(ps, part.as_embedded_statements_node().unwrap())
+            }
+            prism::Node::EmbeddedVariableNode { .. } => {
+                format_embedded_variable_node(ps, part.as_embedded_variable_node().unwrap())
+            }
+            x => unreachable!("Unexpected Node type in heredoc: {:?}", x),
         }
     }
 }

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -671,15 +671,13 @@ fn format_heredoc(
     let heredoc_kind = HeredocKind::from_string(&heredoc_symbol);
     ps.emit_heredoc_start(heredoc_symbol, heredoc_kind);
 
-    let parts = heredoc.parts();
-
     ps.push_heredoc_content(
         loc_to_string(heredoc.closing_loc()).trim().to_string(),
         heredoc_kind,
         ps.get_line_number_for_offset(heredoc.closing_loc().start_offset()),
         Box::new(|n: &mut BaseParserState| {
             n.disable_user_newlines();
-            format_inner_string(n, parts, true);
+            format_inner_string(n, heredoc.parts(), true);
         }),
     );
     ps.wind_dumping_comments_until_offset(heredoc.closing_loc().start_offset());

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -1,14 +1,12 @@
 use crate::comment_block::{CommentBlock, Merge};
 use crate::delimiters::BreakableDelims;
 use crate::file_comments::FileComments;
-use crate::format::{StringType, format_inner_string};
 use crate::heredoc_string::{HeredocKind, HeredocString};
 use crate::line_tokens::*;
 use crate::render_queue_writer::{MAX_LINE_LENGTH, RenderQueueWriter};
 use crate::render_targets::{
     AbstractTokenTarget, BaseQueue, BreakableCallChainEntry, BreakableEntry, MultilineHandling,
 };
-use crate::ripper_tree_types::StringContentPart;
 use crate::types::{ColNumber, LineNumber, SourceOffset};
 use log::debug;
 use std::io::{self, Cursor, Write};
@@ -120,12 +118,12 @@ where
     fn shift_comments_at_index(&mut self, index: usize);
     fn wind_line_forward(&mut self);
     fn render_heredocs(&mut self, skip: bool);
-    fn push_heredoc_content(
+    fn push_heredoc_content<'a>(
         &mut self,
         symbol: String,
         kind: HeredocKind,
-        parts: Vec<StringContentPart>,
         end_line: LineNumber,
+        formatting_func: Box<dyn FnOnce(&mut BaseParserState) + 'a>,
     );
 
     // queries
@@ -212,17 +210,14 @@ impl ConcreteParserState for BaseParserState {
     fn bind_variable(&mut self, s: String) {
         self.scopes.last_mut().expect("it's never empty").push(s);
     }
-    fn push_heredoc_content(
+    fn push_heredoc_content<'a>(
         &mut self,
         symbol: String,
         kind: HeredocKind,
-        parts: Vec<StringContentPart>,
         end_line: LineNumber,
+        formatting_func: Box<dyn FnOnce(&mut BaseParserState) + 'a>,
     ) {
-        let mut next_ps = BaseParserState::render_with_blank_state(self, |n| {
-            n.insert_user_newlines = false;
-            format_inner_string(n, parts, StringType::Heredoc);
-        });
+        let mut next_ps = BaseParserState::render_with_blank_state(self, formatting_func);
 
         for hs in next_ps.heredoc_strings.drain(0..) {
             self.heredoc_strings.push(hs);
@@ -952,6 +947,10 @@ impl BaseParserState {
             .last()
             .expect("depth stack is never empty")
             .get()
+    }
+
+    pub fn disable_user_newlines(&mut self) {
+        self.insert_user_newlines = false;
     }
 
     fn last_token_is_a_newline(&self) -> bool {

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -260,23 +260,23 @@ fixture!(test_small_gvar_symbol, "small/gvar_symbol");
 // fixture!(test_small_hash_comments, "small/hash_comments");
 // fixture!(test_small_hash_heredoc, "small/hash_heredoc");
 // fixture!(test_small_hash_rocket_usage, "small/hash_rocket_usage");
-// fixture!(
-//     test_small_heredoc_comment_header,
-//     "small/heredoc_comment_header"
-// );
+fixture!(
+    test_small_heredoc_comment_header,
+    "small/heredoc_comment_header"
+);
 // fixture!(
 //     test_small_heredoc_ending_with_curly,
 //     "small/heredoc_ending_with_curly"
 // );
-// fixture!(
-//     test_small_heredoc_in_array_in_call,
-//     "small/heredoc_in_array_in_call"
-// );
-// fixture!(
-//     test_small_heredoc_indented_whitespace,
-//     "small/heredoc_indented_whitespace"
-// );
-// fixture!(test_small_heredoc_method_call, "small/heredoc_method_call");
+fixture!(
+    test_small_heredoc_in_array_in_call,
+    "small/heredoc_in_array_in_call"
+);
+fixture!(
+    test_small_heredoc_indented_whitespace,
+    "small/heredoc_indented_whitespace"
+);
+fixture!(test_small_heredoc_method_call, "small/heredoc_method_call");
 fixture!(test_small_heredoc_with_call, "small/heredoc_with_call");
 fixture!(
     test_small_heredoc_with_leading_newline,
@@ -287,11 +287,11 @@ fixture!(
 //     test_small_heredocs_ending_blocks,
 //     "small/heredocs_ending_blocks"
 // );
-// fixture!(test_small_heredocs_in_calls, "small/heredocs_in_calls");
-// fixture!(
-//     test_small_heredocs_with_comments,
-//     "small/heredocs_with_comments"
-// );
+fixture!(test_small_heredocs_in_calls, "small/heredocs_in_calls");
+fixture!(
+    test_small_heredocs_with_comments,
+    "small/heredocs_with_comments"
+);
 fixture!(
     test_small_if_without_extra_parts,
     "small/if_without_extra_parts"
@@ -399,10 +399,10 @@ fixture!(test_small_nested_conditionals, "small/nested_conditionals");
 // fixture!(test_small_next_with_comments, "small/next_with_comments");
 // fixture!(test_small_next_yield, "small/next_yield");
 fixture!(test_small_no_mangle_jpy, "small/no_mangle_jpy");
-// fixture!(
-//     test_small_no_multiline_call_in_string_embexpr,
-//     "small/no_multiline_call_in_string_embexpr"
-// );
+fixture!(
+    test_small_no_multiline_call_in_string_embexpr,
+    "small/no_multiline_call_in_string_embexpr"
+);
 // fixture!(test_small_not, "small/not");
 fixture!(test_small_numbers, "small/numbers");
 fixture!(test_small_op_defs, "small/op_defs");
@@ -434,7 +434,7 @@ fixture!(
     "small/private_gets_trailing_blankline"
 );
 // fixture!(test_small_procs, "small/procs");
-// fixture!(test_small_quoted_heredoc, "small/quoted_heredoc");
+fixture!(test_small_quoted_heredoc, "small/quoted_heredoc");
 fixture!(test_small_raise_star, "small/raise_star");
 // fixture!(test_small_rationals, "small/rationals");
 // fixture!(test_small_redo, "small/redo");


### PR DESCRIPTION
(Editorial note: Man I forgot how annoying heredocs are.)

This PR fixes various issues with rendering heredocs. The primary changes are that it fixes indentation issues with squiggly heredocs (since they are ✨special✨  and their indentation is relative to both the current indentation level _and_ the indentation of the least-indented line), plus it fixes the way they get rendered so that they work correctly inside argument lists. The latter is mostly fixed by just using all the `render_heredocs` machinery that already existed -- I just didn't implement it that way the first time around.