### PR TITLE
[prism] Support `yield` keyword

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2410,8 +2410,24 @@ fn format_x_string_node(_ps: &mut dyn ConcreteParserState, _x_string_node: prism
     todo!()
 }
 
-fn format_yield_node(_ps: &mut dyn ConcreteParserState, _yield_node: prism::YieldNode) {
-    todo!()
+fn format_yield_node(ps: &mut dyn ConcreteParserState, yield_node: prism::YieldNode) {
+    ps.emit_ident("yield".to_string());
+    if let Some(arguments) = yield_node.arguments() {
+        let use_parens =
+            ps.current_formatting_context_requires_parens() || yield_node.lparen_loc().is_some();
+        let delims = if use_parens {
+            BreakableDelims::for_method_call()
+        } else {
+            BreakableDelims::for_kw()
+        };
+
+        ps.breakable_of(
+            delims,
+            Box::new(|ps| {
+                format_arguments_node(ps, arguments);
+            }),
+        );
+    }
 }
 
 fn handle_string_at_offset(ps: &mut dyn ConcreteParserState, ident: String, offset: usize) {

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -572,20 +572,20 @@ fixture!(
 // fixture!(test_small_while, "small/while");
 // fixture!(test_small_while_block_comment, "small/while_block_comment");
 // fixture!(test_small_while_mod, "small/while_mod");
-// fixture!(test_small_yield0, "small/yield0");
-// fixture!(test_small_yield0_in_ifop, "small/yield0_in_ifop");
-// fixture!(test_small_yield, "small/yield");
-// fixture!(test_small_yield_comment, "small/yield_comment");
+fixture!(test_small_yield0, "small/yield0");
+fixture!(test_small_yield0_in_ifop, "small/yield0_in_ifop");
+fixture!(test_small_yield, "small/yield");
+fixture!(test_small_yield_comment, "small/yield_comment");
 // fixture!(test_small_yield_hash_args, "small/yield_hash_args");
-// fixture!(test_small_yield_in_ifop, "small/yield_in_ifop");
-// fixture!(
-//     test_small_yield_keyword_comment_ordering,
-//     "small/yield_keyword_comment_ordering"
-// );
-// fixture!(
-//     test_small_yield_keyword_comment_ordering_spaces,
-//     "small/yield_keyword_comment_ordering_spaces"
-// );
+fixture!(test_small_yield_in_ifop, "small/yield_in_ifop");
+fixture!(
+    test_small_yield_keyword_comment_ordering,
+    "small/yield_keyword_comment_ordering"
+);
+fixture!(
+    test_small_yield_keyword_comment_ordering_spaces,
+    "small/yield_keyword_comment_ordering_spaces"
+);
 // fixture!(test_small_yield_with_paren, "small/yield_with_paren");
 fixture!(test_small_zsuper, "small/zsuper");
 


### PR DESCRIPTION
On the tin -- there's several more `yield` fixtures after this, but most of them rely on postfix `if` conditions, so I'm leaving those for a separate PR