### PR TITLE
Handle implicit rest nodes in both Prism and Ripper

### DIFF
--- a/fixtures/small/implicit_rest_param_actual.rb
+++ b/fixtures/small/implicit_rest_param_actual.rb
@@ -1,0 +1,2 @@
+foo { |bar,| }
+baz do |quux,         |; end

--- a/fixtures/small/implicit_rest_param_expected.rb
+++ b/fixtures/small/implicit_rest_param_expected.rb
@@ -1,0 +1,3 @@
+foo { |bar,| }
+baz do |quux,|
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -192,9 +192,7 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
         Node::IfNode { .. } => format_if_node(ps, node.as_if_node().unwrap()),
         Node::ImaginaryNode { .. } => format_imaginary_node(ps, node.as_imaginary_node().unwrap()),
         Node::ImplicitNode { .. } => format_implicit_node(),
-        Node::ImplicitRestNode { .. } => {
-            format_implicit_rest_node(ps, node.as_implicit_rest_node().unwrap())
-        }
+        Node::ImplicitRestNode { .. } => format_implicit_rest_node(),
         Node::InNode { .. } => format_in_node(ps, node.as_in_node().unwrap()),
         Node::IndexAndWriteNode { .. } => {
             format_index_and_write_node(ps, node.as_index_and_write_node().unwrap())
@@ -362,9 +360,11 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
             format_rescue_modifier_node(ps, node.as_rescue_modifier_node().unwrap())
         }
         Node::RescueNode { .. } => format_rescue_node(ps, node.as_rescue_node().unwrap()),
-        Node::RestParameterNode { .. } => {
-            format_rest_parameter_node(ps, node.as_rest_parameter_node().unwrap())
-        }
+        Node::RestParameterNode { .. } => format_rest_parameter_node(
+            ps,
+            node.as_rest_parameter_node().unwrap(),
+            SpecialCase::NoSpecialCase,
+        ),
         Node::RetryNode { .. } => format_retry_node(ps),
         Node::ReturnNode { .. } => format_return_node(ps, node.as_return_node().unwrap()),
         Node::SelfNode { .. } => format_self_node(ps, node.as_self_node().unwrap()),
@@ -1207,11 +1207,7 @@ fn format_parameters_node(ps: &mut dyn ConcreteParserState, params: prism::Param
         }),
         Box::new(move |ps: &mut dyn ConcreteParserState| {
             if let Some(rest) = rest {
-                format_rest_param(
-                    ps,
-                    rest.as_rest_parameter_node().unwrap(),
-                    SpecialCase::NoSpecialCase,
-                )
+                format_node(ps, rest);
             }
         }),
         Box::new(move |ps: &mut dyn ConcreteParserState| {
@@ -1639,7 +1635,6 @@ fn format_block_parameters_node(
             }
             if has_locals {
                 ps.emit_ident(";".to_string());
-                ps.emit_space();
                 ps.with_start_of_line(
                     false,
                     Box::new(|ps| {
@@ -1778,7 +1773,7 @@ fn collapse_nodes_to_call_chain(node: prism::Node) -> Vec<prism::Node> {
     call_chain_elements
 }
 
-fn format_rest_param(
+fn format_rest_parameter_node(
     ps: &mut dyn ConcreteParserState,
     rest_param: prism::RestParameterNode,
     special_case: SpecialCase,
@@ -2212,11 +2207,14 @@ fn format_implicit_node() {
     // e.g. `{ a: }`, so we don't actually need to do anything to format it
 }
 
-fn format_implicit_rest_node(
-    _ps: &mut dyn ConcreteParserState,
-    _implicit_rest_node: prism::ImplicitRestNode,
-) {
-    todo!()
+fn format_implicit_rest_node() {
+    // Intentionally do nothing.
+    //
+    // prism::ImplicitRestNode is essentially a placeholder for some variable declaration like
+    // func { |x,| }, where the trailing comma is the "implicit rest node". This doesn't actually require us
+    // to do anything, since this node will basically be listed as a node in the arguments list, so we'll
+    // treat it like any other argument: by emitting a comma and a space before it.
+    // Since other machinery actually handles all of this, we don't really need to do anything if we end up here.
 }
 
 fn format_in_node(_ps: &mut dyn ConcreteParserState, _in_node: prism::InNode) {
@@ -2620,13 +2618,6 @@ fn format_rescue_node(ps: &mut dyn ConcreteParserState, rescue_node: prism::Resc
     }
 
     ps.at_offset(rescue_node.location().end_offset());
-}
-
-fn format_rest_parameter_node(
-    _ps: &mut dyn ConcreteParserState,
-    _rest_parameter_node: prism::RestParameterNode,
-) {
-    todo!()
 }
 
 fn format_retry_node(ps: &mut dyn ConcreteParserState) {

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -159,7 +159,6 @@ impl ConcreteLineToken {
     pub fn is_single_line_breakable_garbage(&self) -> bool {
         match self {
             Self::DirectPart { part } => part == &"".to_string(),
-            Self::Comma => true,
             Self::Space => true,
             _ => false,
         }

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1272,7 +1272,11 @@ impl Params {
             (self.4).is_some(),
             (self.5).is_some(),
             (self.6).is_some(),
-            (self.7).is_some(),
+            match self.7 {
+                // BlockArgOrTag::Tag doesn't emit anything, so we should ignore it
+                None | Some(BlockArgOrTag::Tag(..)) => false,
+                _ => true,
+            },
         ]
     }
 }

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -254,6 +254,7 @@ fixture!(
 fixture!(test_small_endless_methods, "small/endless_methods");
 fixture!(test_small_fib, "small/fib");
 fixture!(test_small_first_rest_param, "small/first_rest_param");
+fixture!(test_implicit_rest_param, "small/implicit_rest_param");
 fixture!(test_small_for_loop, "small/for_loop");
 fixture!(test_small_gemfile, "small/gemfile");
 fixture!(test_small_gvar_symbol, "small/gvar_symbol");

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -103,10 +103,10 @@ fixture!(
     test_small_block_ending_with_comment,
     "small/block_ending_with_comment"
 );
-// fixture!(
-//     test_small_block_local_variables,
-//     "small/block_local_variables"
-// );
+fixture!(
+    test_small_block_local_variables,
+    "small/block_local_variables"
+);
 // fixture!(
 //     test_small_block_param_line_length,
 //     "small/block_param_line_length"

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -253,6 +253,7 @@ fixture!(
 // fixture!(test_small_endless_methods, "small/endless_methods");
 // fixture!(test_small_fib, "small/fib");
 fixture!(test_small_first_rest_param, "small/first_rest_param");
+fixture!(test_implicit_rest_param, "small/implicit_rest_param");
 // fixture!(test_small_for_loop, "small/for_loop");
 // fixture!(test_small_gemfile, "small/gemfile");
 fixture!(test_small_gvar_symbol, "small/gvar_symbol");


### PR DESCRIPTION
As part of implementing implicit rest nodes in Prism, this also makes some changes in the Ripper implementation that fixes #442. [Implicit rest nodes](https://ruby-doc.org/3.4.1/stdlibs/prism/Prism/ImplicitRestNode.html) are semantically-meaningful commas that change how a block argument gets destructured. The old Ripper implementation used to strip this trailing comma as a "garbage token" for some reason, but this was actually just covering up a bug, which is that Ripper used to emit a block parameter "tag" for args forwarding nodes (see #401 for the origin of that tag) that caused the parameter machinery to incorrectly emit a comma for a node that had no real content. _However_, since that comma could be meaningful at other times, this PR adjusts that parameter machinery to do the right thing, which is to treat these block parameter tags the same as `None`.

The Prism implementation for this is otherwise straightforward -- implicit rest nodes don't actually _have_ a representation (since they're implicit!), so this otherwise just skips over them and does nothing.


Closes #442