### PR TITLE
[prism/ripper] Fix multiline args forwarding fixtures spacing

### DIFF
--- a/fixtures/small/args_forwarding_multiline_expected.rb
+++ b/fixtures/small/args_forwarding_multiline_expected.rb
@@ -1,5 +1,7 @@
 def a(...)
   if should_pass?
-    return b(...)
+    return b(
+      ...
+    )
   end
 end

--- a/librubyfmt/rubyfmt_lib.rb
+++ b/librubyfmt/rubyfmt_lib.rb
@@ -202,6 +202,10 @@ class Parser < Ripper::SexpBuilderPP
     @lbrace_stack << lineno
   end
 
+  def on_args_forward(*_args)
+    with_lineno { super }
+  end
+
   def on_rbracket(*_args)
     @rbracket_stack << lineno
     super

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -234,7 +234,7 @@ pub fn format_kwrest_params(
                 }),
             );
         }
-        KwRestParamOrArgsForward::ArgsForward(_) => ps.emit_ellipsis(),
+        KwRestParamOrArgsForward::ArgsForward(ArgsForward(..)) => ps.emit_ellipsis(),
     }
     true
 }
@@ -1519,7 +1519,9 @@ pub fn format_list_like_thing(
         ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(el) => {
             format_list_like_thing_items(ps, el, end_line, single_line)
         }
-        ArgsAddStarOrExpressionListOrArgsForward::ArgsForward(_) => {
+        ArgsAddStarOrExpressionListOrArgsForward::ArgsForward(ArgsForward(_, start_end)) => {
+            ps.wind_dumping_comments_until_line(start_end.start_line());
+            ps.emit_soft_indent();
             ps.emit_ellipsis();
             false
         }

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2638,10 +2638,16 @@ fn format_return_node(ps: &mut dyn ConcreteParserState, return_node: prism::Retu
         false,
         Box::new(|ps| {
             if let Some(arguments) = return_node.arguments() {
-                ps.breakable_of(
-                    BreakableDelims::for_kw(),
+                ps.emit_space();
+                ps.with_start_of_line(
+                    false,
                     Box::new(|ps| {
-                        format_arguments_node(ps, arguments);
+                        format_list_like_thing(
+                            ps,
+                            arguments.arguments(),
+                            arguments.location().end_offset(),
+                            true,
+                        );
                     }),
                 );
             }

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1261,7 +1261,7 @@ pub struct ExcessedComma(excessed_comma_tag);
 
 def_tag!(args_forward_tag, "args_forward");
 #[derive(Deserialize, Debug, Clone)]
-pub struct ArgsForward(args_forward_tag);
+pub struct ArgsForward(pub args_forward_tag, pub StartEnd);
 
 impl Params {
     pub fn non_null_positions(&self) -> Vec<bool> {

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -64,10 +64,10 @@ fixture!(
     test_small_args_forwarding_additional_args,
     "small/args_forwarding_additional_args"
 );
-// fixture!(
-//     test_small_args_forwarding_multiline,
-//     "small/args_forwarding_multiline"
-// );
+fixture!(
+    test_small_args_forwarding_multiline,
+    "small/args_forwarding_multiline"
+);
 // fixture!(test_small_array_with_splat, "small/array_with_splat");
 // fixture!(test_small_assign_field, "small/assign_field");
 fixture!(test_small_assoc_double_splat, "small/assoc_double_splat");


### PR DESCRIPTION
(Low lines-changed-to-fixtures-passing ratio :sadpanda:)

Generally, `rubyfmt` considers arguments user-multilined if they ever put parens on multiple lines. As such, something like

```ruby
foo(
  ...
)
```

would be consider multilined. The Prism implementation did this correctly, since it has offsets for every node, but the Ripper implementation didn't have this. (I don't know why we -- probably me? -- didn't do this originally, but that's lost to the sands of time.) _So_, to remedy that, this PR adds a line number to the Ripper node, updates the implementation to handle it, and then also fixes another small issue in the Prism implementation, which is that apparently we never add parens to `return` statements, which I did wrong on the first go-round.

All of this is done to get `test_small_args_forwarding_multiline` passing and consistent in both implementations!