### PR TITLE
[prism] Support redo/retry nodes

### DIFF
--- a/fixtures/small/redo_actual.rb
+++ b/fixtures/small/redo_actual.rb
@@ -1,7 +1,6 @@
 class Foo
   def bees
-    begin
-    rescue
+    loop do
       redo
     end
   end

--- a/fixtures/small/redo_expected.rb
+++ b/fixtures/small/redo_expected.rb
@@ -1,7 +1,6 @@
 class Foo
   def bees
-    begin
-    rescue
+    loop do
       redo
     end
   end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -347,7 +347,7 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::ProgramNode { .. } => format_program(ps, node.as_program_node().unwrap(), None),
         Node::RangeNode { .. } => format_range_node(ps, node.as_range_node().unwrap()),
         Node::RationalNode { .. } => format_rational_node(ps, node.as_rational_node().unwrap()),
-        Node::RedoNode { .. } => format_redo_node(ps, node.as_redo_node().unwrap()),
+        Node::RedoNode { .. } => format_redo_node(ps),
         Node::RegularExpressionNode { .. } => {
             format_regular_expression_node(ps, node.as_regular_expression_node().unwrap())
         }
@@ -365,7 +365,7 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::RestParameterNode { .. } => {
             format_rest_parameter_node(ps, node.as_rest_parameter_node().unwrap())
         }
-        Node::RetryNode { .. } => format_retry_node(ps, node.as_retry_node().unwrap()),
+        Node::RetryNode { .. } => format_retry_node(ps),
         Node::ReturnNode { .. } => format_return_node(ps, node.as_return_node().unwrap()),
         Node::SelfNode { .. } => format_self_node(ps, node.as_self_node().unwrap()),
         Node::ShareableConstantNode { .. } => {
@@ -2503,8 +2503,8 @@ fn format_rational_node(_ps: &mut dyn ConcreteParserState, _rational_node: prism
     todo!()
 }
 
-fn format_redo_node(_ps: &mut dyn ConcreteParserState, _redo_node: prism::RedoNode) {
-    todo!()
+fn format_redo_node(ps: &mut dyn ConcreteParserState) {
+    ps.emit_ident("redo".to_string());
 }
 
 fn format_regular_expression_node(
@@ -2581,8 +2581,8 @@ fn format_rest_parameter_node(
     todo!()
 }
 
-fn format_retry_node(_ps: &mut dyn ConcreteParserState, _retry_node: prism::RetryNode) {
-    todo!()
+fn format_retry_node(ps: &mut dyn ConcreteParserState) {
+    ps.emit_keyword("retry".to_string());
 }
 
 fn format_return_node(ps: &mut dyn ConcreteParserState, return_node: prism::ReturnNode) {

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -54,10 +54,10 @@ fixture!(test_small_all_method_blocks, "small/all_method_blocks");
 // fixture!(test_small_aref_field, "small/aref_field");
 // fixture!(test_small_aref_in_call, "small/aref_in_call");
 // fixture!(test_small_aref_rest_param, "small/aref_rest_param");
-// fixture!(
-//     test_small_arg_list_with_bare_assoc_hash,
-//     "small/arg_list_with_bare_assoc_hash"
-// );
+fixture!(
+    test_small_arg_list_with_bare_assoc_hash,
+    "small/arg_list_with_bare_assoc_hash"
+);
 fixture!(test_small_arg_trailing_comma, "small/arg_trailing_comma");
 fixture!(test_small_args_forwarding, "small/args_forwarding");
 fixture!(
@@ -437,7 +437,7 @@ fixture!(
 fixture!(test_small_quoted_heredoc, "small/quoted_heredoc");
 fixture!(test_small_raise_star, "small/raise_star");
 // fixture!(test_small_rationals, "small/rationals");
-// fixture!(test_small_redo, "small/redo");
+fixture!(test_small_redo, "small/redo");
 // fixture!(test_small_regexp_literal, "small/regexp_literal");
 fixture!(test_small_req_optional_params, "small/req_optional_params");
 // fixture!(test_small_require_rails, "small/require_rails");
@@ -454,7 +454,7 @@ fixture!(test_small_rest_param, "small/rest_param");
 //     test_small_rest_param_unpacking,
 //     "small/rest_param_unpacking"
 // );
-// fixture!(test_small_retry, "small/retry");
+fixture!(test_small_retry, "small/retry");
 // fixture!(test_small_return0, "small/return0");
 // fixture!(test_small_return, "small/return");
 // fixture!(test_small_rspec_its, "small/rspec_its");


### PR DESCRIPTION
On the tin -- probably the only notable thing here is that our `redo` fixtures were actually invalid syntax (that I guess Ripper was fine with?) because `redo` only works in blocks, while `retry` is only for exception handling.