### PR TITLE
[prism] Support block args (`&blk`)

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1347,8 +1347,7 @@ fn format_call_node(
                                 // we want it to be a part of the comma-separated list
                                 if let Some(block_argument_node) = call_node
                                     .block()
-                                    .map(|block_node| block_node.as_block_argument_node())
-                                    .flatten()
+                                    .and_then(|block_node| block_node.as_block_argument_node())
                                 {
                                     if has_arguments {
                                         ps.emit_comma();

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1276,10 +1276,18 @@ fn format_block_parameter_node(
 }
 
 fn format_block_argument_node(
-    _ps: &mut dyn ConcreteParserState,
-    _block_argument_node: prism::BlockArgumentNode,
+    ps: &mut dyn ConcreteParserState,
+    block_argument_node: prism::BlockArgumentNode,
 ) {
-    todo!()
+    ps.emit_ident("&".to_string());
+    if let Some(expression_node) = block_argument_node.expression() {
+        ps.with_start_of_line(
+            false,
+            Box::new(|ps| {
+                format_node(ps, expression_node);
+            }),
+        );
+    }
 }
 
 fn format_call_node(
@@ -1331,7 +1339,23 @@ fn format_call_node(
                         ps.breakable_of(
                             delims,
                             Box::new(|ps| {
+                                let has_arguments = !node_list_is_empty(&arguments.arguments());
                                 format_arguments_node(ps, arguments);
+
+                                // Somewhat confusingly, the block argument node (&blk) is
+                                // separate from the rest of the arguments node. If it's present,
+                                // we want it to be a part of the comma-separated list
+                                if let Some(block_argument_node) = call_node
+                                    .block()
+                                    .map(|block_node| block_node.as_block_argument_node())
+                                    .flatten()
+                                {
+                                    if has_arguments {
+                                        ps.emit_comma();
+                                        ps.emit_soft_newline();
+                                    }
+                                    format_block_argument_node(ps, block_argument_node);
+                                }
                             }),
                         );
                     }),
@@ -1339,13 +1363,26 @@ fn format_call_node(
             };
         }
         if let Some(block) = call_node.block() {
-            ps.emit_space();
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    format_node(ps, block);
-                }),
-            );
+            if block.as_block_argument_node().is_none() {
+                ps.emit_space();
+                ps.with_start_of_line(
+                    false,
+                    Box::new(|ps| {
+                        format_node(ps, block);
+                    }),
+                );
+            // If there's an arguments node, we've handled this block arg with
+            // the rest of the args (since it's included in the comma-separated
+            // args list), otherwise the only argument is the &blk node, so we
+            // have to handle that here separately
+            } else if call_node.arguments().is_none() && block.as_block_argument_node().is_some() {
+                ps.breakable_of(
+                    BreakableDelims::for_method_call(),
+                    Box::new(|ps| {
+                        format_block_argument_node(ps, block.as_block_argument_node().unwrap());
+                    }),
+                );
+            }
         }
     } else {
         ps.with_start_of_line(

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -50,7 +50,7 @@ fixture!(
 // fixture!(test_small_alias_string_symbol, "small/alias_string_symbol");
 fixture!(test_small_all_method_blocks, "small/all_method_blocks");
 // fixture!(test_small_and_or, "small/and_or");
-// fixture!(test_small_anonymous_blockarg, "small/anonymous_blockarg");
+fixture!(test_small_anonymous_blockarg, "small/anonymous_blockarg");
 // fixture!(test_small_aref_field, "small/aref_field");
 // fixture!(test_small_aref_in_call, "small/aref_in_call");
 // fixture!(test_small_aref_rest_param, "small/aref_rest_param");
@@ -68,7 +68,7 @@ fixture!(
     test_small_args_forwarding_multiline,
     "small/args_forwarding_multiline"
 );
-// fixture!(test_small_array_with_splat, "small/array_with_splat");
+fixture!(test_small_array_with_splat, "small/array_with_splat");
 // fixture!(test_small_assign_field, "small/assign_field");
 fixture!(test_small_assoc_double_splat, "small/assoc_double_splat");
 // fixture!(test_small_backref, "small/backref");
@@ -319,9 +319,9 @@ fixture!(test_small_long_blockvar, "small/long_blockvar");
 //     "small/long_line_with_indentation"
 // );
 // fixture!(test_small_long_raise, "small/long_raise");
-// fixture!(test_small_many_arg_types, "small/many_arg_types");
+fixture!(test_small_many_arg_types, "small/many_arg_types");
 // fixture!(test_small_many_opassigns, "small/many_opassigns");
-// fixture!(test_small_many_splats, "small/many_splats");
+fixture!(test_small_many_splats, "small/many_splats");
 // fixture!(test_small_many_weird_args, "small/many_weird_args");
 fixture!(test_small_map_curly, "small/map_curly");
 // fixture!(test_small_massign, "small/massign");
@@ -548,7 +548,7 @@ fixture!(
 fixture!(test_small_symbol_arg, "small/symbol_arg");
 fixture!(test_small_symbol_op, "small/symbol_op");
 fixture!(test_small_ternary, "small/ternary");
-// fixture!(test_small_to_proc_operator, "small/to_proc_operator");
+fixture!(test_small_to_proc_operator, "small/to_proc_operator");
 fixture!(
     test_small_top_const_field_assignment,
     "small/top_const_field_assignment"


### PR DESCRIPTION
So block args are a bit complicated, but that's because Prism represents `foo(&blk)` and `foo { || }` basically the same way. In the former case, they're not included in the `CallNode.arguments()` list, as one may expect, but rather only in the `block()` node, so you have to sort of backport them into the arguments list if there's an argument list, treat them as the sole argument if there's _not_ an args list, and otherwise treat regular brace or do-end blocks normally if they're present.