### PR TITLE
[prism] Support `next` keyword

### DIFF
--- a/fixtures/small/next_with_args_actual.rb
+++ b/fixtures/small/next_with_args_actual.rb
@@ -1,1 +1,3 @@
+[].each do ||
 next 1
+end

--- a/fixtures/small/next_with_args_expected.rb
+++ b/fixtures/small/next_with_args_expected.rb
@@ -1,1 +1,3 @@
-next 1
+[].each do
+  next 1
+end

--- a/fixtures/small/next_yield_actual.rb
+++ b/fixtures/small/next_yield_actual.rb
@@ -1,1 +1,5 @@
+def foo(&blk)
+[].each do ||
 next yield a
+end
+end

--- a/fixtures/small/next_yield_expected.rb
+++ b/fixtures/small/next_yield_expected.rb
@@ -1,1 +1,5 @@
-next yield a
+def foo(&blk)
+  [].each do
+    next yield a
+  end
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1637,6 +1637,13 @@ fn format_block_parameters_node(
     ps: &mut dyn ConcreteParserState,
     block_parameters_node: prism::BlockParametersNode,
 ) {
+    // Exit early if there's no params
+    if node_list_is_empty(&block_parameters_node.locals())
+        && block_parameters_node.parameters().is_none()
+    {
+        return;
+    }
+
     ps.breakable_of(
         BreakableDelims::for_block_params(),
         Box::new(|ps| {
@@ -2454,8 +2461,21 @@ fn format_multi_write_node(
     todo!()
 }
 
-fn format_next_node(_ps: &mut dyn ConcreteParserState, _next_node: prism::NextNode) {
-    todo!()
+fn format_next_node(ps: &mut dyn ConcreteParserState, next_node: prism::NextNode) {
+    ps.emit_ident("next".to_string());
+    if let Some(arguments_node) = next_node.arguments() {
+        ps.with_start_of_line(
+            false,
+            Box::new(|ps| {
+                ps.breakable_of(
+                    BreakableDelims::for_kw(),
+                    Box::new(|ps| {
+                        format_arguments_node(ps, arguments_node);
+                    }),
+                );
+            }),
+        );
+    }
 }
 
 fn format_nil_node(ps: &mut dyn ConcreteParserState, _nil_node: prism::NilNode) {

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -395,9 +395,9 @@ fixture!(test_small_nested_conditionals, "small/nested_conditionals");
 //     test_small_nested_destructuring,
 //     "small/nested_destructuring"
 // );
-// fixture!(test_small_next_with_args, "small/next_with_args");
-// fixture!(test_small_next_with_comments, "small/next_with_comments");
-// fixture!(test_small_next_yield, "small/next_yield");
+fixture!(test_small_next_with_args, "small/next_with_args");
+fixture!(test_small_next_with_comments, "small/next_with_comments");
+fixture!(test_small_next_yield, "small/next_yield");
 fixture!(test_small_no_mangle_jpy, "small/no_mangle_jpy");
 fixture!(
     test_small_no_multiline_call_in_string_embexpr,


### PR DESCRIPTION
What it says -- this also slightly modifies some of the fixtures, since understandably Prism considers `yield` outside of definitions and `next` outside of blocks to be invalid syntax, so this just wraps the old fixtures in blocks/defs as needed.