### PR TITLE
[prism] Fix endless methods spacing

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1095,7 +1095,15 @@ fn format_def_body(ps: &mut dyn ConcreteParserState, def_node: prism::DefNode) {
                         false,
                         Box::new(|ps| {
                             if let Some(body) = def_node.body() {
-                                format_node(ps, body);
+                                format_node(
+                                    ps,
+                                    body.as_statements_node()
+                                        .expect("Endless methods must have a body, and method definitions are always a Statements node")
+                                        .body()
+                                        .iter()
+                                        .next()
+                                        .expect("Endless methods must have exactly one expression in their body")
+                                );
                             }
                         }),
                     )

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1095,15 +1095,15 @@ fn format_def_body(ps: &mut dyn ConcreteParserState, def_node: prism::DefNode) {
                         false,
                         Box::new(|ps| {
                             if let Some(body) = def_node.body() {
-                                format_node(
-                                    ps,
-                                    body.as_statements_node()
-                                        .expect("Endless methods must have a body, and method definitions are always a Statements node")
-                                        .body()
-                                        .iter()
-                                        .next()
-                                        .expect("Endless methods must have exactly one expression in their body")
-                                );
+                                let mut body_node_list = body.as_statements_node()
+                                    .expect("Endless methods must have a body, and method definitions are always a Statements node")
+                                    .body()
+                                    .iter();
+                                let body_expression = body_node_list.next().expect("Endless methods must have exactly one expression in their body");
+
+                                debug_assert!(body_node_list.next().is_none(), "Expected endless method body to have exactly one node.");
+
+                                format_node(ps, body_expression);
                             }
                         }),
                     )

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -250,7 +250,7 @@ fixture!(
     test_small_end_of_file_comments,
     "small/end_of_file_comments"
 );
-// fixture!(test_small_endless_methods, "small/endless_methods");
+fixture!(test_small_endless_methods, "small/endless_methods");
 // fixture!(test_small_fib, "small/fib");
 fixture!(test_small_first_rest_param, "small/first_rest_param");
 // fixture!(test_small_for_loop, "small/for_loop");


### PR DESCRIPTION
There are some cases in Prism where a `StatementsNode` is used, but there can only be a single statement that requires separate treatment. Endless methods are one such example, where that single treatment is treated more like the right side of an assignment instead of like a list of statements (e.g. a regular method body, a class def, etc.),  so this PR yanks that single method out of the StatementsNode and renders it directly to fix some weird spacing issues.
