### PR TITLE
[prism] Handle simple regexp literals

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2507,10 +2507,12 @@ fn format_redo_node(ps: &mut dyn ConcreteParserState) {
 }
 
 fn format_regular_expression_node(
-    _ps: &mut dyn ConcreteParserState,
-    _regular_expression_node: prism::RegularExpressionNode,
+    ps: &mut dyn ConcreteParserState,
+    regular_expression_node: prism::RegularExpressionNode,
 ) {
-    todo!()
+    ps.emit_ident(loc_to_string(regular_expression_node.opening_loc()));
+    ps.emit_string_content(loc_to_string(regular_expression_node.content_loc()));
+    ps.emit_ident(loc_to_string(regular_expression_node.closing_loc()));
 }
 
 fn format_rescue_modifier_node(

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -438,7 +438,7 @@ fixture!(test_small_quoted_heredoc, "small/quoted_heredoc");
 fixture!(test_small_raise_star, "small/raise_star");
 // fixture!(test_small_rationals, "small/rationals");
 fixture!(test_small_redo, "small/redo");
-// fixture!(test_small_regexp_literal, "small/regexp_literal");
+fixture!(test_small_regexp_literal, "small/regexp_literal");
 fixture!(test_small_req_optional_params, "small/req_optional_params");
 // fixture!(test_small_require_rails, "small/require_rails");
 // fixture!(test_small_require_relative, "small/require_relative");
@@ -483,10 +483,10 @@ fixture!(
 fixture!(test_small_splat_in_argument, "small/splat_in_argument");
 fixture!(test_small_splat_rescue, "small/splat_rescue");
 fixture!(test_small_sqb_no_parens, "small/sqb_no_parens");
-// fixture!(
-//     test_small_squiggly_heredoc_interpolation,
-//     "small/squiggly_heredoc_interpolation"
-// );
+fixture!(
+    test_small_squiggly_heredoc_interpolation,
+    "small/squiggly_heredoc_interpolation"
+);
 // fixture!(test_small_stabby_lambda, "small/stabby_lambda");
 fixture!(test_small_star, "small/star");
 fixture!(


### PR DESCRIPTION
This PR handles simple regexp literals -- that is to say, non-interpolated ones. I'll handle interpolated nodes separately, but these had pretty simple fixtures so I figured I'd just knock them out real quick.