### PR TITLE
avoid accidentally quadratic behavior in `into_ruby`

### DIFF
--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -237,17 +237,19 @@ impl ConcreteLineTokenAndTargets {
 
     pub fn into_ruby(self) -> String {
         match self {
-            Self::BreakableEntry(be) => be
-                .into_tokens(ConvertType::SingleLine)
-                .into_iter()
-                .fold("".to_string(), |accum, tok| {
-                    format!("{}{}", accum, tok.into_ruby())
-                }),
+            Self::BreakableEntry(be) => be.into_tokens(ConvertType::SingleLine).into_iter().fold(
+                "".to_string(),
+                |mut accum, tok| {
+                    accum.push_str(&tok.into_ruby());
+                    accum
+                },
+            ),
             Self::BreakableCallChainEntry(bcce) => bcce
                 .into_tokens(ConvertType::SingleLine)
                 .into_iter()
-                .fold("".to_string(), |accum, tok| {
-                    format!("{}{}", accum, tok.into_ruby())
+                .fold("".to_string(), |mut accum, tok| {
+                    accum.push_str(&tok.into_ruby());
+                    accum
                 }),
             Self::ConcreteLineToken(clt) => clt.into_ruby(),
         }


### PR DESCRIPTION
I don't think this is actually a bottleneck right now, but we might as well try to be efficient.  I blame `rustfmt` for the horrible diff.

ptal @elliottt 