### PR TITLE
[prism] add formatting for class and instance variables

### DIFF
--- a/fixtures/small/ivar_actual.rb
+++ b/fixtures/small/ivar_actual.rb
@@ -1,0 +1,3 @@
+class Ivar
+  @converter = NullConverter
+end

--- a/fixtures/small/ivar_expected.rb
+++ b/fixtures/small/ivar_expected.rb
@@ -1,0 +1,3 @@
+class Ivar
+  @converter = NullConverter
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2325,24 +2325,57 @@ fn format_index_target_node(
 }
 
 fn format_instance_variable_and_write_node(
-    _ps: &mut dyn ConcreteParserState,
-    _instance_variable_and_write_node: prism::InstanceVariableAndWriteNode,
+    ps: &mut dyn ConcreteParserState,
+    instance_variable_and_write_node: prism::InstanceVariableAndWriteNode,
 ) {
-    todo!()
+    ps.emit_ident(const_to_string(instance_variable_and_write_node.name()));
+
+    ps.emit_space();
+    ps.emit_op(loc_to_string(
+	instance_variable_and_write_node.operator_loc(),
+    ));
+    ps.emit_space();
+
+    ps.with_start_of_line(
+	false,
+	Box::new(|ps| format_node(ps, instance_variable_and_write_node.value())),
+    );
 }
 
 fn format_instance_variable_operator_write_node(
-    _ps: &mut dyn ConcreteParserState,
-    _instance_variable_operator_write_node: prism::InstanceVariableOperatorWriteNode,
+    ps: &mut dyn ConcreteParserState,
+    instance_variable_operator_write_node: prism::InstanceVariableOperatorWriteNode,
 ) {
-    todo!()
+    ps.emit_ident(const_to_string(instance_variable_operator_write_node.name()));
+
+    ps.emit_space();
+    ps.emit_op(loc_to_string(
+	instance_variable_operator_write_node.binary_operator_loc(),
+    ));
+    ps.emit_space();
+
+    ps.with_start_of_line(
+	false,
+	Box::new(|ps| format_node(ps, instance_variable_operator_write_node.value())),
+    );
 }
 
 fn format_instance_variable_or_write_node(
-    _ps: &mut dyn ConcreteParserState,
-    _instance_variable_or_write_node: prism::InstanceVariableOrWriteNode,
+    ps: &mut dyn ConcreteParserState,
+    instance_variable_or_write_node: prism::InstanceVariableOrWriteNode,
 ) {
-    todo!()
+    ps.emit_ident(const_to_string(instance_variable_or_write_node.name()));
+
+    ps.emit_space();
+    ps.emit_op(loc_to_string(
+	instance_variable_or_write_node.operator_loc(),
+    ));
+    ps.emit_space();
+
+    ps.with_start_of_line(
+	false,
+	Box::new(|ps| format_node(ps, instance_variable_or_write_node.value())),
+    );
 }
 
 fn format_instance_variable_read_node(
@@ -2353,10 +2386,10 @@ fn format_instance_variable_read_node(
 }
 
 fn format_instance_variable_target_node(
-    _ps: &mut dyn ConcreteParserState,
-    _instance_variable_target_node: prism::InstanceVariableTargetNode,
+    ps: &mut dyn ConcreteParserState,
+    instance_variable_target_node: prism::InstanceVariableTargetNode,
 ) {
-    todo!()
+    ps.emit_ident(const_to_string(instance_variable_target_node.name()));
 }
 
 fn format_constant_read_node(

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -952,14 +952,12 @@ fn format_class_variable_and_write_node(
     ps.emit_ident(const_to_string(class_variable_and_write_node.name()));
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(
-	class_variable_and_write_node.operator_loc(),
-    ));
+    ps.emit_op(loc_to_string(class_variable_and_write_node.operator_loc()));
     ps.emit_space();
 
     ps.with_start_of_line(
-	false,
-	Box::new(|ps| format_node(ps, class_variable_and_write_node.value())),
+        false,
+        Box::new(|ps| format_node(ps, class_variable_and_write_node.value())),
     );
 }
 
@@ -971,13 +969,13 @@ fn format_class_variable_operator_write_node(
 
     ps.emit_space();
     ps.emit_op(loc_to_string(
-	class_variable_operator_write_node.binary_operator_loc(),
+        class_variable_operator_write_node.binary_operator_loc(),
     ));
     ps.emit_space();
 
     ps.with_start_of_line(
-	false,
-	Box::new(|ps| format_node(ps, class_variable_operator_write_node.value())),
+        false,
+        Box::new(|ps| format_node(ps, class_variable_operator_write_node.value())),
     );
 }
 
@@ -988,14 +986,12 @@ fn format_class_variable_or_write_node(
     ps.emit_ident(const_to_string(class_variable_or_write_node.name()));
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(
-	class_variable_or_write_node.operator_loc(),
-    ));
+    ps.emit_op(loc_to_string(class_variable_or_write_node.operator_loc()));
     ps.emit_space();
 
     ps.with_start_of_line(
-	false,
-	Box::new(|ps| format_node(ps, class_variable_or_write_node.value())),
+        false,
+        Box::new(|ps| format_node(ps, class_variable_or_write_node.value())),
     );
 }
 
@@ -2374,13 +2370,13 @@ fn format_instance_variable_and_write_node(
 
     ps.emit_space();
     ps.emit_op(loc_to_string(
-	instance_variable_and_write_node.operator_loc(),
+        instance_variable_and_write_node.operator_loc(),
     ));
     ps.emit_space();
 
     ps.with_start_of_line(
-	false,
-	Box::new(|ps| format_node(ps, instance_variable_and_write_node.value())),
+        false,
+        Box::new(|ps| format_node(ps, instance_variable_and_write_node.value())),
     );
 }
 
@@ -2388,17 +2384,19 @@ fn format_instance_variable_operator_write_node(
     ps: &mut dyn ConcreteParserState,
     instance_variable_operator_write_node: prism::InstanceVariableOperatorWriteNode,
 ) {
-    ps.emit_ident(const_to_string(instance_variable_operator_write_node.name()));
+    ps.emit_ident(const_to_string(
+        instance_variable_operator_write_node.name(),
+    ));
 
     ps.emit_space();
     ps.emit_op(loc_to_string(
-	instance_variable_operator_write_node.binary_operator_loc(),
+        instance_variable_operator_write_node.binary_operator_loc(),
     ));
     ps.emit_space();
 
     ps.with_start_of_line(
-	false,
-	Box::new(|ps| format_node(ps, instance_variable_operator_write_node.value())),
+        false,
+        Box::new(|ps| format_node(ps, instance_variable_operator_write_node.value())),
     );
 }
 
@@ -2410,13 +2408,13 @@ fn format_instance_variable_or_write_node(
 
     ps.emit_space();
     ps.emit_op(loc_to_string(
-	instance_variable_or_write_node.operator_loc(),
+        instance_variable_or_write_node.operator_loc(),
     ));
     ps.emit_space();
 
     ps.with_start_of_line(
-	false,
-	Box::new(|ps| format_node(ps, instance_variable_or_write_node.value())),
+        false,
+        Box::new(|ps| format_node(ps, instance_variable_or_write_node.value())),
     );
 }
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -946,45 +946,87 @@ fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassN
 }
 
 fn format_class_variable_and_write_node(
-    _ps: &mut dyn ConcreteParserState,
-    _class_variable_and_write_node: prism::ClassVariableAndWriteNode,
+    ps: &mut dyn ConcreteParserState,
+    class_variable_and_write_node: prism::ClassVariableAndWriteNode,
 ) {
-    todo!()
+    ps.emit_ident(const_to_string(class_variable_and_write_node.name()));
+
+    ps.emit_space();
+    ps.emit_op(loc_to_string(
+	class_variable_and_write_node.operator_loc(),
+    ));
+    ps.emit_space();
+
+    ps.with_start_of_line(
+	false,
+	Box::new(|ps| format_node(ps, class_variable_and_write_node.value())),
+    );
 }
 
 fn format_class_variable_operator_write_node(
-    _ps: &mut dyn ConcreteParserState,
-    _class_variable_operator_write_node: prism::ClassVariableOperatorWriteNode,
+    ps: &mut dyn ConcreteParserState,
+    class_variable_operator_write_node: prism::ClassVariableOperatorWriteNode,
 ) {
-    todo!()
+    ps.emit_ident(const_to_string(class_variable_operator_write_node.name()));
+
+    ps.emit_space();
+    ps.emit_op(loc_to_string(
+	class_variable_operator_write_node.binary_operator_loc(),
+    ));
+    ps.emit_space();
+
+    ps.with_start_of_line(
+	false,
+	Box::new(|ps| format_node(ps, class_variable_operator_write_node.value())),
+    );
 }
 
 fn format_class_variable_or_write_node(
-    _ps: &mut dyn ConcreteParserState,
-    _class_variable_or_write_node: prism::ClassVariableOrWriteNode,
+    ps: &mut dyn ConcreteParserState,
+    class_variable_or_write_node: prism::ClassVariableOrWriteNode,
 ) {
-    todo!()
+    ps.emit_ident(const_to_string(class_variable_or_write_node.name()));
+
+    ps.emit_space();
+    ps.emit_op(loc_to_string(
+	class_variable_or_write_node.operator_loc(),
+    ));
+    ps.emit_space();
+
+    ps.with_start_of_line(
+	false,
+	Box::new(|ps| format_node(ps, class_variable_or_write_node.value())),
+    );
 }
 
 fn format_class_variable_read_node(
-    _ps: &mut dyn ConcreteParserState,
-    _class_variable_read_node: prism::ClassVariableReadNode,
+    ps: &mut dyn ConcreteParserState,
+    class_variable_read_node: prism::ClassVariableReadNode,
 ) {
-    todo!()
+    ps.emit_ident(const_to_string(class_variable_read_node.name()));
 }
 
 fn format_class_variable_target_node(
-    _ps: &mut dyn ConcreteParserState,
-    _class_variable_target_node: prism::ClassVariableTargetNode,
+    ps: &mut dyn ConcreteParserState,
+    class_variable_target_node: prism::ClassVariableTargetNode,
 ) {
-    todo!()
+    ps.emit_ident(const_to_string(class_variable_target_node.name()));
 }
 
 fn format_class_variable_write_node(
-    _ps: &mut dyn ConcreteParserState,
-    _class_variable_write_node: prism::ClassVariableWriteNode,
+    ps: &mut dyn ConcreteParserState,
+    class_variable_write_node: prism::ClassVariableWriteNode,
 ) {
-    todo!()
+    ps.at_offset(class_variable_write_node.location().start_offset());
+
+    ps.emit_ident(const_to_string(class_variable_write_node.name()));
+    ps.emit_space();
+    ps.emit_op("=".to_string());
+    ps.emit_space();
+    ps.with_start_of_line(
+        false,
+        Box::new(|ps| format_node(ps, class_variable_write_node.value())),
+    );
 }
 
 fn format_module_node(ps: &mut dyn ConcreteParserState, module_node: prism::ModuleNode) {

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -300,6 +300,7 @@ fixture!(
 );
 fixture!(test_small_inline_comments, "small/inline_comments");
 fixture!(test_small_inline_rescue, "small/inline_rescue");
+fixture!(test_small_ivar, "small/ivar");
 fixture!(test_small_ivar_symbol, "small/ivar_symbol");
 fixture!(test_small_kw_symbol, "small/kw_symbol");
 fixture!(test_small_kwargs, "small/kwargs");

--- a/tests/prism_fixtures_test.rs
+++ b/tests/prism_fixtures_test.rs
@@ -299,6 +299,7 @@ fixture!(
 );
 fixture!(test_small_inline_comments, "small/inline_comments");
 // fixture!(test_small_inline_rescue, "small/inline_rescue");
+fixture!(test_small_ivar, "small/ivar");
 fixture!(test_small_ivar_symbol, "small/ivar_symbol");
 fixture!(test_small_kw_symbol, "small/kw_symbol");
 fixture!(test_small_kwargs, "small/kwargs");


### PR DESCRIPTION
There is not great test coverage here, but ideally the cargo-culting from local variables will be sufficient.  I did try to add some very basic tests; I'm sure that some of the more complex tests will eventually exercise this stuff.