### PR TITLE
[prism] Implement backtick strings

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2724,8 +2724,10 @@ fn format_while_node(_ps: &mut dyn ConcreteParserState, _while_node: prism::Whil
     todo!()
 }
 
-fn format_x_string_node(_ps: &mut dyn ConcreteParserState, _x_string_node: prism::XStringNode) {
-    todo!()
+fn format_x_string_node(ps: &mut dyn ConcreteParserState, x_string_node: prism::XStringNode) {
+    ps.emit_ident("`".to_string());
+    ps.emit_string_content(loc_to_string(x_string_node.content_loc()));
+    ps.emit_ident("`".to_string());
 }
 
 fn format_yield_node(ps: &mut dyn ConcreteParserState, yield_node: prism::YieldNode) {

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -73,7 +73,7 @@ fixture!(
 fixture!(test_small_assoc_double_splat, "small/assoc_double_splat");
 // fixture!(test_small_backref, "small/backref");
 fixture!(test_small_backtick_symbol, "small/backtick_symbol");
-// fixture!(test_small_backticks, "small/backticks");
+fixture!(test_small_backticks, "small/backticks");
 // fixture!(test_small_bare_alias, "small/bare_alias");
 fixture!(
     test_small_bare_assoc_hash_trailing_comma,


### PR DESCRIPTION
On the tin -- these are easy, since we just dump them exactly as they are!