### PR TITLE
Replace `Intermediary::last` implementation with stdlib

### DIFF
--- a/librubyfmt/src/intermediary.rs
+++ b/librubyfmt/src/intermediary.rs
@@ -2,7 +2,6 @@ use crate::line_metadata::LineMetadata;
 use crate::line_tokens::*;
 #[cfg(debug_assertions)]
 use log::debug;
-use std::convert::TryInto;
 use std::mem;
 
 #[derive(Debug)]
@@ -66,21 +65,8 @@ impl Intermediary {
         self.index_of_last_hard_newline = self.tokens.len() - 1;
     }
 
-    pub fn last<const N: usize>(&self) -> Option<[&ConcreteLineToken; N]> {
-        if self.len() < N {
-            return None;
-        }
-
-        let mut values = Vec::with_capacity(N);
-        for index in (0..N).rev() {
-            values.push(&self.tokens[self.len() - index - 1]);
-        }
-
-        Some(
-            values
-                .try_into()
-                .expect("checked the length when constructing this"),
-        )
+    pub fn last<const N: usize>(&self) -> Option<&[ConcreteLineToken; N]> {
+        self.tokens.last_chunk::<N>()
     }
 
     pub fn into_tokens(self) -> Vec<ConcreteLineToken> {

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -124,10 +124,10 @@ impl RenderQueueWriter {
 
             if let Some(
                 [
-                    &ConcreteLineToken::HeredocClose { .. },
-                    &ConcreteLineToken::HardNewLine,
-                    &ConcreteLineToken::Indent { .. },
-                    &ConcreteLineToken::HardNewLine,
+                    ConcreteLineToken::HeredocClose { .. },
+                    ConcreteLineToken::HardNewLine,
+                    ConcreteLineToken::Indent { .. },
+                    ConcreteLineToken::HardNewLine,
                 ],
             ) = accum.last::<4>()
             {
@@ -136,9 +136,9 @@ impl RenderQueueWriter {
 
             if let Some(
                 [
-                    &ConcreteLineToken::End,
-                    &ConcreteLineToken::HardNewLine,
-                    &ConcreteLineToken::Indent { .. },
+                    ConcreteLineToken::End,
+                    ConcreteLineToken::HardNewLine,
+                    ConcreteLineToken::Indent { .. },
                     x,
                 ],
             ) = accum.last::<4>()
@@ -158,10 +158,10 @@ impl RenderQueueWriter {
 
             if let Some(
                 [
-                    &ConcreteLineToken::End,
-                    &ConcreteLineToken::AfterCallChain,
-                    &ConcreteLineToken::HardNewLine,
-                    &ConcreteLineToken::Indent { .. },
+                    ConcreteLineToken::End,
+                    ConcreteLineToken::AfterCallChain,
+                    ConcreteLineToken::HardNewLine,
+                    ConcreteLineToken::Indent { .. },
                     x,
                     maybe_space,
                     maybe_def,
@@ -195,13 +195,13 @@ impl RenderQueueWriter {
 
             if let Some(
                 [
-                    &ConcreteLineToken::HeredocClose { .. },
-                    &ConcreteLineToken::HardNewLine,
-                    &ConcreteLineToken::Indent { .. },
-                    &ConcreteLineToken::Indent { .. },
-                    &ConcreteLineToken::Delim { .. }
-                    | &ConcreteLineToken::Dot
-                    | &ConcreteLineToken::DirectPart { .. },
+                    ConcreteLineToken::HeredocClose { .. },
+                    ConcreteLineToken::HardNewLine,
+                    ConcreteLineToken::Indent { .. },
+                    ConcreteLineToken::Indent { .. },
+                    ConcreteLineToken::Delim { .. }
+                    | ConcreteLineToken::Dot
+                    | ConcreteLineToken::DirectPart { .. },
                 ],
             ) = accum.last::<5>()
             {
@@ -210,13 +210,13 @@ impl RenderQueueWriter {
 
             if let Some(
                 [
-                    &ConcreteLineToken::HeredocClose { .. },
-                    &ConcreteLineToken::HardNewLine,
-                    &ConcreteLineToken::Indent { .. },
-                    &ConcreteLineToken::Delim { .. },
-                    &ConcreteLineToken::Comma,
-                    &ConcreteLineToken::HardNewLine,
-                    &ConcreteLineToken::HardNewLine,
+                    ConcreteLineToken::HeredocClose { .. },
+                    ConcreteLineToken::HardNewLine,
+                    ConcreteLineToken::Indent { .. },
+                    ConcreteLineToken::Delim { .. },
+                    ConcreteLineToken::Comma,
+                    ConcreteLineToken::HardNewLine,
+                    ConcreteLineToken::HardNewLine,
                 ],
             ) = accum.last::<7>()
             {


### PR DESCRIPTION
I don't recall why this was implemented this way, but `last` is a very hot method (called multiple times for basically every token during the render queue), so creating a new Vec on every single call is probably not great.

This replaces it with `last_chunk` from the standard library, which behaves the same way and just returns a slice, which should be at least a tiny amount faster (although I didn't formally benchmark this FWIW).