### PR TITLE
collapse `ConcreteParserState` and `BaseParserState` into `ParserState`

### DIFF
--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::delimiters::BreakableDelims;
 use crate::heredoc_string::HeredocKind;
-use crate::parser_state::{ParserState, FormattingContext, RenderFunc};
+use crate::parser_state::{FormattingContext, ParserState, RenderFunc};
 use crate::render_targets::MultilineHandling;
 use crate::ripper_tree_types::*;
 use crate::types::LineNumber;
@@ -106,18 +106,12 @@ pub fn inner_format_params(ps: &mut ParserState, params: Box<Params>) {
     let block_arg = params.7;
 
     let formats: Vec<ParamFormattingFunc> = vec![
-        Box::new(move |ps: &mut ParserState| {
-            format_required_params(ps, required_params)
-        }),
-        Box::new(move |ps: &mut ParserState| {
-            format_optional_params(ps, optional_params)
-        }),
+        Box::new(move |ps: &mut ParserState| format_required_params(ps, required_params)),
+        Box::new(move |ps: &mut ParserState| format_optional_params(ps, optional_params)),
         Box::new(move |ps: &mut ParserState| {
             format_rest_param(ps, rest_param, SpecialCase::NoSpecialCase)
         }),
-        Box::new(move |ps: &mut ParserState| {
-            format_required_params(ps, more_required_params)
-        }),
+        Box::new(move |ps: &mut ParserState| format_required_params(ps, more_required_params)),
         Box::new(move |ps: &mut ParserState| format_kwargs(ps, kwargs)),
         Box::new(move |ps: &mut ParserState| format_kwrest_params(ps, kwrest_params)),
         Box::new(move |ps: &mut ParserState| format_block_arg(ps, block_arg)),
@@ -189,11 +183,7 @@ pub fn format_blockvar(ps: &mut ParserState, bv: BlockVar) {
     ps.on_line(start_end.end_line());
 }
 
-pub fn format_params(
-    ps: &mut ParserState,
-    params: Box<Params>,
-    delims: BreakableDelims,
-) {
+pub fn format_params(ps: &mut ParserState, params: Box<Params>, delims: BreakableDelims) {
     let have_any_params = params.non_null_positions().iter().any(|&x| x);
     if !have_any_params {
         return;
@@ -239,10 +229,7 @@ pub fn format_kwrest_params(
     true
 }
 
-pub fn format_block_arg(
-    ps: &mut ParserState,
-    block_arg: Option<BlockArgOrTag>,
-) -> bool {
+pub fn format_block_arg(ps: &mut ParserState, block_arg: Option<BlockArgOrTag>) -> bool {
     match block_arg {
         None | Some(BlockArgOrTag::Tag(..)) => false,
         Some(BlockArgOrTag::BlockArg(ba)) => {
@@ -263,10 +250,7 @@ pub fn format_block_arg(
     }
 }
 
-pub fn format_kwargs(
-    ps: &mut ParserState,
-    kwargs: Vec<(Label, ExpressionOrFalse)>,
-) -> bool {
+pub fn format_kwargs(ps: &mut ParserState, kwargs: Vec<(Label, ExpressionOrFalse)>) -> bool {
     if kwargs.is_empty() {
         return false;
     }
@@ -434,10 +418,7 @@ fn bind_mlhs(ps: &mut ParserState, mlhs: &MLhs) {
     }
 }
 
-pub fn format_required_params(
-    ps: &mut ParserState,
-    required_params: Vec<IdentOrMLhs>,
-) -> bool {
+pub fn format_required_params(ps: &mut ParserState, required_params: Vec<IdentOrMLhs>) -> bool {
     if required_params.is_empty() {
         return false;
     }
@@ -472,11 +453,7 @@ pub fn emit_params_separator(ps: &mut ParserState, index: usize, length: usize) 
     }
 }
 
-pub fn format_bodystmt(
-    ps: &mut ParserState,
-    bodystmt: Box<BodyStmt>,
-    end_line: LineNumber,
-) {
+pub fn format_bodystmt(ps: &mut ParserState, bodystmt: Box<BodyStmt>, end_line: LineNumber) {
     let expressions = bodystmt.1;
     let rescue_part = bodystmt.2;
     let else_part = bodystmt.3;
@@ -1082,11 +1059,7 @@ fn all_labelish(assocs: &[AssocNewOrAssocSplat]) -> bool {
     })
 }
 
-pub fn format_assocs(
-    ps: &mut ParserState,
-    assocs: Vec<AssocNewOrAssocSplat>,
-    sc: SpecialCase,
-) {
+pub fn format_assocs(ps: &mut ParserState, assocs: Vec<AssocNewOrAssocSplat>, sc: SpecialCase) {
     let len = assocs.len();
     let all_labelish = all_labelish(&assocs);
     for (idx, assoc) in assocs.into_iter().enumerate() {
@@ -1101,10 +1074,7 @@ pub fn format_assocs(
     }
 }
 
-pub fn format_assocs_single_line(
-    ps: &mut ParserState,
-    assocs: Vec<AssocNewOrAssocSplat>,
-) {
+pub fn format_assocs_single_line(ps: &mut ParserState, assocs: Vec<AssocNewOrAssocSplat>) {
     let len = assocs.len();
     let all_labelish = all_labelish(&assocs);
     for (idx, assoc) in assocs.into_iter().enumerate() {
@@ -1115,11 +1085,7 @@ pub fn format_assocs_single_line(
     }
 }
 
-pub fn format_assoc(
-    ps: &mut ParserState,
-    assoc: AssocNewOrAssocSplat,
-    all_labelish: bool,
-) {
+pub fn format_assoc(ps: &mut ParserState, assoc: AssocNewOrAssocSplat, all_labelish: bool) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| match assoc {
@@ -1359,11 +1325,7 @@ pub fn percent_symbol_for(tag: String) -> String {
     }
 }
 
-pub fn format_percent_array(
-    ps: &mut ParserState,
-    tag: String,
-    parts: Vec<Vec<StringContentPart>>,
-) {
+pub fn format_percent_array(ps: &mut ParserState, tag: String, parts: Vec<Vec<StringContentPart>>) {
     ps.emit_ident(percent_symbol_for(tag));
     ps.with_start_of_line(
         false,
@@ -1546,11 +1508,7 @@ pub enum StringType {
     Regexp,
 }
 
-fn format_inner_string(
-    ps: &mut ParserState,
-    parts: Vec<StringContentPart>,
-    tipe: StringType,
-) {
+fn format_inner_string(ps: &mut ParserState, parts: Vec<StringContentPart>, tipe: StringType) {
     let mut peekable = parts.into_iter().peekable();
     while peekable.peek().is_some() {
         let part = peekable.next().expect("we peeked");

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -7,7 +7,7 @@ use crate::render_targets::MultilineHandling;
 use crate::ripper_tree_types::*;
 use crate::types::LineNumber;
 
-pub fn format_def(ps: &mut dyn ConcreteParserState, def: Def) {
+pub fn format_def(ps: &mut BaseParserState, def: Def) {
     let def_expression = (def.1).to_def_parts();
 
     let body = def.3;
@@ -27,7 +27,7 @@ pub fn format_def(ps: &mut dyn ConcreteParserState, def: Def) {
 }
 
 fn format_def_body(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     pp: ParenOrParams,
     bodystmt: DefBodyStmt,
     end_line: LineNumber,
@@ -77,9 +77,9 @@ fn format_def_body(
     }
 }
 
-type ParamFormattingFunc = Box<dyn FnOnce(&mut dyn ConcreteParserState) -> bool>;
+type ParamFormattingFunc = Box<dyn FnOnce(&mut BaseParserState) -> bool>;
 
-pub fn inner_format_params(ps: &mut dyn ConcreteParserState, params: Box<Params>) {
+pub fn inner_format_params(ps: &mut BaseParserState, params: Box<Params>) {
     let non_null_positions = params.non_null_positions();
     //def foo(a, b=nil, *args, d, e:, **kwargs, &blk)
     //        ^  ^___^  ^___^  ^  ^    ^_____^   ^
@@ -106,21 +106,21 @@ pub fn inner_format_params(ps: &mut dyn ConcreteParserState, params: Box<Params>
     let block_arg = params.7;
 
     let formats: Vec<ParamFormattingFunc> = vec![
-        Box::new(move |ps: &mut dyn ConcreteParserState| {
+        Box::new(move |ps: &mut BaseParserState| {
             format_required_params(ps, required_params)
         }),
-        Box::new(move |ps: &mut dyn ConcreteParserState| {
+        Box::new(move |ps: &mut BaseParserState| {
             format_optional_params(ps, optional_params)
         }),
-        Box::new(move |ps: &mut dyn ConcreteParserState| {
+        Box::new(move |ps: &mut BaseParserState| {
             format_rest_param(ps, rest_param, SpecialCase::NoSpecialCase)
         }),
-        Box::new(move |ps: &mut dyn ConcreteParserState| {
+        Box::new(move |ps: &mut BaseParserState| {
             format_required_params(ps, more_required_params)
         }),
-        Box::new(move |ps: &mut dyn ConcreteParserState| format_kwargs(ps, kwargs)),
-        Box::new(move |ps: &mut dyn ConcreteParserState| format_kwrest_params(ps, kwrest_params)),
-        Box::new(move |ps: &mut dyn ConcreteParserState| format_block_arg(ps, block_arg)),
+        Box::new(move |ps: &mut BaseParserState| format_kwargs(ps, kwargs)),
+        Box::new(move |ps: &mut BaseParserState| format_kwrest_params(ps, kwrest_params)),
+        Box::new(move |ps: &mut BaseParserState| format_block_arg(ps, block_arg)),
     ];
 
     for (idx, format_fn) in formats.into_iter().enumerate() {
@@ -135,7 +135,7 @@ pub fn inner_format_params(ps: &mut dyn ConcreteParserState, params: Box<Params>
     }
 }
 
-pub fn format_blockvar(ps: &mut dyn ConcreteParserState, bv: BlockVar) {
+pub fn format_blockvar(ps: &mut BaseParserState, bv: BlockVar) {
     let start_end = bv.3;
     let f_params = match bv.2 {
         BlockLocalVariables::Present(v) => Some(v),
@@ -190,7 +190,7 @@ pub fn format_blockvar(ps: &mut dyn ConcreteParserState, bv: BlockVar) {
 }
 
 pub fn format_params(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     params: Box<Params>,
     delims: BreakableDelims,
 ) {
@@ -212,7 +212,7 @@ pub fn format_params(
 }
 
 pub fn format_kwrest_params(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     kwrest_params: Option<KwRestParamOrArgsForward>,
 ) -> bool {
     if kwrest_params.is_none() {
@@ -240,7 +240,7 @@ pub fn format_kwrest_params(
 }
 
 pub fn format_block_arg(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     block_arg: Option<BlockArgOrTag>,
 ) -> bool {
     match block_arg {
@@ -264,7 +264,7 @@ pub fn format_block_arg(
 }
 
 pub fn format_kwargs(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     kwargs: Vec<(Label, ExpressionOrFalse)>,
 ) -> bool {
     if kwargs.is_empty() {
@@ -301,7 +301,7 @@ pub fn format_kwargs(
 }
 
 pub fn format_rest_param(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     rest_param: Option<RestParamOr0OrExcessedComma>,
     special_case: SpecialCase,
 ) -> bool {
@@ -350,7 +350,7 @@ pub fn format_rest_param(
 }
 
 pub fn format_optional_params(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     optional_params: Vec<(Ident, Expression)>,
 ) -> bool {
     if optional_params.is_empty() {
@@ -375,7 +375,7 @@ pub fn format_optional_params(
     true
 }
 
-pub fn format_mlhs(ps: &mut dyn ConcreteParserState, mlhs: MLhs) {
+pub fn format_mlhs(ps: &mut BaseParserState, mlhs: MLhs) {
     ps.emit_open_paren();
 
     ps.with_start_of_line(
@@ -408,15 +408,15 @@ pub fn format_mlhs(ps: &mut dyn ConcreteParserState, mlhs: MLhs) {
     ps.emit_close_paren();
 }
 
-fn bind_var_field(ps: &mut dyn ConcreteParserState, vf: &VarField) {
+fn bind_var_field(ps: &mut BaseParserState, vf: &VarField) {
     ps.bind_variable((vf.1).clone().to_local_string())
 }
 
-fn bind_ident(ps: &mut dyn ConcreteParserState, id: &Ident) {
+fn bind_ident(ps: &mut BaseParserState, id: &Ident) {
     ps.bind_variable((id.1).clone())
 }
 
-fn bind_mlhs(ps: &mut dyn ConcreteParserState, mlhs: &MLhs) {
+fn bind_mlhs(ps: &mut BaseParserState, mlhs: &MLhs) {
     for value in (mlhs.0).iter() {
         match value {
             MLhsInner::VarField(v) => bind_var_field(ps, v),
@@ -435,7 +435,7 @@ fn bind_mlhs(ps: &mut dyn ConcreteParserState, mlhs: &MLhs) {
 }
 
 pub fn format_required_params(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     required_params: Vec<IdentOrMLhs>,
 ) -> bool {
     if required_params.is_empty() {
@@ -465,7 +465,7 @@ pub fn format_required_params(
     true
 }
 
-pub fn emit_params_separator(ps: &mut dyn ConcreteParserState, index: usize, length: usize) {
+pub fn emit_params_separator(ps: &mut BaseParserState, index: usize, length: usize) {
     if index != length - 1 {
         ps.emit_comma();
         ps.emit_soft_newline();
@@ -473,7 +473,7 @@ pub fn emit_params_separator(ps: &mut dyn ConcreteParserState, index: usize, len
 }
 
 pub fn format_bodystmt(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     bodystmt: Box<BodyStmt>,
     end_line: LineNumber,
 ) {
@@ -505,7 +505,7 @@ pub fn format_bodystmt(
     format_ensure(ps, ensure_part);
 }
 
-pub fn format_mrhs(ps: &mut dyn ConcreteParserState, mrhs: Option<MRHS>) {
+pub fn format_mrhs(ps: &mut BaseParserState, mrhs: Option<MRHS>) {
     match mrhs {
         None => {}
         Some(MRHS::Single(expr)) => {
@@ -536,7 +536,7 @@ pub fn format_mrhs(ps: &mut dyn ConcreteParserState, mrhs: Option<MRHS>) {
 }
 
 pub fn format_rescue_capture(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     rescue_capture: Option<Assignable>,
     class_present: bool,
 ) {
@@ -553,7 +553,7 @@ pub fn format_rescue_capture(
     }
 }
 
-pub fn format_rescue(ps: &mut dyn ConcreteParserState, rescue_part: Option<Rescue>) {
+pub fn format_rescue(ps: &mut BaseParserState, rescue_part: Option<Rescue>) {
     match rescue_part {
         None => {}
         Some(Rescue(_, class, capture, expressions, more_rescue, start_end)) => {
@@ -603,7 +603,7 @@ pub fn format_rescue(ps: &mut dyn ConcreteParserState, rescue_part: Option<Rescu
 }
 
 pub fn format_else(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     else_part: Option<RescueElseOrExpressionList>,
     end_line: LineNumber,
 ) {
@@ -653,7 +653,7 @@ pub fn format_else(
     }
 }
 
-pub fn format_ensure(ps: &mut dyn ConcreteParserState, ensure_part: Option<Ensure>) {
+pub fn format_ensure(ps: &mut BaseParserState, ensure_part: Option<Ensure>) {
     match ensure_part {
         None => {}
         Some(e) => {
@@ -713,7 +713,7 @@ lazy_static! {
 }
 
 pub fn use_parens_for_method_call(
-    ps: &dyn ConcreteParserState,
+    ps: &BaseParserState,
     chain: &[CallChainElement],
     method: &IdentOrOpOrKeywordOrConst,
     args: &ArgsAddStarOrExpressionListOrArgsForward,
@@ -789,14 +789,14 @@ pub fn use_parens_for_method_call(
     true
 }
 
-pub fn format_dot_type(ps: &mut dyn ConcreteParserState, dt: DotType) {
+pub fn format_dot_type(ps: &mut BaseParserState, dt: DotType) {
     match dt {
         DotType::Dot(_) => ps.emit_dot(),
         DotType::LonelyOperator(_) => ps.emit_lonely_operator(),
     }
 }
 
-pub fn format_dot(ps: &mut dyn ConcreteParserState, dot: DotTypeOrOp) {
+pub fn format_dot(ps: &mut BaseParserState, dot: DotTypeOrOp) {
     match dot {
         DotTypeOrOp::DotType(dt) => format_dot_type(ps, dt),
         DotTypeOrOp::Op(op) => {
@@ -825,7 +825,7 @@ pub fn format_dot(ps: &mut dyn ConcreteParserState, dot: DotTypeOrOp) {
     }
 }
 
-pub fn format_method_call(ps: &mut dyn ConcreteParserState, method_call: MethodCall) {
+pub fn format_method_call(ps: &mut BaseParserState, method_call: MethodCall) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -865,7 +865,7 @@ pub enum SpecialCase {
 }
 
 pub fn format_list_like_thing_items(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     args: Vec<Expression>,
     end_line: Option<LineNumber>,
     single_line: bool,
@@ -921,7 +921,7 @@ pub fn format_list_like_thing_items(
     emitted_args
 }
 
-pub fn format_ident(ps: &mut dyn ConcreteParserState, ident: Ident) {
+pub fn format_ident(ps: &mut BaseParserState, ident: Ident) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -933,7 +933,7 @@ pub fn format_ident(ps: &mut dyn ConcreteParserState, ident: Ident) {
     }
 }
 
-pub fn format_const(ps: &mut dyn ConcreteParserState, c: Const) {
+pub fn format_const(ps: &mut BaseParserState, c: Const) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -945,7 +945,7 @@ pub fn format_const(ps: &mut dyn ConcreteParserState, c: Const) {
     }
 }
 
-pub fn format_int(ps: &mut dyn ConcreteParserState, int: Int) {
+pub fn format_int(ps: &mut BaseParserState, int: Int) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -957,11 +957,11 @@ pub fn format_int(ps: &mut dyn ConcreteParserState, int: Int) {
     }
 }
 
-pub fn format_bare_assoc_hash(ps: &mut dyn ConcreteParserState, bah: BareAssocHash) {
+pub fn format_bare_assoc_hash(ps: &mut BaseParserState, bah: BareAssocHash) {
     format_assocs(ps, bah.1, SpecialCase::NoSpecialCase)
 }
 
-pub fn format_alias(ps: &mut dyn ConcreteParserState, alias: Alias) {
+pub fn format_alias(ps: &mut BaseParserState, alias: Alias) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -983,7 +983,7 @@ pub fn format_alias(ps: &mut dyn ConcreteParserState, alias: Alias) {
 }
 
 pub fn format_symbol_literal_or_dyna_symbol(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     symbol_literal_or_dyna_symbol: SymbolLiteralOrDynaSymbol,
 ) {
     match symbol_literal_or_dyna_symbol {
@@ -994,7 +994,7 @@ pub fn format_symbol_literal_or_dyna_symbol(
     }
 }
 
-pub fn format_op(ps: &mut dyn ConcreteParserState, op: Op) {
+pub fn format_op(ps: &mut BaseParserState, op: Op) {
     match op.1 {
         Operator::Equals(_) => ps.emit_ident("==".to_string()),
         Operator::Dot(_) => ps.emit_dot(),
@@ -1003,7 +1003,7 @@ pub fn format_op(ps: &mut dyn ConcreteParserState, op: Op) {
     }
 }
 
-pub fn format_kw(ps: &mut dyn ConcreteParserState, kw: Kw) {
+pub fn format_kw(ps: &mut BaseParserState, kw: Kw) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1015,7 +1015,7 @@ pub fn format_kw(ps: &mut dyn ConcreteParserState, kw: Kw) {
     }
 }
 
-pub fn format_backtick(ps: &mut dyn ConcreteParserState, backtick: Backtick) {
+pub fn format_backtick(ps: &mut BaseParserState, backtick: Backtick) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1027,7 +1027,7 @@ pub fn format_backtick(ps: &mut dyn ConcreteParserState, backtick: Backtick) {
     }
 }
 
-pub fn format_symbol(ps: &mut dyn ConcreteParserState, symbol: Symbol) {
+pub fn format_symbol(ps: &mut BaseParserState, symbol: Symbol) {
     ps.emit_ident(":".to_string());
     match symbol.1 {
         IdentOrConstOrKwOrOpOrIvarOrGvarOrCvarOrBacktick::Ident(i) => format_ident(ps, i),
@@ -1049,7 +1049,7 @@ pub fn format_symbol(ps: &mut dyn ConcreteParserState, symbol: Symbol) {
     }
 }
 
-pub fn format_symbol_literal(ps: &mut dyn ConcreteParserState, symbol_literal: SymbolLiteral) {
+pub fn format_symbol_literal(ps: &mut BaseParserState, symbol_literal: SymbolLiteral) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1083,7 +1083,7 @@ fn all_labelish(assocs: &[AssocNewOrAssocSplat]) -> bool {
 }
 
 pub fn format_assocs(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     assocs: Vec<AssocNewOrAssocSplat>,
     sc: SpecialCase,
 ) {
@@ -1102,7 +1102,7 @@ pub fn format_assocs(
 }
 
 pub fn format_assocs_single_line(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     assocs: Vec<AssocNewOrAssocSplat>,
 ) {
     let len = assocs.len();
@@ -1116,7 +1116,7 @@ pub fn format_assocs_single_line(
 }
 
 pub fn format_assoc(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     assoc: AssocNewOrAssocSplat,
     all_labelish: bool,
 ) {
@@ -1158,7 +1158,7 @@ pub fn format_assoc(
     );
 }
 
-pub fn format_begin(ps: &mut dyn ConcreteParserState, begin: Begin) {
+pub fn format_begin(ps: &mut BaseParserState, begin: Begin) {
     if ps.at_start_of_line() {
         ps.emit_indent()
     }
@@ -1190,7 +1190,7 @@ pub fn format_begin(ps: &mut dyn ConcreteParserState, begin: Begin) {
     }
 }
 
-pub fn format_begin_block(ps: &mut dyn ConcreteParserState, begin: BeginBlock) {
+pub fn format_begin_block(ps: &mut BaseParserState, begin: BeginBlock) {
     if ps.at_start_of_line() {
         ps.emit_indent()
     }
@@ -1222,7 +1222,7 @@ pub fn format_begin_block(ps: &mut dyn ConcreteParserState, begin: BeginBlock) {
     }
 }
 
-pub fn format_end_block(ps: &mut dyn ConcreteParserState, end: EndBlock) {
+pub fn format_end_block(ps: &mut BaseParserState, end: EndBlock) {
     if ps.at_start_of_line() {
         ps.emit_indent()
     }
@@ -1267,11 +1267,11 @@ pub fn normalize(e: Expression) -> Expression {
     }
 }
 
-pub fn format_void_stmt(_ps: &mut dyn ConcreteParserState, _void: VoidStmt) {
+pub fn format_void_stmt(_ps: &mut BaseParserState, _void: VoidStmt) {
     // deliberately does nothing
 }
 
-pub fn format_paren(ps: &mut dyn ConcreteParserState, paren: ParenExpr) {
+pub fn format_paren(ps: &mut BaseParserState, paren: ParenExpr) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1311,16 +1311,16 @@ pub fn format_paren(ps: &mut dyn ConcreteParserState, paren: ParenExpr) {
     }
 }
 
-pub fn format_dot2(ps: &mut dyn ConcreteParserState, dot2: Dot2) {
+pub fn format_dot2(ps: &mut BaseParserState, dot2: Dot2) {
     format_dot2_or_3(ps, "..".to_string(), dot2.1, dot2.2);
 }
 
-pub fn format_dot3(ps: &mut dyn ConcreteParserState, dot3: Dot3) {
+pub fn format_dot3(ps: &mut BaseParserState, dot3: Dot3) {
     format_dot2_or_3(ps, "...".to_string(), dot3.1, dot3.2);
 }
 
 pub fn format_dot2_or_3(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     dots: String,
     left: Option<Box<Expression>>,
     right: Option<Box<Expression>>,
@@ -1360,7 +1360,7 @@ pub fn percent_symbol_for(tag: String) -> String {
 }
 
 pub fn format_percent_array(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     tag: String,
     parts: Vec<Vec<StringContentPart>>,
 ) {
@@ -1386,7 +1386,7 @@ pub fn format_percent_array(
     );
 }
 
-pub fn format_array(ps: &mut dyn ConcreteParserState, array: Array) {
+pub fn format_array(ps: &mut BaseParserState, array: Array) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1419,7 +1419,7 @@ pub fn format_array(ps: &mut dyn ConcreteParserState, array: Array) {
 }
 
 pub fn format_array_fast_path(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     start_end: &StartEnd,
     a: Option<ArgsAddStarOrExpressionListOrArgsForward>,
 ) {
@@ -1452,7 +1452,7 @@ pub fn format_array_fast_path(
 }
 
 pub fn format_list_like_thing(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     a: ArgsAddStarOrExpressionListOrArgsForward,
     end_line: Option<LineNumber>,
     single_line: bool,
@@ -1528,7 +1528,7 @@ pub fn format_list_like_thing(
     }
 }
 
-pub fn emit_intermediate_array_separator(ps: &mut dyn ConcreteParserState, single_line: bool) {
+pub fn emit_intermediate_array_separator(ps: &mut BaseParserState, single_line: bool) {
     if single_line {
         ps.emit_comma_space();
     } else {
@@ -1547,7 +1547,7 @@ pub enum StringType {
 }
 
 fn format_inner_string(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     parts: Vec<StringContentPart>,
     tipe: StringType,
 ) {
@@ -1627,7 +1627,7 @@ fn format_inner_string(
 }
 
 pub fn format_heredoc_string_literal(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     hd: HeredocStringLiteral,
     parts: Vec<StringContentPart>,
 ) {
@@ -1663,7 +1663,7 @@ pub fn format_heredoc_string_literal(
     }
 }
 
-pub fn format_string_literal(ps: &mut dyn ConcreteParserState, sl: StringLiteral) {
+pub fn format_string_literal(ps: &mut BaseParserState, sl: StringLiteral) {
     match sl {
         StringLiteral::Heredoc(_, hd, StringContent(_, parts)) => {
             format_heredoc_string_literal(ps, hd, parts)
@@ -1686,7 +1686,7 @@ pub fn format_string_literal(ps: &mut dyn ConcreteParserState, sl: StringLiteral
     }
 }
 
-pub fn format_xstring_literal(ps: &mut dyn ConcreteParserState, xsl: XStringLiteral) {
+pub fn format_xstring_literal(ps: &mut BaseParserState, xsl: XStringLiteral) {
     let parts = xsl.1;
 
     if ps.at_start_of_line() {
@@ -1702,7 +1702,7 @@ pub fn format_xstring_literal(ps: &mut dyn ConcreteParserState, xsl: XStringLite
     }
 }
 
-pub fn format_const_path_field(ps: &mut dyn ConcreteParserState, cf: ConstPathField) {
+pub fn format_const_path_field(ps: &mut BaseParserState, cf: ConstPathField) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1721,7 +1721,7 @@ pub fn format_const_path_field(ps: &mut dyn ConcreteParserState, cf: ConstPathFi
     }
 }
 
-pub fn format_top_const_field(ps: &mut dyn ConcreteParserState, tcf: TopConstField) {
+pub fn format_top_const_field(ps: &mut BaseParserState, tcf: TopConstField) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1739,12 +1739,12 @@ pub fn format_top_const_field(ps: &mut dyn ConcreteParserState, tcf: TopConstFie
     }
 }
 
-pub fn format_var_field(ps: &mut dyn ConcreteParserState, vf: VarField) {
+pub fn format_var_field(ps: &mut BaseParserState, vf: VarField) {
     let left = vf.1;
     format_var_ref_type(ps, left);
 }
 
-pub fn format_aref_field(ps: &mut dyn ConcreteParserState, af: ArefField) {
+pub fn format_aref_field(ps: &mut BaseParserState, af: ArefField) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1778,7 +1778,7 @@ pub fn format_aref_field(ps: &mut dyn ConcreteParserState, af: ArefField) {
     }
 }
 
-pub fn format_field(ps: &mut dyn ConcreteParserState, f: Field) {
+pub fn format_field(ps: &mut BaseParserState, f: Field) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1800,7 +1800,7 @@ pub fn format_field(ps: &mut dyn ConcreteParserState, f: Field) {
     }
 }
 
-pub fn format_assignable(ps: &mut dyn ConcreteParserState, v: Assignable) {
+pub fn format_assignable(ps: &mut BaseParserState, v: Assignable) {
     match v {
         Assignable::VarField(vf) => {
             bind_var_field(ps, &vf);
@@ -1835,7 +1835,7 @@ pub fn format_assignable(ps: &mut dyn ConcreteParserState, v: Assignable) {
     }
 }
 
-pub fn format_assign(ps: &mut dyn ConcreteParserState, assign: Assign) {
+pub fn format_assign(ps: &mut BaseParserState, assign: Assign) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1867,7 +1867,7 @@ pub fn format_assign(ps: &mut dyn ConcreteParserState, assign: Assign) {
     }
 }
 
-pub fn format_massign(ps: &mut dyn ConcreteParserState, massign: MAssign) {
+pub fn format_massign(ps: &mut BaseParserState, massign: MAssign) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1915,7 +1915,7 @@ pub fn format_massign(ps: &mut dyn ConcreteParserState, massign: MAssign) {
     }
 }
 
-pub fn format_var_ref_type(ps: &mut dyn ConcreteParserState, vr: VarRefType) {
+pub fn format_var_ref_type(ps: &mut BaseParserState, vr: VarRefType) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1934,16 +1934,16 @@ pub fn format_var_ref_type(ps: &mut dyn ConcreteParserState, vr: VarRefType) {
     }
 }
 
-pub fn handle_string_and_linecol(ps: &mut dyn ConcreteParserState, ident: String, lc: LineCol) {
+pub fn handle_string_and_linecol(ps: &mut BaseParserState, ident: String, lc: LineCol) {
     ps.on_line(lc.0);
     ps.emit_ident(ident);
 }
 
-pub fn format_var_ref(ps: &mut dyn ConcreteParserState, vr: VarRef) {
+pub fn format_var_ref(ps: &mut BaseParserState, vr: VarRef) {
     format_var_ref_type(ps, vr.1);
 }
 
-pub fn format_const_path_ref(ps: &mut dyn ConcreteParserState, cpr: ConstPathRef) {
+pub fn format_const_path_ref(ps: &mut BaseParserState, cpr: ConstPathRef) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1962,7 +1962,7 @@ pub fn format_const_path_ref(ps: &mut dyn ConcreteParserState, cpr: ConstPathRef
     }
 }
 
-pub fn format_top_const_ref(ps: &mut dyn ConcreteParserState, tcr: TopConstRef) {
+pub fn format_top_const_ref(ps: &mut BaseParserState, tcr: TopConstRef) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1980,7 +1980,7 @@ pub fn format_top_const_ref(ps: &mut dyn ConcreteParserState, tcr: TopConstRef) 
     }
 }
 
-pub fn format_defined(ps: &mut dyn ConcreteParserState, defined: Defined) {
+pub fn format_defined(ps: &mut BaseParserState, defined: Defined) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2000,7 +2000,7 @@ pub fn format_defined(ps: &mut dyn ConcreteParserState, defined: Defined) {
     }
 }
 
-pub fn format_rescue_mod(ps: &mut dyn ConcreteParserState, rescue_mod: RescueMod) {
+pub fn format_rescue_mod(ps: &mut BaseParserState, rescue_mod: RescueMod) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2021,7 +2021,7 @@ pub fn format_rescue_mod(ps: &mut dyn ConcreteParserState, rescue_mod: RescueMod
     }
 }
 
-pub fn format_mrhs_new_from_args(ps: &mut dyn ConcreteParserState, mnfa: MRHSNewFromArgs) {
+pub fn format_mrhs_new_from_args(ps: &mut BaseParserState, mnfa: MRHSNewFromArgs) {
     format_list_like_thing(ps, mnfa.1, None, true);
 
     if let Some(expr) = mnfa.2 {
@@ -2030,7 +2030,7 @@ pub fn format_mrhs_new_from_args(ps: &mut dyn ConcreteParserState, mnfa: MRHSNew
     }
 }
 
-pub fn format_mrhs_add_star(ps: &mut dyn ConcreteParserState, mrhs: MRHSAddStar) {
+pub fn format_mrhs_add_star(ps: &mut BaseParserState, mrhs: MRHSAddStar) {
     let first = mrhs.1;
     let second = mrhs.2;
     ps.with_start_of_line(
@@ -2058,7 +2058,7 @@ pub fn format_mrhs_add_star(ps: &mut dyn ConcreteParserState, mrhs: MRHSAddStar)
     );
 }
 
-pub fn format_next(ps: &mut dyn ConcreteParserState, next: Next) {
+pub fn format_next(ps: &mut BaseParserState, next: Next) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2099,7 +2099,7 @@ pub fn format_next(ps: &mut dyn ConcreteParserState, next: Next) {
     }
 }
 
-pub fn format_unary(ps: &mut dyn ConcreteParserState, unary: Unary) {
+pub fn format_unary(ps: &mut BaseParserState, unary: Unary) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2135,7 +2135,7 @@ pub fn format_unary(ps: &mut dyn ConcreteParserState, unary: Unary) {
     }
 }
 
-pub fn format_string_concat(ps: &mut dyn ConcreteParserState, sc: StringConcat) {
+pub fn format_string_concat(ps: &mut BaseParserState, sc: StringConcat) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2165,7 +2165,7 @@ pub fn format_string_concat(ps: &mut dyn ConcreteParserState, sc: StringConcat) 
     }
 }
 
-pub fn format_dyna_symbol(ps: &mut dyn ConcreteParserState, ds: DynaSymbol) {
+pub fn format_dyna_symbol(ps: &mut BaseParserState, ds: DynaSymbol) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2183,7 +2183,7 @@ pub fn format_dyna_symbol(ps: &mut dyn ConcreteParserState, ds: DynaSymbol) {
     }
 }
 
-pub fn format_undef(ps: &mut dyn ConcreteParserState, undef: Undef) {
+pub fn format_undef(ps: &mut BaseParserState, undef: Undef) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2205,7 +2205,7 @@ pub fn format_undef(ps: &mut dyn ConcreteParserState, undef: Undef) {
     }
 }
 
-pub fn format_defs(ps: &mut dyn ConcreteParserState, defs: Defs) {
+pub fn format_defs(ps: &mut BaseParserState, defs: Defs) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2247,7 +2247,7 @@ pub fn format_defs(ps: &mut dyn ConcreteParserState, defs: Defs) {
     }
 }
 
-pub fn format_paren_or_params(ps: &mut dyn ConcreteParserState, pp: ParenOrParams) {
+pub fn format_paren_or_params(ps: &mut BaseParserState, pp: ParenOrParams) {
     let maybe_closing_paren_line = match &pp {
         ParenOrParams::Paren(p) => Some(p.2.end_line()),
         _ => None,
@@ -2266,7 +2266,7 @@ pub fn format_paren_or_params(ps: &mut dyn ConcreteParserState, pp: ParenOrParam
 
 // Modules and classes bodies should be treated the same,
 // the only real difference is in the module/class name and inheritance
-fn format_constant_body(ps: &mut dyn ConcreteParserState, bodystmt: Box<BodyStmt>, end_line: u64) {
+fn format_constant_body(ps: &mut BaseParserState, bodystmt: Box<BodyStmt>, end_line: u64) {
     ps.new_block(Box::new(|ps| {
         ps.with_start_of_line(
             true,
@@ -2294,7 +2294,7 @@ fn format_constant_body(ps: &mut dyn ConcreteParserState, bodystmt: Box<BodyStmt
     }
 }
 
-pub fn format_class(ps: &mut dyn ConcreteParserState, class: Class) {
+pub fn format_class(ps: &mut BaseParserState, class: Class) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2332,7 +2332,7 @@ pub fn format_class(ps: &mut dyn ConcreteParserState, class: Class) {
     format_constant_body(ps, bodystmt, end_line);
 }
 
-pub fn format_module(ps: &mut dyn ConcreteParserState, module: Module) {
+pub fn format_module(ps: &mut BaseParserState, module: Module) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2365,7 +2365,7 @@ pub fn format_module(ps: &mut dyn ConcreteParserState, module: Module) {
 }
 
 pub fn format_conditional(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     cond_expr: Expression,
     body: Vec<Expression>,
     kw: String,
@@ -2441,7 +2441,7 @@ pub fn format_conditional(
     }
 }
 
-pub fn format_if(ps: &mut dyn ConcreteParserState, ifs: If) {
+pub fn format_if(ps: &mut BaseParserState, ifs: If) {
     let vifs = ifs.clone();
     format_conditional(ps, *ifs.1, ifs.2, "if".to_string(), ifs.3, Some(ifs.4));
 
@@ -2458,7 +2458,7 @@ pub fn format_if(ps: &mut dyn ConcreteParserState, ifs: If) {
     }
 }
 
-pub fn format_unless(ps: &mut dyn ConcreteParserState, unless: Unless) {
+pub fn format_unless(ps: &mut BaseParserState, unless: Unless) {
     format_conditional(
         ps,
         *unless.1,
@@ -2479,7 +2479,7 @@ pub fn format_unless(ps: &mut dyn ConcreteParserState, unless: Unless) {
     }
 }
 
-pub fn format_binary(ps: &mut dyn ConcreteParserState, binary: Binary) {
+pub fn format_binary(ps: &mut BaseParserState, binary: Binary) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2508,7 +2508,7 @@ pub fn format_binary(ps: &mut dyn ConcreteParserState, binary: Binary) {
 // Performs the actual formatting for binary operators. This method assumes that it's
 // inside of a breakable, but it's separated out so that it can recurse inside of
 // nested breakables so that nested breakables stay at the same indentation level.
-fn format_binary_inner(ps: &mut dyn ConcreteParserState, binary: Binary) {
+fn format_binary_inner(ps: &mut BaseParserState, binary: Binary) {
     ps.with_formatting_context(
         FormattingContext::Binary,
         Box::new(|ps| {
@@ -2554,7 +2554,7 @@ fn format_binary_inner(ps: &mut dyn ConcreteParserState, binary: Binary) {
     );
 }
 
-pub fn format_float(ps: &mut dyn ConcreteParserState, float: Float) {
+pub fn format_float(ps: &mut BaseParserState, float: Float) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2566,7 +2566,7 @@ pub fn format_float(ps: &mut dyn ConcreteParserState, float: Float) {
     }
 }
 
-pub fn format_aref(ps: &mut dyn ConcreteParserState, aref: Aref) {
+pub fn format_aref(ps: &mut BaseParserState, aref: Aref) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2598,7 +2598,7 @@ pub fn format_aref(ps: &mut dyn ConcreteParserState, aref: Aref) {
     }
 }
 
-pub fn format_char(ps: &mut dyn ConcreteParserState, c: Char) {
+pub fn format_char(ps: &mut BaseParserState, c: Char) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2613,7 +2613,7 @@ pub fn format_char(ps: &mut dyn ConcreteParserState, c: Char) {
     }
 }
 
-pub fn format_hash(ps: &mut dyn ConcreteParserState, hash: Hash) {
+pub fn format_hash(ps: &mut BaseParserState, hash: Hash) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2657,7 +2657,7 @@ pub fn format_hash(ps: &mut dyn ConcreteParserState, hash: Hash) {
     }
 }
 
-pub fn format_regexp_literal(ps: &mut dyn ConcreteParserState, regexp: RegexpLiteral) {
+pub fn format_regexp_literal(ps: &mut BaseParserState, regexp: RegexpLiteral) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2675,7 +2675,7 @@ pub fn format_regexp_literal(ps: &mut dyn ConcreteParserState, regexp: RegexpLit
     }
 }
 
-pub fn format_backref(ps: &mut dyn ConcreteParserState, backref: Backref) {
+pub fn format_backref(ps: &mut BaseParserState, backref: Backref) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2731,7 +2731,7 @@ fn can_elide_parens_for_reserved_names(cc: &[CallChainElement]) -> bool {
 
 /// Returns `true` if the call chain is indented, `false` if not
 fn format_call_chain(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     cc: Vec<CallChainElement>,
     last_call_use_parens: Option<bool>,
 ) {
@@ -2753,7 +2753,7 @@ fn format_call_chain(
 }
 
 fn format_call_chain_elements(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     cc: Vec<CallChainElement>,
     // Whether or not to force the last call to use parens. By default, falls back to normal call chain rules.
     // This is necessary for supporting things like parenthesized methods in `self.method` method chains where
@@ -2883,14 +2883,14 @@ fn format_call_chain_elements(
     }
 }
 
-pub fn format_block(ps: &mut dyn ConcreteParserState, b: Block) {
+pub fn format_block(ps: &mut BaseParserState, b: Block) {
     match b {
         Block::BraceBlock(bb) => format_brace_block(ps, bb),
         Block::DoBlock(db) => format_do_block(ps, db),
     }
 }
 
-pub fn format_method_add_block(ps: &mut dyn ConcreteParserState, mab: MethodAddBlock) {
+pub fn format_method_add_block(ps: &mut BaseParserState, mab: MethodAddBlock) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2944,7 +2944,7 @@ enum BraceBlockRenderMethod {
     MultipleExpressions,
 }
 
-pub fn format_brace_block(ps: &mut dyn ConcreteParserState, brace_block: BraceBlock) {
+pub fn format_brace_block(ps: &mut BaseParserState, brace_block: BraceBlock) {
     let bv = brace_block.1;
     let body = brace_block.2;
     let StartEnd(start_line, end_line) = brace_block.3;
@@ -2966,7 +2966,7 @@ pub fn format_brace_block(ps: &mut dyn ConcreteParserState, brace_block: BraceBl
 }
 
 fn render_block_contents(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     brace_block_render_method: BraceBlockRenderMethod,
     body: Vec<Expression>,
     end_line: u64,
@@ -3028,7 +3028,7 @@ fn render_block_contents(
 }
 
 fn get_brace_block_render_method(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     start_line: u64,
     end_line: u64,
     body: &[Expression],
@@ -3049,7 +3049,7 @@ fn get_brace_block_render_method(
     }
 }
 
-pub fn format_do_block(ps: &mut dyn ConcreteParserState, do_block: DoBlock) {
+pub fn format_do_block(ps: &mut BaseParserState, do_block: DoBlock) {
     ps.emit_do_keyword();
 
     let bv = do_block.1;
@@ -3081,7 +3081,7 @@ pub fn format_do_block(ps: &mut dyn ConcreteParserState, do_block: DoBlock) {
 }
 
 pub fn format_keyword(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     args: ParenOrArgsAddBlock,
     kw: String,
     start_end: StartEnd,
@@ -3138,7 +3138,7 @@ pub fn format_keyword(
 }
 
 pub fn format_while(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     conditional: Expression,
     exprs: Vec<Expression>,
     kw: String,
@@ -3175,7 +3175,7 @@ pub fn format_while(
 /// end
 /// ```
 pub fn format_inline_mod(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     conditional: Box<Expression>,
     body: Box<Expression>,
     name: String,
@@ -3202,7 +3202,7 @@ pub fn format_inline_mod(
 /// Some mod statements can be safely converted to their equivalent
 /// multiline forms, specifically `if` and `unless` mod statements.
 pub fn format_multilinable_mod(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     conditional: Box<Expression>,
     body: Box<Expression>,
     name: String,
@@ -3236,7 +3236,7 @@ pub fn format_multilinable_mod(
     }
 }
 
-pub fn format_when_or_else(ps: &mut dyn ConcreteParserState, tail: WhenOrElse) {
+pub fn format_when_or_else(ps: &mut BaseParserState, tail: WhenOrElse) {
     match tail {
         WhenOrElse::When(when) => {
             let conditionals = when.1;
@@ -3300,7 +3300,7 @@ pub fn format_when_or_else(ps: &mut dyn ConcreteParserState, tail: WhenOrElse) {
     }
 }
 
-pub fn format_case(ps: &mut dyn ConcreteParserState, case: Case) {
+pub fn format_case(ps: &mut BaseParserState, case: Case) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3338,7 +3338,7 @@ pub fn format_case(ps: &mut dyn ConcreteParserState, case: Case) {
     ps.on_line(case.3.1);
 }
 
-pub fn format_retry(ps: &mut dyn ConcreteParserState, r: Retry) {
+pub fn format_retry(ps: &mut BaseParserState, r: Retry) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
@@ -3347,7 +3347,7 @@ pub fn format_retry(ps: &mut dyn ConcreteParserState, r: Retry) {
     );
 }
 
-pub fn format_redo(ps: &mut dyn ConcreteParserState, r: Redo) {
+pub fn format_redo(ps: &mut BaseParserState, r: Redo) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
@@ -3356,7 +3356,7 @@ pub fn format_redo(ps: &mut dyn ConcreteParserState, r: Redo) {
     );
 }
 
-pub fn format_sclass(ps: &mut dyn ConcreteParserState, sc: SClass) {
+pub fn format_sclass(ps: &mut BaseParserState, sc: SClass) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3398,7 +3398,7 @@ pub fn format_sclass(ps: &mut dyn ConcreteParserState, sc: SClass) {
     }
 }
 
-pub fn format_stabby_lambda(ps: &mut dyn ConcreteParserState, sl: StabbyLambda) {
+pub fn format_stabby_lambda(ps: &mut BaseParserState, sl: StabbyLambda) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3463,7 +3463,7 @@ pub fn format_stabby_lambda(ps: &mut dyn ConcreteParserState, sl: StabbyLambda) 
     }
 }
 
-pub fn format_imaginary(ps: &mut dyn ConcreteParserState, imaginary: Imaginary) {
+pub fn format_imaginary(ps: &mut BaseParserState, imaginary: Imaginary) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3475,7 +3475,7 @@ pub fn format_imaginary(ps: &mut dyn ConcreteParserState, imaginary: Imaginary) 
     }
 }
 
-pub fn format_rational(ps: &mut dyn ConcreteParserState, rational: Rational) {
+pub fn format_rational(ps: &mut BaseParserState, rational: Rational) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3487,7 +3487,7 @@ pub fn format_rational(ps: &mut dyn ConcreteParserState, rational: Rational) {
     }
 }
 
-pub fn format_for(ps: &mut dyn ConcreteParserState, forloop: For) {
+pub fn format_for(ps: &mut BaseParserState, forloop: For) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3545,7 +3545,7 @@ pub fn format_for(ps: &mut dyn ConcreteParserState, forloop: For) {
     }
 }
 
-pub fn format_ifop(ps: &mut dyn ConcreteParserState, ifop: IfOp) {
+pub fn format_ifop(ps: &mut BaseParserState, ifop: IfOp) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3575,7 +3575,7 @@ pub fn format_ifop(ps: &mut dyn ConcreteParserState, ifop: IfOp) {
     }
 }
 
-pub fn format_return0(ps: &mut dyn ConcreteParserState, r: Return0) {
+pub fn format_return0(ps: &mut BaseParserState, r: Return0) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
@@ -3584,7 +3584,7 @@ pub fn format_return0(ps: &mut dyn ConcreteParserState, r: Return0) {
     );
 }
 
-pub fn format_opassign(ps: &mut dyn ConcreteParserState, opassign: OpAssign) {
+pub fn format_opassign(ps: &mut BaseParserState, opassign: OpAssign) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3604,16 +3604,16 @@ pub fn format_opassign(ps: &mut dyn ConcreteParserState, opassign: OpAssign) {
         ps.emit_newline();
     }
 }
-pub fn format_to_proc(ps: &mut dyn ConcreteParserState, e: Box<Expression>) {
+pub fn format_to_proc(ps: &mut BaseParserState, e: Box<Expression>) {
     ps.emit_ident("&".to_string());
     ps.with_start_of_line(false, Box::new(|ps| format_expression(ps, *e)));
 }
 
-pub fn format_anon_block_arg(ps: &mut dyn ConcreteParserState) {
+pub fn format_anon_block_arg(ps: &mut BaseParserState) {
     ps.emit_ident("&".to_string());
 }
 
-pub fn format_zsuper(ps: &mut dyn ConcreteParserState, start_end: StartEnd) {
+pub fn format_zsuper(ps: &mut BaseParserState, start_end: StartEnd) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
@@ -3622,7 +3622,7 @@ pub fn format_zsuper(ps: &mut dyn ConcreteParserState, start_end: StartEnd) {
     )
 }
 
-pub fn format_yield0(ps: &mut dyn ConcreteParserState, start_end: StartEnd) {
+pub fn format_yield0(ps: &mut BaseParserState, start_end: StartEnd) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
@@ -3631,11 +3631,11 @@ pub fn format_yield0(ps: &mut dyn ConcreteParserState, start_end: StartEnd) {
     )
 }
 
-pub fn format_yield(ps: &mut dyn ConcreteParserState, y: Yield) {
+pub fn format_yield(ps: &mut BaseParserState, y: Yield) {
     format_method_call(ps, y.to_method_call())
 }
 
-pub fn format_return(ps: &mut dyn ConcreteParserState, ret: Return) {
+pub fn format_return(ps: &mut BaseParserState, ret: Return) {
     let args = ret.1;
     let line = (ret.2).0;
     ps.on_line(line);
@@ -3695,7 +3695,7 @@ pub fn format_return(ps: &mut dyn ConcreteParserState, ret: Return) {
 }
 
 pub fn format_bare_return_args(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     args: ArgsAddStarOrExpressionListOrArgsForward,
 ) {
     ps.breakable_of(
@@ -3712,7 +3712,7 @@ pub fn format_bare_return_args(
     );
 }
 
-pub fn format_expression(ps: &mut dyn ConcreteParserState, expression: Expression) {
+pub fn format_expression(ps: &mut BaseParserState, expression: Expression) {
     let expression = normalize(expression);
     match expression {
         Expression::Def(def) => format_def(ps, def),

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2,12 +2,12 @@ use std::collections::HashSet;
 
 use crate::delimiters::BreakableDelims;
 use crate::heredoc_string::HeredocKind;
-use crate::parser_state::{BaseParserState, FormattingContext, RenderFunc};
+use crate::parser_state::{ParserState, FormattingContext, RenderFunc};
 use crate::render_targets::MultilineHandling;
 use crate::ripper_tree_types::*;
 use crate::types::LineNumber;
 
-pub fn format_def(ps: &mut BaseParserState, def: Def) {
+pub fn format_def(ps: &mut ParserState, def: Def) {
     let def_expression = (def.1).to_def_parts();
 
     let body = def.3;
@@ -27,7 +27,7 @@ pub fn format_def(ps: &mut BaseParserState, def: Def) {
 }
 
 fn format_def_body(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     pp: ParenOrParams,
     bodystmt: DefBodyStmt,
     end_line: LineNumber,
@@ -77,9 +77,9 @@ fn format_def_body(
     }
 }
 
-type ParamFormattingFunc = Box<dyn FnOnce(&mut BaseParserState) -> bool>;
+type ParamFormattingFunc = Box<dyn FnOnce(&mut ParserState) -> bool>;
 
-pub fn inner_format_params(ps: &mut BaseParserState, params: Box<Params>) {
+pub fn inner_format_params(ps: &mut ParserState, params: Box<Params>) {
     let non_null_positions = params.non_null_positions();
     //def foo(a, b=nil, *args, d, e:, **kwargs, &blk)
     //        ^  ^___^  ^___^  ^  ^    ^_____^   ^
@@ -106,21 +106,21 @@ pub fn inner_format_params(ps: &mut BaseParserState, params: Box<Params>) {
     let block_arg = params.7;
 
     let formats: Vec<ParamFormattingFunc> = vec![
-        Box::new(move |ps: &mut BaseParserState| {
+        Box::new(move |ps: &mut ParserState| {
             format_required_params(ps, required_params)
         }),
-        Box::new(move |ps: &mut BaseParserState| {
+        Box::new(move |ps: &mut ParserState| {
             format_optional_params(ps, optional_params)
         }),
-        Box::new(move |ps: &mut BaseParserState| {
+        Box::new(move |ps: &mut ParserState| {
             format_rest_param(ps, rest_param, SpecialCase::NoSpecialCase)
         }),
-        Box::new(move |ps: &mut BaseParserState| {
+        Box::new(move |ps: &mut ParserState| {
             format_required_params(ps, more_required_params)
         }),
-        Box::new(move |ps: &mut BaseParserState| format_kwargs(ps, kwargs)),
-        Box::new(move |ps: &mut BaseParserState| format_kwrest_params(ps, kwrest_params)),
-        Box::new(move |ps: &mut BaseParserState| format_block_arg(ps, block_arg)),
+        Box::new(move |ps: &mut ParserState| format_kwargs(ps, kwargs)),
+        Box::new(move |ps: &mut ParserState| format_kwrest_params(ps, kwrest_params)),
+        Box::new(move |ps: &mut ParserState| format_block_arg(ps, block_arg)),
     ];
 
     for (idx, format_fn) in formats.into_iter().enumerate() {
@@ -135,7 +135,7 @@ pub fn inner_format_params(ps: &mut BaseParserState, params: Box<Params>) {
     }
 }
 
-pub fn format_blockvar(ps: &mut BaseParserState, bv: BlockVar) {
+pub fn format_blockvar(ps: &mut ParserState, bv: BlockVar) {
     let start_end = bv.3;
     let f_params = match bv.2 {
         BlockLocalVariables::Present(v) => Some(v),
@@ -190,7 +190,7 @@ pub fn format_blockvar(ps: &mut BaseParserState, bv: BlockVar) {
 }
 
 pub fn format_params(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     params: Box<Params>,
     delims: BreakableDelims,
 ) {
@@ -212,7 +212,7 @@ pub fn format_params(
 }
 
 pub fn format_kwrest_params(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     kwrest_params: Option<KwRestParamOrArgsForward>,
 ) -> bool {
     if kwrest_params.is_none() {
@@ -240,7 +240,7 @@ pub fn format_kwrest_params(
 }
 
 pub fn format_block_arg(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     block_arg: Option<BlockArgOrTag>,
 ) -> bool {
     match block_arg {
@@ -264,7 +264,7 @@ pub fn format_block_arg(
 }
 
 pub fn format_kwargs(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     kwargs: Vec<(Label, ExpressionOrFalse)>,
 ) -> bool {
     if kwargs.is_empty() {
@@ -301,7 +301,7 @@ pub fn format_kwargs(
 }
 
 pub fn format_rest_param(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     rest_param: Option<RestParamOr0OrExcessedComma>,
     special_case: SpecialCase,
 ) -> bool {
@@ -350,7 +350,7 @@ pub fn format_rest_param(
 }
 
 pub fn format_optional_params(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     optional_params: Vec<(Ident, Expression)>,
 ) -> bool {
     if optional_params.is_empty() {
@@ -375,7 +375,7 @@ pub fn format_optional_params(
     true
 }
 
-pub fn format_mlhs(ps: &mut BaseParserState, mlhs: MLhs) {
+pub fn format_mlhs(ps: &mut ParserState, mlhs: MLhs) {
     ps.emit_open_paren();
 
     ps.with_start_of_line(
@@ -408,15 +408,15 @@ pub fn format_mlhs(ps: &mut BaseParserState, mlhs: MLhs) {
     ps.emit_close_paren();
 }
 
-fn bind_var_field(ps: &mut BaseParserState, vf: &VarField) {
+fn bind_var_field(ps: &mut ParserState, vf: &VarField) {
     ps.bind_variable((vf.1).clone().to_local_string())
 }
 
-fn bind_ident(ps: &mut BaseParserState, id: &Ident) {
+fn bind_ident(ps: &mut ParserState, id: &Ident) {
     ps.bind_variable((id.1).clone())
 }
 
-fn bind_mlhs(ps: &mut BaseParserState, mlhs: &MLhs) {
+fn bind_mlhs(ps: &mut ParserState, mlhs: &MLhs) {
     for value in (mlhs.0).iter() {
         match value {
             MLhsInner::VarField(v) => bind_var_field(ps, v),
@@ -435,7 +435,7 @@ fn bind_mlhs(ps: &mut BaseParserState, mlhs: &MLhs) {
 }
 
 pub fn format_required_params(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     required_params: Vec<IdentOrMLhs>,
 ) -> bool {
     if required_params.is_empty() {
@@ -465,7 +465,7 @@ pub fn format_required_params(
     true
 }
 
-pub fn emit_params_separator(ps: &mut BaseParserState, index: usize, length: usize) {
+pub fn emit_params_separator(ps: &mut ParserState, index: usize, length: usize) {
     if index != length - 1 {
         ps.emit_comma();
         ps.emit_soft_newline();
@@ -473,7 +473,7 @@ pub fn emit_params_separator(ps: &mut BaseParserState, index: usize, length: usi
 }
 
 pub fn format_bodystmt(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     bodystmt: Box<BodyStmt>,
     end_line: LineNumber,
 ) {
@@ -505,7 +505,7 @@ pub fn format_bodystmt(
     format_ensure(ps, ensure_part);
 }
 
-pub fn format_mrhs(ps: &mut BaseParserState, mrhs: Option<MRHS>) {
+pub fn format_mrhs(ps: &mut ParserState, mrhs: Option<MRHS>) {
     match mrhs {
         None => {}
         Some(MRHS::Single(expr)) => {
@@ -536,7 +536,7 @@ pub fn format_mrhs(ps: &mut BaseParserState, mrhs: Option<MRHS>) {
 }
 
 pub fn format_rescue_capture(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     rescue_capture: Option<Assignable>,
     class_present: bool,
 ) {
@@ -553,7 +553,7 @@ pub fn format_rescue_capture(
     }
 }
 
-pub fn format_rescue(ps: &mut BaseParserState, rescue_part: Option<Rescue>) {
+pub fn format_rescue(ps: &mut ParserState, rescue_part: Option<Rescue>) {
     match rescue_part {
         None => {}
         Some(Rescue(_, class, capture, expressions, more_rescue, start_end)) => {
@@ -603,7 +603,7 @@ pub fn format_rescue(ps: &mut BaseParserState, rescue_part: Option<Rescue>) {
 }
 
 pub fn format_else(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     else_part: Option<RescueElseOrExpressionList>,
     end_line: LineNumber,
 ) {
@@ -653,7 +653,7 @@ pub fn format_else(
     }
 }
 
-pub fn format_ensure(ps: &mut BaseParserState, ensure_part: Option<Ensure>) {
+pub fn format_ensure(ps: &mut ParserState, ensure_part: Option<Ensure>) {
     match ensure_part {
         None => {}
         Some(e) => {
@@ -713,7 +713,7 @@ lazy_static! {
 }
 
 pub fn use_parens_for_method_call(
-    ps: &BaseParserState,
+    ps: &ParserState,
     chain: &[CallChainElement],
     method: &IdentOrOpOrKeywordOrConst,
     args: &ArgsAddStarOrExpressionListOrArgsForward,
@@ -789,14 +789,14 @@ pub fn use_parens_for_method_call(
     true
 }
 
-pub fn format_dot_type(ps: &mut BaseParserState, dt: DotType) {
+pub fn format_dot_type(ps: &mut ParserState, dt: DotType) {
     match dt {
         DotType::Dot(_) => ps.emit_dot(),
         DotType::LonelyOperator(_) => ps.emit_lonely_operator(),
     }
 }
 
-pub fn format_dot(ps: &mut BaseParserState, dot: DotTypeOrOp) {
+pub fn format_dot(ps: &mut ParserState, dot: DotTypeOrOp) {
     match dot {
         DotTypeOrOp::DotType(dt) => format_dot_type(ps, dt),
         DotTypeOrOp::Op(op) => {
@@ -825,7 +825,7 @@ pub fn format_dot(ps: &mut BaseParserState, dot: DotTypeOrOp) {
     }
 }
 
-pub fn format_method_call(ps: &mut BaseParserState, method_call: MethodCall) {
+pub fn format_method_call(ps: &mut ParserState, method_call: MethodCall) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -865,7 +865,7 @@ pub enum SpecialCase {
 }
 
 pub fn format_list_like_thing_items(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     args: Vec<Expression>,
     end_line: Option<LineNumber>,
     single_line: bool,
@@ -921,7 +921,7 @@ pub fn format_list_like_thing_items(
     emitted_args
 }
 
-pub fn format_ident(ps: &mut BaseParserState, ident: Ident) {
+pub fn format_ident(ps: &mut ParserState, ident: Ident) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -933,7 +933,7 @@ pub fn format_ident(ps: &mut BaseParserState, ident: Ident) {
     }
 }
 
-pub fn format_const(ps: &mut BaseParserState, c: Const) {
+pub fn format_const(ps: &mut ParserState, c: Const) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -945,7 +945,7 @@ pub fn format_const(ps: &mut BaseParserState, c: Const) {
     }
 }
 
-pub fn format_int(ps: &mut BaseParserState, int: Int) {
+pub fn format_int(ps: &mut ParserState, int: Int) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -957,11 +957,11 @@ pub fn format_int(ps: &mut BaseParserState, int: Int) {
     }
 }
 
-pub fn format_bare_assoc_hash(ps: &mut BaseParserState, bah: BareAssocHash) {
+pub fn format_bare_assoc_hash(ps: &mut ParserState, bah: BareAssocHash) {
     format_assocs(ps, bah.1, SpecialCase::NoSpecialCase)
 }
 
-pub fn format_alias(ps: &mut BaseParserState, alias: Alias) {
+pub fn format_alias(ps: &mut ParserState, alias: Alias) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -983,7 +983,7 @@ pub fn format_alias(ps: &mut BaseParserState, alias: Alias) {
 }
 
 pub fn format_symbol_literal_or_dyna_symbol(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     symbol_literal_or_dyna_symbol: SymbolLiteralOrDynaSymbol,
 ) {
     match symbol_literal_or_dyna_symbol {
@@ -994,7 +994,7 @@ pub fn format_symbol_literal_or_dyna_symbol(
     }
 }
 
-pub fn format_op(ps: &mut BaseParserState, op: Op) {
+pub fn format_op(ps: &mut ParserState, op: Op) {
     match op.1 {
         Operator::Equals(_) => ps.emit_ident("==".to_string()),
         Operator::Dot(_) => ps.emit_dot(),
@@ -1003,7 +1003,7 @@ pub fn format_op(ps: &mut BaseParserState, op: Op) {
     }
 }
 
-pub fn format_kw(ps: &mut BaseParserState, kw: Kw) {
+pub fn format_kw(ps: &mut ParserState, kw: Kw) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1015,7 +1015,7 @@ pub fn format_kw(ps: &mut BaseParserState, kw: Kw) {
     }
 }
 
-pub fn format_backtick(ps: &mut BaseParserState, backtick: Backtick) {
+pub fn format_backtick(ps: &mut ParserState, backtick: Backtick) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1027,7 +1027,7 @@ pub fn format_backtick(ps: &mut BaseParserState, backtick: Backtick) {
     }
 }
 
-pub fn format_symbol(ps: &mut BaseParserState, symbol: Symbol) {
+pub fn format_symbol(ps: &mut ParserState, symbol: Symbol) {
     ps.emit_ident(":".to_string());
     match symbol.1 {
         IdentOrConstOrKwOrOpOrIvarOrGvarOrCvarOrBacktick::Ident(i) => format_ident(ps, i),
@@ -1049,7 +1049,7 @@ pub fn format_symbol(ps: &mut BaseParserState, symbol: Symbol) {
     }
 }
 
-pub fn format_symbol_literal(ps: &mut BaseParserState, symbol_literal: SymbolLiteral) {
+pub fn format_symbol_literal(ps: &mut ParserState, symbol_literal: SymbolLiteral) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1083,7 +1083,7 @@ fn all_labelish(assocs: &[AssocNewOrAssocSplat]) -> bool {
 }
 
 pub fn format_assocs(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     assocs: Vec<AssocNewOrAssocSplat>,
     sc: SpecialCase,
 ) {
@@ -1102,7 +1102,7 @@ pub fn format_assocs(
 }
 
 pub fn format_assocs_single_line(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     assocs: Vec<AssocNewOrAssocSplat>,
 ) {
     let len = assocs.len();
@@ -1116,7 +1116,7 @@ pub fn format_assocs_single_line(
 }
 
 pub fn format_assoc(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     assoc: AssocNewOrAssocSplat,
     all_labelish: bool,
 ) {
@@ -1158,7 +1158,7 @@ pub fn format_assoc(
     );
 }
 
-pub fn format_begin(ps: &mut BaseParserState, begin: Begin) {
+pub fn format_begin(ps: &mut ParserState, begin: Begin) {
     if ps.at_start_of_line() {
         ps.emit_indent()
     }
@@ -1190,7 +1190,7 @@ pub fn format_begin(ps: &mut BaseParserState, begin: Begin) {
     }
 }
 
-pub fn format_begin_block(ps: &mut BaseParserState, begin: BeginBlock) {
+pub fn format_begin_block(ps: &mut ParserState, begin: BeginBlock) {
     if ps.at_start_of_line() {
         ps.emit_indent()
     }
@@ -1222,7 +1222,7 @@ pub fn format_begin_block(ps: &mut BaseParserState, begin: BeginBlock) {
     }
 }
 
-pub fn format_end_block(ps: &mut BaseParserState, end: EndBlock) {
+pub fn format_end_block(ps: &mut ParserState, end: EndBlock) {
     if ps.at_start_of_line() {
         ps.emit_indent()
     }
@@ -1267,11 +1267,11 @@ pub fn normalize(e: Expression) -> Expression {
     }
 }
 
-pub fn format_void_stmt(_ps: &mut BaseParserState, _void: VoidStmt) {
+pub fn format_void_stmt(_ps: &mut ParserState, _void: VoidStmt) {
     // deliberately does nothing
 }
 
-pub fn format_paren(ps: &mut BaseParserState, paren: ParenExpr) {
+pub fn format_paren(ps: &mut ParserState, paren: ParenExpr) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1311,16 +1311,16 @@ pub fn format_paren(ps: &mut BaseParserState, paren: ParenExpr) {
     }
 }
 
-pub fn format_dot2(ps: &mut BaseParserState, dot2: Dot2) {
+pub fn format_dot2(ps: &mut ParserState, dot2: Dot2) {
     format_dot2_or_3(ps, "..".to_string(), dot2.1, dot2.2);
 }
 
-pub fn format_dot3(ps: &mut BaseParserState, dot3: Dot3) {
+pub fn format_dot3(ps: &mut ParserState, dot3: Dot3) {
     format_dot2_or_3(ps, "...".to_string(), dot3.1, dot3.2);
 }
 
 pub fn format_dot2_or_3(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     dots: String,
     left: Option<Box<Expression>>,
     right: Option<Box<Expression>>,
@@ -1360,7 +1360,7 @@ pub fn percent_symbol_for(tag: String) -> String {
 }
 
 pub fn format_percent_array(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     tag: String,
     parts: Vec<Vec<StringContentPart>>,
 ) {
@@ -1386,7 +1386,7 @@ pub fn format_percent_array(
     );
 }
 
-pub fn format_array(ps: &mut BaseParserState, array: Array) {
+pub fn format_array(ps: &mut ParserState, array: Array) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1419,7 +1419,7 @@ pub fn format_array(ps: &mut BaseParserState, array: Array) {
 }
 
 pub fn format_array_fast_path(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     start_end: &StartEnd,
     a: Option<ArgsAddStarOrExpressionListOrArgsForward>,
 ) {
@@ -1452,7 +1452,7 @@ pub fn format_array_fast_path(
 }
 
 pub fn format_list_like_thing(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     a: ArgsAddStarOrExpressionListOrArgsForward,
     end_line: Option<LineNumber>,
     single_line: bool,
@@ -1528,7 +1528,7 @@ pub fn format_list_like_thing(
     }
 }
 
-pub fn emit_intermediate_array_separator(ps: &mut BaseParserState, single_line: bool) {
+pub fn emit_intermediate_array_separator(ps: &mut ParserState, single_line: bool) {
     if single_line {
         ps.emit_comma_space();
     } else {
@@ -1547,7 +1547,7 @@ pub enum StringType {
 }
 
 fn format_inner_string(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     parts: Vec<StringContentPart>,
     tipe: StringType,
 ) {
@@ -1627,7 +1627,7 @@ fn format_inner_string(
 }
 
 pub fn format_heredoc_string_literal(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     hd: HeredocStringLiteral,
     parts: Vec<StringContentPart>,
 ) {
@@ -1650,7 +1650,7 @@ pub fn format_heredoc_string_literal(
                 heredoc_symbol,
                 kind,
                 end_line,
-                Box::new(|n: &mut BaseParserState| {
+                Box::new(|n: &mut ParserState| {
                     n.disable_user_newlines();
                     format_inner_string(n, parts, StringType::Heredoc);
                 }),
@@ -1663,7 +1663,7 @@ pub fn format_heredoc_string_literal(
     }
 }
 
-pub fn format_string_literal(ps: &mut BaseParserState, sl: StringLiteral) {
+pub fn format_string_literal(ps: &mut ParserState, sl: StringLiteral) {
     match sl {
         StringLiteral::Heredoc(_, hd, StringContent(_, parts)) => {
             format_heredoc_string_literal(ps, hd, parts)
@@ -1686,7 +1686,7 @@ pub fn format_string_literal(ps: &mut BaseParserState, sl: StringLiteral) {
     }
 }
 
-pub fn format_xstring_literal(ps: &mut BaseParserState, xsl: XStringLiteral) {
+pub fn format_xstring_literal(ps: &mut ParserState, xsl: XStringLiteral) {
     let parts = xsl.1;
 
     if ps.at_start_of_line() {
@@ -1702,7 +1702,7 @@ pub fn format_xstring_literal(ps: &mut BaseParserState, xsl: XStringLiteral) {
     }
 }
 
-pub fn format_const_path_field(ps: &mut BaseParserState, cf: ConstPathField) {
+pub fn format_const_path_field(ps: &mut ParserState, cf: ConstPathField) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1721,7 +1721,7 @@ pub fn format_const_path_field(ps: &mut BaseParserState, cf: ConstPathField) {
     }
 }
 
-pub fn format_top_const_field(ps: &mut BaseParserState, tcf: TopConstField) {
+pub fn format_top_const_field(ps: &mut ParserState, tcf: TopConstField) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1739,12 +1739,12 @@ pub fn format_top_const_field(ps: &mut BaseParserState, tcf: TopConstField) {
     }
 }
 
-pub fn format_var_field(ps: &mut BaseParserState, vf: VarField) {
+pub fn format_var_field(ps: &mut ParserState, vf: VarField) {
     let left = vf.1;
     format_var_ref_type(ps, left);
 }
 
-pub fn format_aref_field(ps: &mut BaseParserState, af: ArefField) {
+pub fn format_aref_field(ps: &mut ParserState, af: ArefField) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1778,7 +1778,7 @@ pub fn format_aref_field(ps: &mut BaseParserState, af: ArefField) {
     }
 }
 
-pub fn format_field(ps: &mut BaseParserState, f: Field) {
+pub fn format_field(ps: &mut ParserState, f: Field) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1800,7 +1800,7 @@ pub fn format_field(ps: &mut BaseParserState, f: Field) {
     }
 }
 
-pub fn format_assignable(ps: &mut BaseParserState, v: Assignable) {
+pub fn format_assignable(ps: &mut ParserState, v: Assignable) {
     match v {
         Assignable::VarField(vf) => {
             bind_var_field(ps, &vf);
@@ -1835,7 +1835,7 @@ pub fn format_assignable(ps: &mut BaseParserState, v: Assignable) {
     }
 }
 
-pub fn format_assign(ps: &mut BaseParserState, assign: Assign) {
+pub fn format_assign(ps: &mut ParserState, assign: Assign) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1867,7 +1867,7 @@ pub fn format_assign(ps: &mut BaseParserState, assign: Assign) {
     }
 }
 
-pub fn format_massign(ps: &mut BaseParserState, massign: MAssign) {
+pub fn format_massign(ps: &mut ParserState, massign: MAssign) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1915,7 +1915,7 @@ pub fn format_massign(ps: &mut BaseParserState, massign: MAssign) {
     }
 }
 
-pub fn format_var_ref_type(ps: &mut BaseParserState, vr: VarRefType) {
+pub fn format_var_ref_type(ps: &mut ParserState, vr: VarRefType) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1934,16 +1934,16 @@ pub fn format_var_ref_type(ps: &mut BaseParserState, vr: VarRefType) {
     }
 }
 
-pub fn handle_string_and_linecol(ps: &mut BaseParserState, ident: String, lc: LineCol) {
+pub fn handle_string_and_linecol(ps: &mut ParserState, ident: String, lc: LineCol) {
     ps.on_line(lc.0);
     ps.emit_ident(ident);
 }
 
-pub fn format_var_ref(ps: &mut BaseParserState, vr: VarRef) {
+pub fn format_var_ref(ps: &mut ParserState, vr: VarRef) {
     format_var_ref_type(ps, vr.1);
 }
 
-pub fn format_const_path_ref(ps: &mut BaseParserState, cpr: ConstPathRef) {
+pub fn format_const_path_ref(ps: &mut ParserState, cpr: ConstPathRef) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1962,7 +1962,7 @@ pub fn format_const_path_ref(ps: &mut BaseParserState, cpr: ConstPathRef) {
     }
 }
 
-pub fn format_top_const_ref(ps: &mut BaseParserState, tcr: TopConstRef) {
+pub fn format_top_const_ref(ps: &mut ParserState, tcr: TopConstRef) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -1980,7 +1980,7 @@ pub fn format_top_const_ref(ps: &mut BaseParserState, tcr: TopConstRef) {
     }
 }
 
-pub fn format_defined(ps: &mut BaseParserState, defined: Defined) {
+pub fn format_defined(ps: &mut ParserState, defined: Defined) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2000,7 +2000,7 @@ pub fn format_defined(ps: &mut BaseParserState, defined: Defined) {
     }
 }
 
-pub fn format_rescue_mod(ps: &mut BaseParserState, rescue_mod: RescueMod) {
+pub fn format_rescue_mod(ps: &mut ParserState, rescue_mod: RescueMod) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2021,7 +2021,7 @@ pub fn format_rescue_mod(ps: &mut BaseParserState, rescue_mod: RescueMod) {
     }
 }
 
-pub fn format_mrhs_new_from_args(ps: &mut BaseParserState, mnfa: MRHSNewFromArgs) {
+pub fn format_mrhs_new_from_args(ps: &mut ParserState, mnfa: MRHSNewFromArgs) {
     format_list_like_thing(ps, mnfa.1, None, true);
 
     if let Some(expr) = mnfa.2 {
@@ -2030,7 +2030,7 @@ pub fn format_mrhs_new_from_args(ps: &mut BaseParserState, mnfa: MRHSNewFromArgs
     }
 }
 
-pub fn format_mrhs_add_star(ps: &mut BaseParserState, mrhs: MRHSAddStar) {
+pub fn format_mrhs_add_star(ps: &mut ParserState, mrhs: MRHSAddStar) {
     let first = mrhs.1;
     let second = mrhs.2;
     ps.with_start_of_line(
@@ -2058,7 +2058,7 @@ pub fn format_mrhs_add_star(ps: &mut BaseParserState, mrhs: MRHSAddStar) {
     );
 }
 
-pub fn format_next(ps: &mut BaseParserState, next: Next) {
+pub fn format_next(ps: &mut ParserState, next: Next) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2099,7 +2099,7 @@ pub fn format_next(ps: &mut BaseParserState, next: Next) {
     }
 }
 
-pub fn format_unary(ps: &mut BaseParserState, unary: Unary) {
+pub fn format_unary(ps: &mut ParserState, unary: Unary) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2135,7 +2135,7 @@ pub fn format_unary(ps: &mut BaseParserState, unary: Unary) {
     }
 }
 
-pub fn format_string_concat(ps: &mut BaseParserState, sc: StringConcat) {
+pub fn format_string_concat(ps: &mut ParserState, sc: StringConcat) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2165,7 +2165,7 @@ pub fn format_string_concat(ps: &mut BaseParserState, sc: StringConcat) {
     }
 }
 
-pub fn format_dyna_symbol(ps: &mut BaseParserState, ds: DynaSymbol) {
+pub fn format_dyna_symbol(ps: &mut ParserState, ds: DynaSymbol) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2183,7 +2183,7 @@ pub fn format_dyna_symbol(ps: &mut BaseParserState, ds: DynaSymbol) {
     }
 }
 
-pub fn format_undef(ps: &mut BaseParserState, undef: Undef) {
+pub fn format_undef(ps: &mut ParserState, undef: Undef) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2205,7 +2205,7 @@ pub fn format_undef(ps: &mut BaseParserState, undef: Undef) {
     }
 }
 
-pub fn format_defs(ps: &mut BaseParserState, defs: Defs) {
+pub fn format_defs(ps: &mut ParserState, defs: Defs) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2247,7 +2247,7 @@ pub fn format_defs(ps: &mut BaseParserState, defs: Defs) {
     }
 }
 
-pub fn format_paren_or_params(ps: &mut BaseParserState, pp: ParenOrParams) {
+pub fn format_paren_or_params(ps: &mut ParserState, pp: ParenOrParams) {
     let maybe_closing_paren_line = match &pp {
         ParenOrParams::Paren(p) => Some(p.2.end_line()),
         _ => None,
@@ -2266,7 +2266,7 @@ pub fn format_paren_or_params(ps: &mut BaseParserState, pp: ParenOrParams) {
 
 // Modules and classes bodies should be treated the same,
 // the only real difference is in the module/class name and inheritance
-fn format_constant_body(ps: &mut BaseParserState, bodystmt: Box<BodyStmt>, end_line: u64) {
+fn format_constant_body(ps: &mut ParserState, bodystmt: Box<BodyStmt>, end_line: u64) {
     ps.new_block(Box::new(|ps| {
         ps.with_start_of_line(
             true,
@@ -2294,7 +2294,7 @@ fn format_constant_body(ps: &mut BaseParserState, bodystmt: Box<BodyStmt>, end_l
     }
 }
 
-pub fn format_class(ps: &mut BaseParserState, class: Class) {
+pub fn format_class(ps: &mut ParserState, class: Class) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2332,7 +2332,7 @@ pub fn format_class(ps: &mut BaseParserState, class: Class) {
     format_constant_body(ps, bodystmt, end_line);
 }
 
-pub fn format_module(ps: &mut BaseParserState, module: Module) {
+pub fn format_module(ps: &mut ParserState, module: Module) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2365,7 +2365,7 @@ pub fn format_module(ps: &mut BaseParserState, module: Module) {
 }
 
 pub fn format_conditional(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     cond_expr: Expression,
     body: Vec<Expression>,
     kw: String,
@@ -2441,7 +2441,7 @@ pub fn format_conditional(
     }
 }
 
-pub fn format_if(ps: &mut BaseParserState, ifs: If) {
+pub fn format_if(ps: &mut ParserState, ifs: If) {
     let vifs = ifs.clone();
     format_conditional(ps, *ifs.1, ifs.2, "if".to_string(), ifs.3, Some(ifs.4));
 
@@ -2458,7 +2458,7 @@ pub fn format_if(ps: &mut BaseParserState, ifs: If) {
     }
 }
 
-pub fn format_unless(ps: &mut BaseParserState, unless: Unless) {
+pub fn format_unless(ps: &mut ParserState, unless: Unless) {
     format_conditional(
         ps,
         *unless.1,
@@ -2479,7 +2479,7 @@ pub fn format_unless(ps: &mut BaseParserState, unless: Unless) {
     }
 }
 
-pub fn format_binary(ps: &mut BaseParserState, binary: Binary) {
+pub fn format_binary(ps: &mut ParserState, binary: Binary) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2508,7 +2508,7 @@ pub fn format_binary(ps: &mut BaseParserState, binary: Binary) {
 // Performs the actual formatting for binary operators. This method assumes that it's
 // inside of a breakable, but it's separated out so that it can recurse inside of
 // nested breakables so that nested breakables stay at the same indentation level.
-fn format_binary_inner(ps: &mut BaseParserState, binary: Binary) {
+fn format_binary_inner(ps: &mut ParserState, binary: Binary) {
     ps.with_formatting_context(
         FormattingContext::Binary,
         Box::new(|ps| {
@@ -2554,7 +2554,7 @@ fn format_binary_inner(ps: &mut BaseParserState, binary: Binary) {
     );
 }
 
-pub fn format_float(ps: &mut BaseParserState, float: Float) {
+pub fn format_float(ps: &mut ParserState, float: Float) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2566,7 +2566,7 @@ pub fn format_float(ps: &mut BaseParserState, float: Float) {
     }
 }
 
-pub fn format_aref(ps: &mut BaseParserState, aref: Aref) {
+pub fn format_aref(ps: &mut ParserState, aref: Aref) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2598,7 +2598,7 @@ pub fn format_aref(ps: &mut BaseParserState, aref: Aref) {
     }
 }
 
-pub fn format_char(ps: &mut BaseParserState, c: Char) {
+pub fn format_char(ps: &mut ParserState, c: Char) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2613,7 +2613,7 @@ pub fn format_char(ps: &mut BaseParserState, c: Char) {
     }
 }
 
-pub fn format_hash(ps: &mut BaseParserState, hash: Hash) {
+pub fn format_hash(ps: &mut ParserState, hash: Hash) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2657,7 +2657,7 @@ pub fn format_hash(ps: &mut BaseParserState, hash: Hash) {
     }
 }
 
-pub fn format_regexp_literal(ps: &mut BaseParserState, regexp: RegexpLiteral) {
+pub fn format_regexp_literal(ps: &mut ParserState, regexp: RegexpLiteral) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2675,7 +2675,7 @@ pub fn format_regexp_literal(ps: &mut BaseParserState, regexp: RegexpLiteral) {
     }
 }
 
-pub fn format_backref(ps: &mut BaseParserState, backref: Backref) {
+pub fn format_backref(ps: &mut ParserState, backref: Backref) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2731,7 +2731,7 @@ fn can_elide_parens_for_reserved_names(cc: &[CallChainElement]) -> bool {
 
 /// Returns `true` if the call chain is indented, `false` if not
 fn format_call_chain(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     cc: Vec<CallChainElement>,
     last_call_use_parens: Option<bool>,
 ) {
@@ -2753,7 +2753,7 @@ fn format_call_chain(
 }
 
 fn format_call_chain_elements(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     cc: Vec<CallChainElement>,
     // Whether or not to force the last call to use parens. By default, falls back to normal call chain rules.
     // This is necessary for supporting things like parenthesized methods in `self.method` method chains where
@@ -2883,14 +2883,14 @@ fn format_call_chain_elements(
     }
 }
 
-pub fn format_block(ps: &mut BaseParserState, b: Block) {
+pub fn format_block(ps: &mut ParserState, b: Block) {
     match b {
         Block::BraceBlock(bb) => format_brace_block(ps, bb),
         Block::DoBlock(db) => format_do_block(ps, db),
     }
 }
 
-pub fn format_method_add_block(ps: &mut BaseParserState, mab: MethodAddBlock) {
+pub fn format_method_add_block(ps: &mut ParserState, mab: MethodAddBlock) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -2944,7 +2944,7 @@ enum BraceBlockRenderMethod {
     MultipleExpressions,
 }
 
-pub fn format_brace_block(ps: &mut BaseParserState, brace_block: BraceBlock) {
+pub fn format_brace_block(ps: &mut ParserState, brace_block: BraceBlock) {
     let bv = brace_block.1;
     let body = brace_block.2;
     let StartEnd(start_line, end_line) = brace_block.3;
@@ -2966,7 +2966,7 @@ pub fn format_brace_block(ps: &mut BaseParserState, brace_block: BraceBlock) {
 }
 
 fn render_block_contents(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     brace_block_render_method: BraceBlockRenderMethod,
     body: Vec<Expression>,
     end_line: u64,
@@ -3028,7 +3028,7 @@ fn render_block_contents(
 }
 
 fn get_brace_block_render_method(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     start_line: u64,
     end_line: u64,
     body: &[Expression],
@@ -3049,7 +3049,7 @@ fn get_brace_block_render_method(
     }
 }
 
-pub fn format_do_block(ps: &mut BaseParserState, do_block: DoBlock) {
+pub fn format_do_block(ps: &mut ParserState, do_block: DoBlock) {
     ps.emit_do_keyword();
 
     let bv = do_block.1;
@@ -3081,7 +3081,7 @@ pub fn format_do_block(ps: &mut BaseParserState, do_block: DoBlock) {
 }
 
 pub fn format_keyword(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     args: ParenOrArgsAddBlock,
     kw: String,
     start_end: StartEnd,
@@ -3138,7 +3138,7 @@ pub fn format_keyword(
 }
 
 pub fn format_while(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     conditional: Expression,
     exprs: Vec<Expression>,
     kw: String,
@@ -3175,7 +3175,7 @@ pub fn format_while(
 /// end
 /// ```
 pub fn format_inline_mod(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     conditional: Box<Expression>,
     body: Box<Expression>,
     name: String,
@@ -3202,7 +3202,7 @@ pub fn format_inline_mod(
 /// Some mod statements can be safely converted to their equivalent
 /// multiline forms, specifically `if` and `unless` mod statements.
 pub fn format_multilinable_mod(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     conditional: Box<Expression>,
     body: Box<Expression>,
     name: String,
@@ -3236,7 +3236,7 @@ pub fn format_multilinable_mod(
     }
 }
 
-pub fn format_when_or_else(ps: &mut BaseParserState, tail: WhenOrElse) {
+pub fn format_when_or_else(ps: &mut ParserState, tail: WhenOrElse) {
     match tail {
         WhenOrElse::When(when) => {
             let conditionals = when.1;
@@ -3300,7 +3300,7 @@ pub fn format_when_or_else(ps: &mut BaseParserState, tail: WhenOrElse) {
     }
 }
 
-pub fn format_case(ps: &mut BaseParserState, case: Case) {
+pub fn format_case(ps: &mut ParserState, case: Case) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3338,7 +3338,7 @@ pub fn format_case(ps: &mut BaseParserState, case: Case) {
     ps.on_line(case.3.1);
 }
 
-pub fn format_retry(ps: &mut BaseParserState, r: Retry) {
+pub fn format_retry(ps: &mut ParserState, r: Retry) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
@@ -3347,7 +3347,7 @@ pub fn format_retry(ps: &mut BaseParserState, r: Retry) {
     );
 }
 
-pub fn format_redo(ps: &mut BaseParserState, r: Redo) {
+pub fn format_redo(ps: &mut ParserState, r: Redo) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
@@ -3356,7 +3356,7 @@ pub fn format_redo(ps: &mut BaseParserState, r: Redo) {
     );
 }
 
-pub fn format_sclass(ps: &mut BaseParserState, sc: SClass) {
+pub fn format_sclass(ps: &mut ParserState, sc: SClass) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3398,7 +3398,7 @@ pub fn format_sclass(ps: &mut BaseParserState, sc: SClass) {
     }
 }
 
-pub fn format_stabby_lambda(ps: &mut BaseParserState, sl: StabbyLambda) {
+pub fn format_stabby_lambda(ps: &mut ParserState, sl: StabbyLambda) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3463,7 +3463,7 @@ pub fn format_stabby_lambda(ps: &mut BaseParserState, sl: StabbyLambda) {
     }
 }
 
-pub fn format_imaginary(ps: &mut BaseParserState, imaginary: Imaginary) {
+pub fn format_imaginary(ps: &mut ParserState, imaginary: Imaginary) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3475,7 +3475,7 @@ pub fn format_imaginary(ps: &mut BaseParserState, imaginary: Imaginary) {
     }
 }
 
-pub fn format_rational(ps: &mut BaseParserState, rational: Rational) {
+pub fn format_rational(ps: &mut ParserState, rational: Rational) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3487,7 +3487,7 @@ pub fn format_rational(ps: &mut BaseParserState, rational: Rational) {
     }
 }
 
-pub fn format_for(ps: &mut BaseParserState, forloop: For) {
+pub fn format_for(ps: &mut ParserState, forloop: For) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3545,7 +3545,7 @@ pub fn format_for(ps: &mut BaseParserState, forloop: For) {
     }
 }
 
-pub fn format_ifop(ps: &mut BaseParserState, ifop: IfOp) {
+pub fn format_ifop(ps: &mut ParserState, ifop: IfOp) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3575,7 +3575,7 @@ pub fn format_ifop(ps: &mut BaseParserState, ifop: IfOp) {
     }
 }
 
-pub fn format_return0(ps: &mut BaseParserState, r: Return0) {
+pub fn format_return0(ps: &mut ParserState, r: Return0) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
@@ -3584,7 +3584,7 @@ pub fn format_return0(ps: &mut BaseParserState, r: Return0) {
     );
 }
 
-pub fn format_opassign(ps: &mut BaseParserState, opassign: OpAssign) {
+pub fn format_opassign(ps: &mut ParserState, opassign: OpAssign) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
@@ -3604,16 +3604,16 @@ pub fn format_opassign(ps: &mut BaseParserState, opassign: OpAssign) {
         ps.emit_newline();
     }
 }
-pub fn format_to_proc(ps: &mut BaseParserState, e: Box<Expression>) {
+pub fn format_to_proc(ps: &mut ParserState, e: Box<Expression>) {
     ps.emit_ident("&".to_string());
     ps.with_start_of_line(false, Box::new(|ps| format_expression(ps, *e)));
 }
 
-pub fn format_anon_block_arg(ps: &mut BaseParserState) {
+pub fn format_anon_block_arg(ps: &mut ParserState) {
     ps.emit_ident("&".to_string());
 }
 
-pub fn format_zsuper(ps: &mut BaseParserState, start_end: StartEnd) {
+pub fn format_zsuper(ps: &mut ParserState, start_end: StartEnd) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
@@ -3622,7 +3622,7 @@ pub fn format_zsuper(ps: &mut BaseParserState, start_end: StartEnd) {
     )
 }
 
-pub fn format_yield0(ps: &mut BaseParserState, start_end: StartEnd) {
+pub fn format_yield0(ps: &mut ParserState, start_end: StartEnd) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
@@ -3631,11 +3631,11 @@ pub fn format_yield0(ps: &mut BaseParserState, start_end: StartEnd) {
     )
 }
 
-pub fn format_yield(ps: &mut BaseParserState, y: Yield) {
+pub fn format_yield(ps: &mut ParserState, y: Yield) {
     format_method_call(ps, y.to_method_call())
 }
 
-pub fn format_return(ps: &mut BaseParserState, ret: Return) {
+pub fn format_return(ps: &mut ParserState, ret: Return) {
     let args = ret.1;
     let line = (ret.2).0;
     ps.on_line(line);
@@ -3695,7 +3695,7 @@ pub fn format_return(ps: &mut BaseParserState, ret: Return) {
 }
 
 pub fn format_bare_return_args(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     args: ArgsAddStarOrExpressionListOrArgsForward,
 ) {
     ps.breakable_of(
@@ -3712,7 +3712,7 @@ pub fn format_bare_return_args(
     );
 }
 
-pub fn format_expression(ps: &mut BaseParserState, expression: Expression) {
+pub fn format_expression(ps: &mut ParserState, expression: Expression) {
     let expression = normalize(expression);
     match expression {
         Expression::Def(def) => format_def(ps, def),
@@ -3789,7 +3789,7 @@ pub fn format_expression(ps: &mut BaseParserState, expression: Expression) {
     }
 }
 
-pub fn format_program(ps: &mut BaseParserState, program: Program, end_data: Option<&str>) {
+pub fn format_program(ps: &mut ParserState, program: Program, end_data: Option<&str>) {
     ps.flush_start_of_file_comments();
     for expression in program.1 {
         format_expression(ps, expression);

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::delimiters::BreakableDelims;
 use crate::heredoc_string::HeredocKind;
-use crate::parser_state::{BaseParserState, ConcreteParserState, FormattingContext, RenderFunc};
+use crate::parser_state::{BaseParserState, FormattingContext, RenderFunc};
 use crate::render_targets::MultilineHandling;
 use crate::ripper_tree_types::*;
 use crate::types::LineNumber;

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4,7 +4,7 @@ use crate::{
     delimiters::BreakableDelims,
     format::SpecialCase,
     heredoc_string::HeredocKind,
-    parser_state::{BaseParserState, ConcreteParserState, FormattingContext, HashType, RenderFunc},
+    parser_state::{BaseParserState, FormattingContext, HashType, RenderFunc},
     render_targets::MultilineHandling,
     types::SourceOffset,
     util::{const_to_string, loc_to_string, u8_to_string},

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -10,7 +10,7 @@ use crate::{
     util::{const_to_string, loc_to_string, u8_to_string},
 };
 
-pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
+pub fn format_node(ps: &mut BaseParserState, node: prism::Node) {
     use prism::Node;
 
     ps.at_offset(node.location().start_offset());
@@ -405,38 +405,38 @@ pub fn format_node(ps: &mut dyn ConcreteParserState, node: prism::Node) {
 }
 
 fn format_alias_global_variable_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _alias_global_variable_node: prism::AliasGlobalVariableNode,
 ) {
     todo!()
 }
 
 fn format_alias_method_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _alias_method_node: prism::AliasMethodNode,
 ) {
     todo!()
 }
 
 fn format_alternation_pattern_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _alternation_pattern_node: prism::AlternationPatternNode,
 ) {
     todo!()
 }
 
-fn format_and_node(_ps: &mut dyn ConcreteParserState, _and_node: prism::AndNode) {
+fn format_and_node(_ps: &mut BaseParserState, _and_node: prism::AndNode) {
     todo!()
 }
 
 fn format_back_reference_read_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _back_reference_read_node: prism::BackReferenceReadNode,
 ) {
     todo!()
 }
 
-fn format_begin_node(ps: &mut dyn ConcreteParserState, begin_node: prism::BeginNode) {
+fn format_begin_node(ps: &mut BaseParserState, begin_node: prism::BeginNode) {
     // If there's no `begin` keyword loc, this is probably an "implicit" begin node,
     // like a rescue/ensure in a def without a `begin` keyword:
     // ```ruby
@@ -499,30 +499,30 @@ fn format_begin_node(ps: &mut dyn ConcreteParserState, begin_node: prism::BeginN
     ps.at_offset(begin_node.location().end_offset());
 }
 
-fn format_break_node(_ps: &mut dyn ConcreteParserState, _break_node: prism::BreakNode) {
+fn format_break_node(_ps: &mut BaseParserState, _break_node: prism::BreakNode) {
     todo!()
 }
 
 fn format_capture_pattern_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _capture_pattern_node: prism::CapturePatternNode,
 ) {
     todo!()
 }
 
 fn format_case_match_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _case_match_node: prism::CaseMatchNode,
 ) {
     todo!()
 }
 
-fn format_case_node(_ps: &mut dyn ConcreteParserState, _case_node: prism::CaseNode) {
+fn format_case_node(_ps: &mut BaseParserState, _case_node: prism::CaseNode) {
     todo!()
 }
 
 pub fn format_program(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     program_node: prism::ProgramNode,
     data_loc: Option<prism::Location>,
 ) {
@@ -541,7 +541,7 @@ pub fn format_program(
     }
 }
 
-fn format_statements(ps: &mut dyn ConcreteParserState, statements_node: prism::StatementsNode) {
+fn format_statements(ps: &mut BaseParserState, statements_node: prism::StatementsNode) {
     ps.with_start_of_line(
         true,
         Box::new(|ps| {
@@ -552,7 +552,7 @@ fn format_statements(ps: &mut dyn ConcreteParserState, statements_node: prism::S
     );
 }
 
-fn format_string_node(ps: &mut dyn ConcreteParserState, string_node: prism::StringNode) {
+fn format_string_node(ps: &mut BaseParserState, string_node: prism::StringNode) {
     ps.at_offset(string_node.location().start_offset());
 
     // `opening_loc()` is only `None` in the case of the inner parts of multiline strings
@@ -611,7 +611,7 @@ fn format_string_node(ps: &mut dyn ConcreteParserState, string_node: prism::Stri
 }
 
 fn format_interpolated_string_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     interpolated_string_node: prism::InterpolatedStringNode,
 ) {
     let opener = interpolated_string_node
@@ -723,7 +723,7 @@ impl HeredocNodeType<'_> {
 }
 
 fn format_heredoc(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     heredoc: HeredocNodeType,
     heredoc_symbol: String,
 ) {
@@ -743,7 +743,7 @@ fn format_heredoc(
 }
 
 fn format_inner_string(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     parts: Vec<prism::Node>,
     is_heredoc: bool,
 ) {
@@ -796,49 +796,49 @@ fn format_inner_string(
 }
 
 fn format_interpolated_symbol_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _interpolated_string_node: prism::InterpolatedSymbolNode,
 ) {
     todo!()
 }
 
 fn format_interpolated_x_string_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _interpolated_x_string_node: prism::InterpolatedXStringNode,
 ) {
     todo!()
 }
 
 fn format_it_local_variable_read_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _it_local_variable_read_node: prism::ItLocalVariableReadNode,
 ) {
     todo!()
 }
 
 fn format_it_parameters_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _it_parameters_node: prism::ItParametersNode,
 ) {
     todo!()
 }
 
 fn format_interpolated_last_line_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _interpolated_match_last_line_node: prism::InterpolatedMatchLastLineNode,
 ) {
     todo!()
 }
 
 fn format_interpolated_regular_expression_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _interpolated_regular_expression_node: prism::InterpolatedRegularExpressionNode,
 ) {
     todo!()
 }
 
 fn format_embedded_statements_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     embedded_statements_node: prism::EmbeddedStatementsNode,
 ) {
     ps.emit_string_content("#{".to_string());
@@ -866,13 +866,13 @@ fn format_embedded_statements_node(
 }
 
 fn format_embedded_variable_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _embedded_variable_node: prism::EmbeddedVariableNode,
 ) {
     todo!()
 }
 
-fn format_ensure_node(ps: &mut dyn ConcreteParserState, ensure_node: prism::EnsureNode) {
+fn format_ensure_node(ps: &mut BaseParserState, ensure_node: prism::EnsureNode) {
     // Double check that these offsets are correct, since begin/rescue/ensure/else
     // aren't always handled with `format_node`, which usually handles this
     ps.at_offset(ensure_node.location().start_offset());
@@ -888,7 +888,7 @@ fn format_ensure_node(ps: &mut dyn ConcreteParserState, ensure_node: prism::Ensu
     ps.at_offset(ensure_node.location().end_offset());
 }
 
-fn format_false_node(ps: &mut dyn ConcreteParserState, false_node: prism::FalseNode) {
+fn format_false_node(ps: &mut BaseParserState, false_node: prism::FalseNode) {
     handle_string_at_offset(
         ps,
         "false".to_string(),
@@ -897,17 +897,17 @@ fn format_false_node(ps: &mut dyn ConcreteParserState, false_node: prism::FalseN
 }
 
 fn format_find_pattern_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _find_pattern_node: prism::FindPatternNode,
 ) {
     todo!()
 }
 
-fn format_flip_flop_node(_ps: &mut dyn ConcreteParserState, _flip_flop_node: prism::FlipFlopNode) {
+fn format_flip_flop_node(_ps: &mut BaseParserState, _flip_flop_node: prism::FlipFlopNode) {
     todo!()
 }
 
-fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassNode) {
+fn format_class_node(ps: &mut BaseParserState, class_node: prism::ClassNode) {
     ps.emit_class_keyword();
     ps.emit_space();
     ps.with_start_of_line(
@@ -946,7 +946,7 @@ fn format_class_node(ps: &mut dyn ConcreteParserState, class_node: prism::ClassN
 }
 
 fn format_class_variable_and_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     class_variable_and_write_node: prism::ClassVariableAndWriteNode,
 ) {
     ps.emit_ident(const_to_string(class_variable_and_write_node.name()));
@@ -962,7 +962,7 @@ fn format_class_variable_and_write_node(
 }
 
 fn format_class_variable_operator_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     class_variable_operator_write_node: prism::ClassVariableOperatorWriteNode,
 ) {
     ps.emit_ident(const_to_string(class_variable_operator_write_node.name()));
@@ -980,7 +980,7 @@ fn format_class_variable_operator_write_node(
 }
 
 fn format_class_variable_or_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     class_variable_or_write_node: prism::ClassVariableOrWriteNode,
 ) {
     ps.emit_ident(const_to_string(class_variable_or_write_node.name()));
@@ -996,21 +996,21 @@ fn format_class_variable_or_write_node(
 }
 
 fn format_class_variable_read_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     class_variable_read_node: prism::ClassVariableReadNode,
 ) {
     ps.emit_ident(const_to_string(class_variable_read_node.name()));
 }
 
 fn format_class_variable_target_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     class_variable_target_node: prism::ClassVariableTargetNode,
 ) {
     ps.emit_ident(const_to_string(class_variable_target_node.name()));
 }
 
 fn format_class_variable_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     class_variable_write_node: prism::ClassVariableWriteNode,
 ) {
     ps.at_offset(class_variable_write_node.location().start_offset());
@@ -1025,7 +1025,7 @@ fn format_class_variable_write_node(
     );
 }
 
-fn format_module_node(ps: &mut dyn ConcreteParserState, module_node: prism::ModuleNode) {
+fn format_module_node(ps: &mut BaseParserState, module_node: prism::ModuleNode) {
     ps.emit_module_keyword();
     ps.emit_space();
     ps.with_start_of_line(
@@ -1053,7 +1053,7 @@ fn format_module_node(ps: &mut dyn ConcreteParserState, module_node: prism::Modu
     );
 }
 
-fn format_def_node(ps: &mut dyn ConcreteParserState, def_node: prism::DefNode) {
+fn format_def_node(ps: &mut BaseParserState, def_node: prism::DefNode) {
     ps.emit_keyword("def".to_string());
     ps.emit_space();
 
@@ -1076,7 +1076,7 @@ fn format_def_node(ps: &mut dyn ConcreteParserState, def_node: prism::DefNode) {
     format_def_body(ps, def_node);
 }
 
-fn format_def_body(ps: &mut dyn ConcreteParserState, def_node: prism::DefNode) {
+fn format_def_body(ps: &mut BaseParserState, def_node: prism::DefNode) {
     ps.new_scope(Box::new(|ps| {
         if let Some(parameters_node) = def_node.parameters() {
             ps.breakable_of(
@@ -1161,11 +1161,11 @@ fn format_def_body(ps: &mut dyn ConcreteParserState, def_node: prism::DefNode) {
     }
 }
 
-fn format_defined_node(_ps: &mut dyn ConcreteParserState, _defined_node: prism::DefinedNode) {
+fn format_defined_node(_ps: &mut BaseParserState, _defined_node: prism::DefinedNode) {
     todo!()
 }
 
-fn format_else_node(ps: &mut dyn ConcreteParserState, else_node: prism::ElseNode) {
+fn format_else_node(ps: &mut BaseParserState, else_node: prism::ElseNode) {
     // Double check that these offsets are correct, since begin/rescue/ensure/else
     // aren't always handled with `format_node`, which usually handles this
     ps.at_offset(else_node.location().start_offset());
@@ -1207,9 +1207,9 @@ fn format_else_node(ps: &mut dyn ConcreteParserState, else_node: prism::ElseNode
     ps.at_offset(else_node.location().end_offset());
 }
 
-type ParamFormattingFunc<'a> = Box<dyn FnOnce(&mut dyn ConcreteParserState) + 'a>;
+type ParamFormattingFunc<'a> = Box<dyn FnOnce(&mut BaseParserState) + 'a>;
 
-fn format_parameters_node(ps: &mut dyn ConcreteParserState, params: prism::ParametersNode) {
+fn format_parameters_node(ps: &mut BaseParserState, params: prism::ParametersNode) {
     let non_null_positions = non_null_positions(&params);
 
     //def foo(a, b=nil, *args, d, e:, **kwargs, &blk)
@@ -1237,45 +1237,45 @@ fn format_parameters_node(ps: &mut dyn ConcreteParserState, params: prism::Param
     let block = params.block();
 
     let formats: Vec<ParamFormattingFunc> = vec![
-        Box::new(move |ps: &mut dyn ConcreteParserState| {
+        Box::new(move |ps: &mut BaseParserState| {
             if node_list_is_empty(&requireds) {
                 return;
             }
             let end_offset = requireds.iter().last().unwrap().location().end_offset();
             format_list_like_thing(ps, requireds, end_offset, false);
         }),
-        Box::new(move |ps: &mut dyn ConcreteParserState| {
+        Box::new(move |ps: &mut BaseParserState| {
             if node_list_is_empty(&optionals) {
                 return;
             }
             let end_offset = optionals.iter().last().unwrap().location().end_offset();
             format_list_like_thing(ps, optionals, end_offset, false);
         }),
-        Box::new(move |ps: &mut dyn ConcreteParserState| {
+        Box::new(move |ps: &mut BaseParserState| {
             if let Some(rest) = rest {
                 format_node(ps, rest);
             }
         }),
-        Box::new(move |ps: &mut dyn ConcreteParserState| {
+        Box::new(move |ps: &mut BaseParserState| {
             if node_list_is_empty(&posts) {
                 return;
             }
             let end_offset = posts.iter().last().unwrap().location().end_offset();
             format_list_like_thing(ps, posts, end_offset, false);
         }),
-        Box::new(move |ps: &mut dyn ConcreteParserState| {
+        Box::new(move |ps: &mut BaseParserState| {
             if node_list_is_empty(&keywords) {
                 return;
             }
             let end_offset = keywords.iter().last().unwrap().location().end_offset();
             format_list_like_thing(ps, keywords, end_offset, false);
         }),
-        Box::new(move |ps: &mut dyn ConcreteParserState| {
+        Box::new(move |ps: &mut BaseParserState| {
             if let Some(keyword_rest) = keyword_rest {
                 format_node(ps, keyword_rest);
             }
         }),
-        Box::new(move |ps: &mut dyn ConcreteParserState| {
+        Box::new(move |ps: &mut BaseParserState| {
             if let Some(block) = block {
                 format_block_parameter_node(ps, block);
             }
@@ -1296,7 +1296,7 @@ fn format_parameters_node(ps: &mut dyn ConcreteParserState, params: prism::Param
 }
 
 fn format_block_parameter_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     block_arg: prism::BlockParameterNode,
 ) {
     ps.with_start_of_line(
@@ -1314,7 +1314,7 @@ fn format_block_parameter_node(
 }
 
 fn format_block_argument_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     block_argument_node: prism::BlockArgumentNode,
 ) {
     ps.emit_ident("&".to_string());
@@ -1329,7 +1329,7 @@ fn format_block_argument_node(
 }
 
 fn format_call_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     call_node: prism::CallNode,
     skip_receiver: bool,
 ) {
@@ -1478,7 +1478,7 @@ fn format_call_node(
 }
 
 fn call_chain_elements_are_user_multilined(
-    ps: &dyn ConcreteParserState,
+    ps: &BaseParserState,
     call_chain_elements: Vec<&prism::Node>,
 ) -> bool {
     // Making a mutable copy since we may pop some items off later
@@ -1538,34 +1538,34 @@ fn call_chain_elements_are_user_multilined(
 }
 
 fn format_call_and_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _call_and_write_node: prism::CallAndWriteNode,
 ) {
     todo!()
 }
 
 fn format_call_operator_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _call_operator_write_node: prism::CallOperatorWriteNode,
 ) {
     todo!()
 }
 
 fn format_call_or_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _call_or_write_node: prism::CallOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_call_target_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _call_target_node: prism::CallTargetNode,
 ) {
     todo!()
 }
 
-fn format_symbol_node(ps: &mut dyn ConcreteParserState, symbol_node: prism::SymbolNode) {
+fn format_symbol_node(ps: &mut BaseParserState, symbol_node: prism::SymbolNode) {
     if let Some(opening_loc) = symbol_node.opening_loc() {
         ps.emit_ident(loc_to_string(opening_loc));
     }
@@ -1574,7 +1574,7 @@ fn format_symbol_node(ps: &mut dyn ConcreteParserState, symbol_node: prism::Symb
     }
 }
 
-fn format_assoc_node(ps: &mut dyn ConcreteParserState, assoc_node: prism::AssocNode) {
+fn format_assoc_node(ps: &mut BaseParserState, assoc_node: prism::AssocNode) {
     let as_symbol = if let Some(hash_type) = ps.hash_type_from_formatting_context() {
         matches!(hash_type, HashType::SymbolKey)
     } else {
@@ -1602,7 +1602,7 @@ fn format_assoc_node(ps: &mut dyn ConcreteParserState, assoc_node: prism::AssocN
 }
 
 fn format_assoc_splat_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     assoc_splat_node: prism::AssocSplatNode,
 ) {
     ps.with_start_of_line(
@@ -1616,7 +1616,7 @@ fn format_assoc_splat_node(
     );
 }
 
-fn format_block_node(ps: &mut dyn ConcreteParserState, block_node: prism::BlockNode) {
+fn format_block_node(ps: &mut BaseParserState, block_node: prism::BlockNode) {
     if &loc_to_string(block_node.opening_loc()) == "do" {
         ps.new_block(Box::new(|ps| {
             ps.emit_do_keyword();
@@ -1704,7 +1704,7 @@ fn format_block_node(ps: &mut dyn ConcreteParserState, block_node: prism::BlockN
 }
 
 fn format_block_parameters_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     block_parameters_node: prism::BlockParametersNode,
 ) {
     // Exit early if there's no params
@@ -1741,7 +1741,7 @@ fn format_block_parameters_node(
 }
 
 fn format_block_local_variable_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     block_local_variable_node: prism::BlockLocalVariableNode,
 ) {
     handle_string_at_offset(
@@ -1751,7 +1751,7 @@ fn format_block_local_variable_node(
     );
 }
 
-fn format_array_node(ps: &mut dyn ConcreteParserState, array_node: prism::ArrayNode) {
+fn format_array_node(ps: &mut BaseParserState, array_node: prism::ArrayNode) {
     if node_list_is_empty(&array_node.elements()) {
         if ps.has_comment_in_offset_span(
             array_node.location().start_offset(),
@@ -1796,14 +1796,14 @@ fn format_array_node(ps: &mut dyn ConcreteParserState, array_node: prism::ArrayN
 }
 
 fn format_array_pattern_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _array_pattern_node: prism::ArrayPatternNode,
 ) {
     todo!()
 }
 
 fn format_parentheses_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     parentheses_node: prism::ParenthesesNode,
 ) {
     ps.emit_open_paren();
@@ -1863,7 +1863,7 @@ fn collapse_nodes_to_call_chain(node: prism::Node) -> Vec<prism::Node> {
 }
 
 fn format_rest_parameter_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     rest_param: prism::RestParameterNode,
     special_case: SpecialCase,
 ) {
@@ -1888,7 +1888,7 @@ fn format_rest_parameter_node(
     );
 }
 
-fn format_arguments_node(ps: &mut dyn ConcreteParserState, arguments_node: prism::ArgumentsNode) {
+fn format_arguments_node(ps: &mut BaseParserState, arguments_node: prism::ArgumentsNode) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -1903,7 +1903,7 @@ fn format_arguments_node(ps: &mut dyn ConcreteParserState, arguments_node: prism
 }
 
 fn format_keyword_hash_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     keyword_hash_node: prism::KeywordHashNode,
 ) {
     let all_symbol_keys = keyword_hash_node
@@ -1937,7 +1937,7 @@ fn format_keyword_hash_node(
 }
 
 fn format_keyword_rest_parameter_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     keyword_rest_parameter_node: prism::KeywordRestParameterNode,
 ) {
     ps.emit_ident("**".to_string());
@@ -1949,7 +1949,7 @@ fn format_keyword_rest_parameter_node(
 }
 
 fn format_required_keyword_parameter_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     required_keyword_parameter_node: prism::RequiredKeywordParameterNode,
 ) {
     let name = const_to_string(required_keyword_parameter_node.name());
@@ -1959,7 +1959,7 @@ fn format_required_keyword_parameter_node(
 }
 
 fn format_required_parameter_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     required_parameter_node: prism::RequiredParameterNode,
 ) {
     let name = const_to_string(required_parameter_node.name());
@@ -1968,7 +1968,7 @@ fn format_required_parameter_node(
 }
 
 fn format_local_variable_and_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     local_variable_and_write_node: prism::LocalVariableAndWriteNode,
 ) {
     let variable_name = const_to_string(local_variable_and_write_node.name());
@@ -1986,7 +1986,7 @@ fn format_local_variable_and_write_node(
 }
 
 fn format_local_variable_operator_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     local_variable_operator_write_node: prism::LocalVariableOperatorWriteNode,
 ) {
     let variable_name = const_to_string(local_variable_operator_write_node.name());
@@ -2006,14 +2006,14 @@ fn format_local_variable_operator_write_node(
 }
 
 fn format_local_variable_or_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _local_variable_or_write_node: prism::LocalVariableOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_local_variable_target_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     local_variable_target_node: prism::LocalVariableTargetNode,
 ) {
     let variable_name = const_to_string(local_variable_target_node.name());
@@ -2022,7 +2022,7 @@ fn format_local_variable_target_node(
 }
 
 fn format_local_variable_read_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     local_variable_read_node: prism::LocalVariableReadNode,
 ) {
     let name = const_to_string(local_variable_read_node.name());
@@ -2031,7 +2031,7 @@ fn format_local_variable_read_node(
 }
 
 fn format_local_variable_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     local_variable_write_node: prism::LocalVariableWriteNode,
 ) {
     let name = const_to_string(local_variable_write_node.name());
@@ -2046,7 +2046,7 @@ fn format_local_variable_write_node(
     );
 }
 
-fn format_splat_node(ps: &mut dyn ConcreteParserState, splat_node: prism::SplatNode) {
+fn format_splat_node(ps: &mut BaseParserState, splat_node: prism::SplatNode) {
     ps.emit_ident("*".to_string());
     if let Some(node) = splat_node.expression() {
         ps.with_start_of_line(
@@ -2058,12 +2058,12 @@ fn format_splat_node(ps: &mut dyn ConcreteParserState, splat_node: prism::SplatN
     }
 }
 
-fn format_ident(ps: &mut dyn ConcreteParserState, ident: String, offset: usize) {
+fn format_ident(ps: &mut BaseParserState, ident: String, offset: usize) {
     handle_string_at_offset(ps, ident, offset);
 }
 
 fn format_instance_variable_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     instance_variable_write_node: prism::InstanceVariableWriteNode,
 ) {
     ps.at_offset(instance_variable_write_node.location().start_offset());
@@ -2078,7 +2078,7 @@ fn format_instance_variable_write_node(
     );
 }
 
-fn format_integer_node(ps: &mut dyn ConcreteParserState, integer_node: prism::IntegerNode) {
+fn format_integer_node(ps: &mut BaseParserState, integer_node: prism::IntegerNode) {
     handle_string_at_offset(
         ps,
         loc_to_string(integer_node.location()),
@@ -2086,7 +2086,7 @@ fn format_integer_node(ps: &mut dyn ConcreteParserState, integer_node: prism::In
     );
 }
 
-fn format_float_node(ps: &mut dyn ConcreteParserState, float_node: prism::FloatNode) {
+fn format_float_node(ps: &mut BaseParserState, float_node: prism::FloatNode) {
     handle_string_at_offset(
         ps,
         loc_to_string(float_node.location()),
@@ -2094,12 +2094,12 @@ fn format_float_node(ps: &mut dyn ConcreteParserState, float_node: prism::FloatN
     );
 }
 
-fn format_for_node(_ps: &mut dyn ConcreteParserState, _for_node: prism::ForNode) {
+fn format_for_node(_ps: &mut BaseParserState, _for_node: prism::ForNode) {
     todo!()
 }
 
 fn format_forwarding_arguments_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     forwarding_arguments_node: prism::ForwardingArgumentsNode,
 ) {
     handle_string_at_offset(
@@ -2110,7 +2110,7 @@ fn format_forwarding_arguments_node(
 }
 
 fn format_forwarding_parameter_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     forwarding_parameter_node: prism::ForwardingParameterNode,
 ) {
     handle_string_at_offset(
@@ -2121,7 +2121,7 @@ fn format_forwarding_parameter_node(
 }
 
 fn format_forwarding_super_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     forwarding_super_node: prism::ForwardingSuperNode,
 ) {
     ps.emit_ident("super".to_string());
@@ -2131,7 +2131,7 @@ fn format_forwarding_super_node(
     }
 }
 
-fn format_super_node(ps: &mut dyn ConcreteParserState, super_node: prism::SuperNode) {
+fn format_super_node(ps: &mut BaseParserState, super_node: prism::SuperNode) {
     ps.emit_ident("super".to_string());
     // Note that we always emit parens for SuperNodes,
     // since they're distinct from ForwardingSuperNode which never use parens
@@ -2155,48 +2155,48 @@ fn format_super_node(ps: &mut dyn ConcreteParserState, super_node: prism::SuperN
 }
 
 fn format_global_variable_and_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _global_variable_and_write_node: prism::GlobalVariableAndWriteNode,
 ) {
     todo!()
 }
 
 fn format_global_variable_operator_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _global_variable_operator_write_node: prism::GlobalVariableOperatorWriteNode,
 ) {
     todo!()
 }
 
 fn format_global_variable_or_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _global_variable_or_write_node: prism::GlobalVariableOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_global_variable_read_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _global_variable_read_node: prism::GlobalVariableReadNode,
 ) {
     todo!()
 }
 
 fn format_global_variable_target_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _global_variable_target_node: prism::GlobalVariableTargetNode,
 ) {
     todo!()
 }
 
 fn format_global_variable_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _global_variable_write_node: prism::GlobalVariableWriteNode,
 ) {
     todo!()
 }
 
-fn format_hash_node(ps: &mut dyn ConcreteParserState, hash_node: prism::HashNode) {
+fn format_hash_node(ps: &mut BaseParserState, hash_node: prism::HashNode) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -2243,13 +2243,13 @@ fn format_hash_node(ps: &mut dyn ConcreteParserState, hash_node: prism::HashNode
 }
 
 fn format_hash_pattern_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _hash_pattern_node: prism::HashPatternNode,
 ) {
     todo!()
 }
 
-fn format_if_node(ps: &mut dyn ConcreteParserState, if_node: prism::IfNode) {
+fn format_if_node(ps: &mut BaseParserState, if_node: prism::IfNode) {
     // If a keyword is present, we're in an `if/elsif` block.
     // If it's not there, this is actually a ternary, which is sufficiently
     // different that we handle it in its own branch
@@ -2310,7 +2310,7 @@ fn format_if_node(ps: &mut dyn ConcreteParserState, if_node: prism::IfNode) {
     }
 }
 
-fn format_imaginary_node(_ps: &mut dyn ConcreteParserState, _imaginary_node: prism::ImaginaryNode) {
+fn format_imaginary_node(_ps: &mut BaseParserState, _imaginary_node: prism::ImaginaryNode) {
     todo!()
 }
 
@@ -2330,40 +2330,40 @@ fn format_implicit_rest_node() {
     // Since other machinery actually handles all of this, we don't really need to do anything if we end up here.
 }
 
-fn format_in_node(_ps: &mut dyn ConcreteParserState, _in_node: prism::InNode) {
+fn format_in_node(_ps: &mut BaseParserState, _in_node: prism::InNode) {
     todo!()
 }
 
 fn format_index_and_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _index_and_write_node: prism::IndexAndWriteNode,
 ) {
     todo!()
 }
 
 fn format_index_operator_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _index_operator_write_node: prism::IndexOperatorWriteNode,
 ) {
     todo!()
 }
 
 fn format_index_or_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _index_or_write_node: prism::IndexOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_index_target_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _index_target_node: prism::IndexTargetNode,
 ) {
     todo!()
 }
 
 fn format_instance_variable_and_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     instance_variable_and_write_node: prism::InstanceVariableAndWriteNode,
 ) {
     ps.emit_ident(const_to_string(instance_variable_and_write_node.name()));
@@ -2381,7 +2381,7 @@ fn format_instance_variable_and_write_node(
 }
 
 fn format_instance_variable_operator_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     instance_variable_operator_write_node: prism::InstanceVariableOperatorWriteNode,
 ) {
     ps.emit_ident(const_to_string(
@@ -2401,7 +2401,7 @@ fn format_instance_variable_operator_write_node(
 }
 
 fn format_instance_variable_or_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     instance_variable_or_write_node: prism::InstanceVariableOrWriteNode,
 ) {
     ps.emit_ident(const_to_string(instance_variable_or_write_node.name()));
@@ -2419,21 +2419,21 @@ fn format_instance_variable_or_write_node(
 }
 
 fn format_instance_variable_read_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     instance_variable_read_node: prism::InstanceVariableReadNode,
 ) {
     ps.emit_ident(const_to_string(instance_variable_read_node.name()));
 }
 
 fn format_instance_variable_target_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     instance_variable_target_node: prism::InstanceVariableTargetNode,
 ) {
     ps.emit_ident(const_to_string(instance_variable_target_node.name()));
 }
 
 fn format_constant_read_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     constant_read_node: prism::ConstantReadNode,
 ) {
     handle_string_at_offset(
@@ -2444,7 +2444,7 @@ fn format_constant_read_node(
 }
 
 fn format_constant_path_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     constant_path_node: prism::ConstantPathNode,
 ) {
     ps.with_start_of_line(
@@ -2467,56 +2467,56 @@ fn format_constant_path_node(
 }
 
 fn format_constant_and_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _constant_and_write_node: prism::ConstantAndWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_operator_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _constant_operator_write_node: prism::ConstantOperatorWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_or_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _constant_or_write_node: prism::ConstantOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_path_and_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _constant_path_and_write_node: prism::ConstantPathAndWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_path_operator_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _constant_path_operator_write_node: prism::ConstantPathOperatorWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_path_or_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _constant_path_or_write_node: prism::ConstantPathOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_path_target_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _constant_path_target_node: prism::ConstantPathTargetNode,
 ) {
     todo!()
 }
 
 fn format_constant_path_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     constant_path_write_node: prism::ConstantPathWriteNode,
 ) {
     format_constant_path_node(ps, constant_path_write_node.target());
@@ -2528,14 +2528,14 @@ fn format_constant_path_write_node(
 }
 
 fn format_constant_target_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _constant_target_node: prism::ConstantTargetNode,
 ) {
     todo!()
 }
 
 fn format_constant_write_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     constant_write_node: prism::ConstantWriteNode,
 ) {
     ps.emit_ident(const_to_string(constant_write_node.name()));
@@ -2546,53 +2546,53 @@ fn format_constant_write_node(
     );
 }
 
-fn format_lambda_node(_ps: &mut dyn ConcreteParserState, _lambda_node: prism::LambdaNode) {
+fn format_lambda_node(_ps: &mut BaseParserState, _lambda_node: prism::LambdaNode) {
     todo!()
 }
 
 fn format_match_last_line_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _match_last_line_node: prism::MatchLastLineNode,
 ) {
     todo!()
 }
 
 fn format_match_predicate_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _match_predicate_node: prism::MatchPredicateNode,
 ) {
     todo!()
 }
 
 fn format_match_required_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _match_required_node: prism::MatchRequiredNode,
 ) {
     todo!()
 }
 
 fn format_match_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _match_write_node: prism::MatchWriteNode,
 ) {
     todo!()
 }
 
 fn format_multi_target_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _multi_target_node: prism::MultiTargetNode,
 ) {
     todo!()
 }
 
 fn format_multi_write_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _multi_write_node: prism::MultiWriteNode,
 ) {
     todo!()
 }
 
-fn format_next_node(ps: &mut dyn ConcreteParserState, next_node: prism::NextNode) {
+fn format_next_node(ps: &mut BaseParserState, next_node: prism::NextNode) {
     ps.emit_ident("next".to_string());
     if let Some(arguments_node) = next_node.arguments() {
         ps.with_start_of_line(
@@ -2609,33 +2609,33 @@ fn format_next_node(ps: &mut dyn ConcreteParserState, next_node: prism::NextNode
     }
 }
 
-fn format_nil_node(ps: &mut dyn ConcreteParserState, _nil_node: prism::NilNode) {
+fn format_nil_node(ps: &mut BaseParserState, _nil_node: prism::NilNode) {
     ps.emit_ident("nil".to_string());
 }
 
 fn format_no_keywords_parameter_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _no_keywords_parameter_node: prism::NoKeywordsParameterNode,
 ) {
     todo!()
 }
 
 fn format_numbered_parameters_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _numbered_parameters_node: prism::NumberedParametersNode,
 ) {
     todo!()
 }
 
 fn format_numbered_reference_read_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _numbered_reference_read_node: prism::NumberedReferenceReadNode,
 ) {
     todo!()
 }
 
 fn format_optional_keyword_parameter_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     optional_keyword_parameter_node: prism::OptionalKeywordParameterNode,
 ) {
     ps.emit_ident(const_to_string(optional_keyword_parameter_node.name()));
@@ -2649,7 +2649,7 @@ fn format_optional_keyword_parameter_node(
 }
 
 fn format_optional_parameter_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     optional_parameter_node: prism::OptionalParameterNode,
 ) {
     ps.emit_ident(const_to_string(optional_parameter_node.name()));
@@ -2657,39 +2657,39 @@ fn format_optional_parameter_node(
     format_node(ps, optional_parameter_node.value());
 }
 
-fn format_or_node(_ps: &mut dyn ConcreteParserState, _or_node: prism::OrNode) {
+fn format_or_node(_ps: &mut BaseParserState, _or_node: prism::OrNode) {
     todo!()
 }
 
 fn format_pinned_expression_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _pinned_expression_node: prism::PinnedExpressionNode,
 ) {
     todo!()
 }
 
 fn format_pinned_variable_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _pinned_variable_node: prism::PinnedVariableNode,
 ) {
     todo!()
 }
 
 fn format_post_execution_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _post_execution_node: prism::PostExecutionNode,
 ) {
     todo!()
 }
 
 fn format_pre_execution_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _pre_execution_node: prism::PreExecutionNode,
 ) {
     todo!()
 }
 
-fn format_range_node(ps: &mut dyn ConcreteParserState, range_node: prism::RangeNode) {
+fn format_range_node(ps: &mut BaseParserState, range_node: prism::RangeNode) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -2704,16 +2704,16 @@ fn format_range_node(ps: &mut dyn ConcreteParserState, range_node: prism::RangeN
     );
 }
 
-fn format_rational_node(_ps: &mut dyn ConcreteParserState, _rational_node: prism::RationalNode) {
+fn format_rational_node(_ps: &mut BaseParserState, _rational_node: prism::RationalNode) {
     todo!()
 }
 
-fn format_redo_node(ps: &mut dyn ConcreteParserState) {
+fn format_redo_node(ps: &mut BaseParserState) {
     ps.emit_ident("redo".to_string());
 }
 
 fn format_regular_expression_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     regular_expression_node: prism::RegularExpressionNode,
 ) {
     ps.emit_ident(loc_to_string(regular_expression_node.opening_loc()));
@@ -2722,13 +2722,13 @@ fn format_regular_expression_node(
 }
 
 fn format_rescue_modifier_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _rescue_modifier_node: prism::RescueModifierNode,
 ) {
     todo!()
 }
 
-fn format_rescue_node(ps: &mut dyn ConcreteParserState, rescue_node: prism::RescueNode) {
+fn format_rescue_node(ps: &mut BaseParserState, rescue_node: prism::RescueNode) {
     // Double check that these offsets are correct, since begin/rescue/ensure/else
     // aren't always handled with `format_node`, which usually handles this
     ps.at_offset(rescue_node.location().start_offset());
@@ -2781,11 +2781,11 @@ fn format_rescue_node(ps: &mut dyn ConcreteParserState, rescue_node: prism::Resc
     ps.at_offset(rescue_node.location().end_offset());
 }
 
-fn format_retry_node(ps: &mut dyn ConcreteParserState) {
+fn format_retry_node(ps: &mut BaseParserState) {
     ps.emit_keyword("retry".to_string());
 }
 
-fn format_return_node(ps: &mut dyn ConcreteParserState, return_node: prism::ReturnNode) {
+fn format_return_node(ps: &mut BaseParserState, return_node: prism::ReturnNode) {
     ps.emit_ident("return".to_string());
     ps.with_start_of_line(
         false,
@@ -2809,21 +2809,21 @@ fn format_return_node(ps: &mut dyn ConcreteParserState, return_node: prism::Retu
 }
 
 fn format_shareable_constant_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _shareable_constant_node: prism::ShareableConstantNode,
 ) {
     todo!()
 }
 
 fn format_singleton_class_node(
-    _ps: &mut dyn ConcreteParserState,
+    _ps: &mut BaseParserState,
     _singleton_class_node: prism::SingletonClassNode,
 ) {
     todo!()
 }
 
 fn format_source_encoding_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     source_encoding_node: prism::SourceEncodingNode,
 ) {
     handle_string_at_offset(
@@ -2834,7 +2834,7 @@ fn format_source_encoding_node(
 }
 
 fn format_source_file_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     source_file_node: prism::SourceFileNode,
 ) {
     handle_string_at_offset(
@@ -2845,7 +2845,7 @@ fn format_source_file_node(
 }
 
 fn format_source_line_node(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     source_line_node: prism::SourceLineNode,
 ) {
     handle_string_at_offset(
@@ -2855,31 +2855,31 @@ fn format_source_line_node(
     );
 }
 
-fn format_self_node(ps: &mut dyn ConcreteParserState, _self_node: prism::SelfNode) {
+fn format_self_node(ps: &mut BaseParserState, _self_node: prism::SelfNode) {
     ps.emit_ident("self".to_string());
 }
 
-fn format_true_node(ps: &mut dyn ConcreteParserState, true_node: prism::TrueNode) {
+fn format_true_node(ps: &mut BaseParserState, true_node: prism::TrueNode) {
     handle_string_at_offset(ps, "true".to_string(), true_node.location().start_offset());
 }
 
-fn format_undef_node(_ps: &mut dyn ConcreteParserState, _undef_node: prism::UndefNode) {
+fn format_undef_node(_ps: &mut BaseParserState, _undef_node: prism::UndefNode) {
     todo!()
 }
 
-fn format_unless_node(_ps: &mut dyn ConcreteParserState, _unless_node: prism::UnlessNode) {
+fn format_unless_node(_ps: &mut BaseParserState, _unless_node: prism::UnlessNode) {
     todo!()
 }
 
-fn format_until_node(_ps: &mut dyn ConcreteParserState, _until_node: prism::UntilNode) {
+fn format_until_node(_ps: &mut BaseParserState, _until_node: prism::UntilNode) {
     todo!()
 }
 
-fn format_when_node(_ps: &mut dyn ConcreteParserState, _when_node: prism::WhenNode) {
+fn format_when_node(_ps: &mut BaseParserState, _when_node: prism::WhenNode) {
     todo!()
 }
 
-fn format_while_node(ps: &mut dyn ConcreteParserState, while_node: prism::WhileNode) {
+fn format_while_node(ps: &mut BaseParserState, while_node: prism::WhileNode) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -2900,13 +2900,13 @@ fn format_while_node(ps: &mut dyn ConcreteParserState, while_node: prism::WhileN
     ps.emit_end();
 }
 
-fn format_x_string_node(ps: &mut dyn ConcreteParserState, x_string_node: prism::XStringNode) {
+fn format_x_string_node(ps: &mut BaseParserState, x_string_node: prism::XStringNode) {
     ps.emit_ident("`".to_string());
     ps.emit_string_content(loc_to_string(x_string_node.content_loc()));
     ps.emit_ident("`".to_string());
 }
 
-fn format_yield_node(ps: &mut dyn ConcreteParserState, yield_node: prism::YieldNode) {
+fn format_yield_node(ps: &mut BaseParserState, yield_node: prism::YieldNode) {
     ps.emit_ident("yield".to_string());
     if let Some(arguments) = yield_node.arguments() {
         let use_parens =
@@ -2926,7 +2926,7 @@ fn format_yield_node(ps: &mut dyn ConcreteParserState, yield_node: prism::YieldN
     }
 }
 
-fn handle_string_at_offset(ps: &mut dyn ConcreteParserState, ident: String, offset: usize) {
+fn handle_string_at_offset(ps: &mut BaseParserState, ident: String, offset: usize) {
     ps.at_offset(offset);
     ps.emit_ident(ident);
 }
@@ -2948,7 +2948,7 @@ fn node_list_is_empty(node_list: &prism::NodeList) -> bool {
 }
 
 fn format_list_like_thing(
-    ps: &mut dyn ConcreteParserState,
+    ps: &mut BaseParserState,
     node_list: prism::NodeList,
     end_offset: SourceOffset,
     single_line: bool,

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4,7 +4,7 @@ use crate::{
     delimiters::BreakableDelims,
     format::SpecialCase,
     heredoc_string::HeredocKind,
-    parser_state::{ParserState, FormattingContext, HashType, RenderFunc},
+    parser_state::{FormattingContext, HashType, ParserState, RenderFunc},
     render_targets::MultilineHandling,
     types::SourceOffset,
     util::{const_to_string, loc_to_string, u8_to_string},
@@ -411,10 +411,7 @@ fn format_alias_global_variable_node(
     todo!()
 }
 
-fn format_alias_method_node(
-    _ps: &mut ParserState,
-    _alias_method_node: prism::AliasMethodNode,
-) {
+fn format_alias_method_node(_ps: &mut ParserState, _alias_method_node: prism::AliasMethodNode) {
     todo!()
 }
 
@@ -510,10 +507,7 @@ fn format_capture_pattern_node(
     todo!()
 }
 
-fn format_case_match_node(
-    _ps: &mut ParserState,
-    _case_match_node: prism::CaseMatchNode,
-) {
+fn format_case_match_node(_ps: &mut ParserState, _case_match_node: prism::CaseMatchNode) {
     todo!()
 }
 
@@ -722,11 +716,7 @@ impl HeredocNodeType<'_> {
     }
 }
 
-fn format_heredoc(
-    ps: &mut ParserState,
-    heredoc: HeredocNodeType,
-    heredoc_symbol: String,
-) {
+fn format_heredoc(ps: &mut ParserState, heredoc: HeredocNodeType, heredoc_symbol: String) {
     let heredoc_kind = HeredocKind::from_string(&heredoc_symbol);
     ps.emit_heredoc_start(heredoc_symbol, heredoc_kind);
 
@@ -742,11 +732,7 @@ fn format_heredoc(
     ps.wind_dumping_comments_until_offset(heredoc.closing_loc().start_offset());
 }
 
-fn format_inner_string(
-    ps: &mut ParserState,
-    parts: Vec<prism::Node>,
-    is_heredoc: bool,
-) {
+fn format_inner_string(ps: &mut ParserState, parts: Vec<prism::Node>, is_heredoc: bool) {
     let mut peekable = parts.iter().peekable();
     while let Some(part) = peekable.next() {
         match part {
@@ -816,10 +802,7 @@ fn format_it_local_variable_read_node(
     todo!()
 }
 
-fn format_it_parameters_node(
-    _ps: &mut ParserState,
-    _it_parameters_node: prism::ItParametersNode,
-) {
+fn format_it_parameters_node(_ps: &mut ParserState, _it_parameters_node: prism::ItParametersNode) {
     todo!()
 }
 
@@ -896,10 +879,7 @@ fn format_false_node(ps: &mut ParserState, false_node: prism::FalseNode) {
     );
 }
 
-fn format_find_pattern_node(
-    _ps: &mut ParserState,
-    _find_pattern_node: prism::FindPatternNode,
-) {
+fn format_find_pattern_node(_ps: &mut ParserState, _find_pattern_node: prism::FindPatternNode) {
     todo!()
 }
 
@@ -1295,10 +1275,7 @@ fn format_parameters_node(ps: &mut ParserState, params: prism::ParametersNode) {
     }
 }
 
-fn format_block_parameter_node(
-    ps: &mut ParserState,
-    block_arg: prism::BlockParameterNode,
-) {
+fn format_block_parameter_node(ps: &mut ParserState, block_arg: prism::BlockParameterNode) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -1313,10 +1290,7 @@ fn format_block_parameter_node(
     );
 }
 
-fn format_block_argument_node(
-    ps: &mut ParserState,
-    block_argument_node: prism::BlockArgumentNode,
-) {
+fn format_block_argument_node(ps: &mut ParserState, block_argument_node: prism::BlockArgumentNode) {
     ps.emit_ident("&".to_string());
     if let Some(expression_node) = block_argument_node.expression() {
         ps.with_start_of_line(
@@ -1328,11 +1302,7 @@ fn format_block_argument_node(
     }
 }
 
-fn format_call_node(
-    ps: &mut ParserState,
-    call_node: prism::CallNode,
-    skip_receiver: bool,
-) {
+fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_receiver: bool) {
     if skip_receiver || call_node.receiver().is_none() {
         let method_name = const_to_string(call_node.name());
         let is_aref = &method_name == "[]";
@@ -1551,17 +1521,11 @@ fn format_call_operator_write_node(
     todo!()
 }
 
-fn format_call_or_write_node(
-    _ps: &mut ParserState,
-    _call_or_write_node: prism::CallOrWriteNode,
-) {
+fn format_call_or_write_node(_ps: &mut ParserState, _call_or_write_node: prism::CallOrWriteNode) {
     todo!()
 }
 
-fn format_call_target_node(
-    _ps: &mut ParserState,
-    _call_target_node: prism::CallTargetNode,
-) {
+fn format_call_target_node(_ps: &mut ParserState, _call_target_node: prism::CallTargetNode) {
     todo!()
 }
 
@@ -1601,10 +1565,7 @@ fn format_assoc_node(ps: &mut ParserState, assoc_node: prism::AssocNode) {
     );
 }
 
-fn format_assoc_splat_node(
-    ps: &mut ParserState,
-    assoc_splat_node: prism::AssocSplatNode,
-) {
+fn format_assoc_splat_node(ps: &mut ParserState, assoc_splat_node: prism::AssocSplatNode) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -1795,17 +1756,11 @@ fn format_array_node(ps: &mut ParserState, array_node: prism::ArrayNode) {
     }
 }
 
-fn format_array_pattern_node(
-    _ps: &mut ParserState,
-    _array_pattern_node: prism::ArrayPatternNode,
-) {
+fn format_array_pattern_node(_ps: &mut ParserState, _array_pattern_node: prism::ArrayPatternNode) {
     todo!()
 }
 
-fn format_parentheses_node(
-    ps: &mut ParserState,
-    parentheses_node: prism::ParenthesesNode,
-) {
+fn format_parentheses_node(ps: &mut ParserState, parentheses_node: prism::ParenthesesNode) {
     ps.emit_open_paren();
     if let Some(body) = parentheses_node.body() {
         ps.with_start_of_line(
@@ -1902,10 +1857,7 @@ fn format_arguments_node(ps: &mut ParserState, arguments_node: prism::ArgumentsN
     );
 }
 
-fn format_keyword_hash_node(
-    ps: &mut ParserState,
-    keyword_hash_node: prism::KeywordHashNode,
-) {
+fn format_keyword_hash_node(ps: &mut ParserState, keyword_hash_node: prism::KeywordHashNode) {
     let all_symbol_keys = keyword_hash_node
         .elements()
         .iter()
@@ -2242,10 +2194,7 @@ fn format_hash_node(ps: &mut ParserState, hash_node: prism::HashNode) {
     );
 }
 
-fn format_hash_pattern_node(
-    _ps: &mut ParserState,
-    _hash_pattern_node: prism::HashPatternNode,
-) {
+fn format_hash_pattern_node(_ps: &mut ParserState, _hash_pattern_node: prism::HashPatternNode) {
     todo!()
 }
 
@@ -2355,10 +2304,7 @@ fn format_index_or_write_node(
     todo!()
 }
 
-fn format_index_target_node(
-    _ps: &mut ParserState,
-    _index_target_node: prism::IndexTargetNode,
-) {
+fn format_index_target_node(_ps: &mut ParserState, _index_target_node: prism::IndexTargetNode) {
     todo!()
 }
 
@@ -2432,10 +2378,7 @@ fn format_instance_variable_target_node(
     ps.emit_ident(const_to_string(instance_variable_target_node.name()));
 }
 
-fn format_constant_read_node(
-    ps: &mut ParserState,
-    constant_read_node: prism::ConstantReadNode,
-) {
+fn format_constant_read_node(ps: &mut ParserState, constant_read_node: prism::ConstantReadNode) {
     handle_string_at_offset(
         ps,
         const_to_string(constant_read_node.name()),
@@ -2443,10 +2386,7 @@ fn format_constant_read_node(
     );
 }
 
-fn format_constant_path_node(
-    ps: &mut ParserState,
-    constant_path_node: prism::ConstantPathNode,
-) {
+fn format_constant_path_node(ps: &mut ParserState, constant_path_node: prism::ConstantPathNode) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -2534,10 +2474,7 @@ fn format_constant_target_node(
     todo!()
 }
 
-fn format_constant_write_node(
-    ps: &mut ParserState,
-    constant_write_node: prism::ConstantWriteNode,
-) {
+fn format_constant_write_node(ps: &mut ParserState, constant_write_node: prism::ConstantWriteNode) {
     ps.emit_ident(const_to_string(constant_write_node.name()));
     ps.emit_op(" = ".to_string());
     ps.with_start_of_line(
@@ -2571,24 +2508,15 @@ fn format_match_required_node(
     todo!()
 }
 
-fn format_match_write_node(
-    _ps: &mut ParserState,
-    _match_write_node: prism::MatchWriteNode,
-) {
+fn format_match_write_node(_ps: &mut ParserState, _match_write_node: prism::MatchWriteNode) {
     todo!()
 }
 
-fn format_multi_target_node(
-    _ps: &mut ParserState,
-    _multi_target_node: prism::MultiTargetNode,
-) {
+fn format_multi_target_node(_ps: &mut ParserState, _multi_target_node: prism::MultiTargetNode) {
     todo!()
 }
 
-fn format_multi_write_node(
-    _ps: &mut ParserState,
-    _multi_write_node: prism::MultiWriteNode,
-) {
+fn format_multi_write_node(_ps: &mut ParserState, _multi_write_node: prism::MultiWriteNode) {
     todo!()
 }
 
@@ -2682,10 +2610,7 @@ fn format_post_execution_node(
     todo!()
 }
 
-fn format_pre_execution_node(
-    _ps: &mut ParserState,
-    _pre_execution_node: prism::PreExecutionNode,
-) {
+fn format_pre_execution_node(_ps: &mut ParserState, _pre_execution_node: prism::PreExecutionNode) {
     todo!()
 }
 
@@ -2833,10 +2758,7 @@ fn format_source_encoding_node(
     );
 }
 
-fn format_source_file_node(
-    ps: &mut ParserState,
-    source_file_node: prism::SourceFileNode,
-) {
+fn format_source_file_node(ps: &mut ParserState, source_file_node: prism::SourceFileNode) {
     handle_string_at_offset(
         ps,
         "__FILE__".to_string(),
@@ -2844,10 +2766,7 @@ fn format_source_file_node(
     );
 }
 
-fn format_source_line_node(
-    ps: &mut ParserState,
-    source_line_node: prism::SourceLineNode,
-) {
+fn format_source_line_node(ps: &mut ParserState, source_line_node: prism::SourceLineNode) {
     handle_string_at_offset(
         ps,
         "__LINE__".to_string(),

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4,13 +4,13 @@ use crate::{
     delimiters::BreakableDelims,
     format::SpecialCase,
     heredoc_string::HeredocKind,
-    parser_state::{BaseParserState, FormattingContext, HashType, RenderFunc},
+    parser_state::{ParserState, FormattingContext, HashType, RenderFunc},
     render_targets::MultilineHandling,
     types::SourceOffset,
     util::{const_to_string, loc_to_string, u8_to_string},
 };
 
-pub fn format_node(ps: &mut BaseParserState, node: prism::Node) {
+pub fn format_node(ps: &mut ParserState, node: prism::Node) {
     use prism::Node;
 
     ps.at_offset(node.location().start_offset());
@@ -405,38 +405,38 @@ pub fn format_node(ps: &mut BaseParserState, node: prism::Node) {
 }
 
 fn format_alias_global_variable_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _alias_global_variable_node: prism::AliasGlobalVariableNode,
 ) {
     todo!()
 }
 
 fn format_alias_method_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _alias_method_node: prism::AliasMethodNode,
 ) {
     todo!()
 }
 
 fn format_alternation_pattern_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _alternation_pattern_node: prism::AlternationPatternNode,
 ) {
     todo!()
 }
 
-fn format_and_node(_ps: &mut BaseParserState, _and_node: prism::AndNode) {
+fn format_and_node(_ps: &mut ParserState, _and_node: prism::AndNode) {
     todo!()
 }
 
 fn format_back_reference_read_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _back_reference_read_node: prism::BackReferenceReadNode,
 ) {
     todo!()
 }
 
-fn format_begin_node(ps: &mut BaseParserState, begin_node: prism::BeginNode) {
+fn format_begin_node(ps: &mut ParserState, begin_node: prism::BeginNode) {
     // If there's no `begin` keyword loc, this is probably an "implicit" begin node,
     // like a rescue/ensure in a def without a `begin` keyword:
     // ```ruby
@@ -499,30 +499,30 @@ fn format_begin_node(ps: &mut BaseParserState, begin_node: prism::BeginNode) {
     ps.at_offset(begin_node.location().end_offset());
 }
 
-fn format_break_node(_ps: &mut BaseParserState, _break_node: prism::BreakNode) {
+fn format_break_node(_ps: &mut ParserState, _break_node: prism::BreakNode) {
     todo!()
 }
 
 fn format_capture_pattern_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _capture_pattern_node: prism::CapturePatternNode,
 ) {
     todo!()
 }
 
 fn format_case_match_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _case_match_node: prism::CaseMatchNode,
 ) {
     todo!()
 }
 
-fn format_case_node(_ps: &mut BaseParserState, _case_node: prism::CaseNode) {
+fn format_case_node(_ps: &mut ParserState, _case_node: prism::CaseNode) {
     todo!()
 }
 
 pub fn format_program(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     program_node: prism::ProgramNode,
     data_loc: Option<prism::Location>,
 ) {
@@ -541,7 +541,7 @@ pub fn format_program(
     }
 }
 
-fn format_statements(ps: &mut BaseParserState, statements_node: prism::StatementsNode) {
+fn format_statements(ps: &mut ParserState, statements_node: prism::StatementsNode) {
     ps.with_start_of_line(
         true,
         Box::new(|ps| {
@@ -552,7 +552,7 @@ fn format_statements(ps: &mut BaseParserState, statements_node: prism::Statement
     );
 }
 
-fn format_string_node(ps: &mut BaseParserState, string_node: prism::StringNode) {
+fn format_string_node(ps: &mut ParserState, string_node: prism::StringNode) {
     ps.at_offset(string_node.location().start_offset());
 
     // `opening_loc()` is only `None` in the case of the inner parts of multiline strings
@@ -611,7 +611,7 @@ fn format_string_node(ps: &mut BaseParserState, string_node: prism::StringNode) 
 }
 
 fn format_interpolated_string_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     interpolated_string_node: prism::InterpolatedStringNode,
 ) {
     let opener = interpolated_string_node
@@ -723,7 +723,7 @@ impl HeredocNodeType<'_> {
 }
 
 fn format_heredoc(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     heredoc: HeredocNodeType,
     heredoc_symbol: String,
 ) {
@@ -734,7 +734,7 @@ fn format_heredoc(
         loc_to_string(heredoc.closing_loc()).trim().to_string(),
         heredoc_kind,
         ps.get_line_number_for_offset(heredoc.closing_loc().start_offset()),
-        Box::new(|n: &mut BaseParserState| {
+        Box::new(|n: &mut ParserState| {
             n.disable_user_newlines();
             format_inner_string(n, heredoc.parts(), true);
         }),
@@ -743,7 +743,7 @@ fn format_heredoc(
 }
 
 fn format_inner_string(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     parts: Vec<prism::Node>,
     is_heredoc: bool,
 ) {
@@ -796,49 +796,49 @@ fn format_inner_string(
 }
 
 fn format_interpolated_symbol_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _interpolated_string_node: prism::InterpolatedSymbolNode,
 ) {
     todo!()
 }
 
 fn format_interpolated_x_string_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _interpolated_x_string_node: prism::InterpolatedXStringNode,
 ) {
     todo!()
 }
 
 fn format_it_local_variable_read_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _it_local_variable_read_node: prism::ItLocalVariableReadNode,
 ) {
     todo!()
 }
 
 fn format_it_parameters_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _it_parameters_node: prism::ItParametersNode,
 ) {
     todo!()
 }
 
 fn format_interpolated_last_line_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _interpolated_match_last_line_node: prism::InterpolatedMatchLastLineNode,
 ) {
     todo!()
 }
 
 fn format_interpolated_regular_expression_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _interpolated_regular_expression_node: prism::InterpolatedRegularExpressionNode,
 ) {
     todo!()
 }
 
 fn format_embedded_statements_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     embedded_statements_node: prism::EmbeddedStatementsNode,
 ) {
     ps.emit_string_content("#{".to_string());
@@ -866,13 +866,13 @@ fn format_embedded_statements_node(
 }
 
 fn format_embedded_variable_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _embedded_variable_node: prism::EmbeddedVariableNode,
 ) {
     todo!()
 }
 
-fn format_ensure_node(ps: &mut BaseParserState, ensure_node: prism::EnsureNode) {
+fn format_ensure_node(ps: &mut ParserState, ensure_node: prism::EnsureNode) {
     // Double check that these offsets are correct, since begin/rescue/ensure/else
     // aren't always handled with `format_node`, which usually handles this
     ps.at_offset(ensure_node.location().start_offset());
@@ -888,7 +888,7 @@ fn format_ensure_node(ps: &mut BaseParserState, ensure_node: prism::EnsureNode) 
     ps.at_offset(ensure_node.location().end_offset());
 }
 
-fn format_false_node(ps: &mut BaseParserState, false_node: prism::FalseNode) {
+fn format_false_node(ps: &mut ParserState, false_node: prism::FalseNode) {
     handle_string_at_offset(
         ps,
         "false".to_string(),
@@ -897,17 +897,17 @@ fn format_false_node(ps: &mut BaseParserState, false_node: prism::FalseNode) {
 }
 
 fn format_find_pattern_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _find_pattern_node: prism::FindPatternNode,
 ) {
     todo!()
 }
 
-fn format_flip_flop_node(_ps: &mut BaseParserState, _flip_flop_node: prism::FlipFlopNode) {
+fn format_flip_flop_node(_ps: &mut ParserState, _flip_flop_node: prism::FlipFlopNode) {
     todo!()
 }
 
-fn format_class_node(ps: &mut BaseParserState, class_node: prism::ClassNode) {
+fn format_class_node(ps: &mut ParserState, class_node: prism::ClassNode) {
     ps.emit_class_keyword();
     ps.emit_space();
     ps.with_start_of_line(
@@ -946,7 +946,7 @@ fn format_class_node(ps: &mut BaseParserState, class_node: prism::ClassNode) {
 }
 
 fn format_class_variable_and_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     class_variable_and_write_node: prism::ClassVariableAndWriteNode,
 ) {
     ps.emit_ident(const_to_string(class_variable_and_write_node.name()));
@@ -962,7 +962,7 @@ fn format_class_variable_and_write_node(
 }
 
 fn format_class_variable_operator_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     class_variable_operator_write_node: prism::ClassVariableOperatorWriteNode,
 ) {
     ps.emit_ident(const_to_string(class_variable_operator_write_node.name()));
@@ -980,7 +980,7 @@ fn format_class_variable_operator_write_node(
 }
 
 fn format_class_variable_or_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     class_variable_or_write_node: prism::ClassVariableOrWriteNode,
 ) {
     ps.emit_ident(const_to_string(class_variable_or_write_node.name()));
@@ -996,21 +996,21 @@ fn format_class_variable_or_write_node(
 }
 
 fn format_class_variable_read_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     class_variable_read_node: prism::ClassVariableReadNode,
 ) {
     ps.emit_ident(const_to_string(class_variable_read_node.name()));
 }
 
 fn format_class_variable_target_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     class_variable_target_node: prism::ClassVariableTargetNode,
 ) {
     ps.emit_ident(const_to_string(class_variable_target_node.name()));
 }
 
 fn format_class_variable_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     class_variable_write_node: prism::ClassVariableWriteNode,
 ) {
     ps.at_offset(class_variable_write_node.location().start_offset());
@@ -1025,7 +1025,7 @@ fn format_class_variable_write_node(
     );
 }
 
-fn format_module_node(ps: &mut BaseParserState, module_node: prism::ModuleNode) {
+fn format_module_node(ps: &mut ParserState, module_node: prism::ModuleNode) {
     ps.emit_module_keyword();
     ps.emit_space();
     ps.with_start_of_line(
@@ -1053,7 +1053,7 @@ fn format_module_node(ps: &mut BaseParserState, module_node: prism::ModuleNode) 
     );
 }
 
-fn format_def_node(ps: &mut BaseParserState, def_node: prism::DefNode) {
+fn format_def_node(ps: &mut ParserState, def_node: prism::DefNode) {
     ps.emit_keyword("def".to_string());
     ps.emit_space();
 
@@ -1076,7 +1076,7 @@ fn format_def_node(ps: &mut BaseParserState, def_node: prism::DefNode) {
     format_def_body(ps, def_node);
 }
 
-fn format_def_body(ps: &mut BaseParserState, def_node: prism::DefNode) {
+fn format_def_body(ps: &mut ParserState, def_node: prism::DefNode) {
     ps.new_scope(Box::new(|ps| {
         if let Some(parameters_node) = def_node.parameters() {
             ps.breakable_of(
@@ -1161,11 +1161,11 @@ fn format_def_body(ps: &mut BaseParserState, def_node: prism::DefNode) {
     }
 }
 
-fn format_defined_node(_ps: &mut BaseParserState, _defined_node: prism::DefinedNode) {
+fn format_defined_node(_ps: &mut ParserState, _defined_node: prism::DefinedNode) {
     todo!()
 }
 
-fn format_else_node(ps: &mut BaseParserState, else_node: prism::ElseNode) {
+fn format_else_node(ps: &mut ParserState, else_node: prism::ElseNode) {
     // Double check that these offsets are correct, since begin/rescue/ensure/else
     // aren't always handled with `format_node`, which usually handles this
     ps.at_offset(else_node.location().start_offset());
@@ -1207,9 +1207,9 @@ fn format_else_node(ps: &mut BaseParserState, else_node: prism::ElseNode) {
     ps.at_offset(else_node.location().end_offset());
 }
 
-type ParamFormattingFunc<'a> = Box<dyn FnOnce(&mut BaseParserState) + 'a>;
+type ParamFormattingFunc<'a> = Box<dyn FnOnce(&mut ParserState) + 'a>;
 
-fn format_parameters_node(ps: &mut BaseParserState, params: prism::ParametersNode) {
+fn format_parameters_node(ps: &mut ParserState, params: prism::ParametersNode) {
     let non_null_positions = non_null_positions(&params);
 
     //def foo(a, b=nil, *args, d, e:, **kwargs, &blk)
@@ -1237,45 +1237,45 @@ fn format_parameters_node(ps: &mut BaseParserState, params: prism::ParametersNod
     let block = params.block();
 
     let formats: Vec<ParamFormattingFunc> = vec![
-        Box::new(move |ps: &mut BaseParserState| {
+        Box::new(move |ps: &mut ParserState| {
             if node_list_is_empty(&requireds) {
                 return;
             }
             let end_offset = requireds.iter().last().unwrap().location().end_offset();
             format_list_like_thing(ps, requireds, end_offset, false);
         }),
-        Box::new(move |ps: &mut BaseParserState| {
+        Box::new(move |ps: &mut ParserState| {
             if node_list_is_empty(&optionals) {
                 return;
             }
             let end_offset = optionals.iter().last().unwrap().location().end_offset();
             format_list_like_thing(ps, optionals, end_offset, false);
         }),
-        Box::new(move |ps: &mut BaseParserState| {
+        Box::new(move |ps: &mut ParserState| {
             if let Some(rest) = rest {
                 format_node(ps, rest);
             }
         }),
-        Box::new(move |ps: &mut BaseParserState| {
+        Box::new(move |ps: &mut ParserState| {
             if node_list_is_empty(&posts) {
                 return;
             }
             let end_offset = posts.iter().last().unwrap().location().end_offset();
             format_list_like_thing(ps, posts, end_offset, false);
         }),
-        Box::new(move |ps: &mut BaseParserState| {
+        Box::new(move |ps: &mut ParserState| {
             if node_list_is_empty(&keywords) {
                 return;
             }
             let end_offset = keywords.iter().last().unwrap().location().end_offset();
             format_list_like_thing(ps, keywords, end_offset, false);
         }),
-        Box::new(move |ps: &mut BaseParserState| {
+        Box::new(move |ps: &mut ParserState| {
             if let Some(keyword_rest) = keyword_rest {
                 format_node(ps, keyword_rest);
             }
         }),
-        Box::new(move |ps: &mut BaseParserState| {
+        Box::new(move |ps: &mut ParserState| {
             if let Some(block) = block {
                 format_block_parameter_node(ps, block);
             }
@@ -1296,7 +1296,7 @@ fn format_parameters_node(ps: &mut BaseParserState, params: prism::ParametersNod
 }
 
 fn format_block_parameter_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     block_arg: prism::BlockParameterNode,
 ) {
     ps.with_start_of_line(
@@ -1314,7 +1314,7 @@ fn format_block_parameter_node(
 }
 
 fn format_block_argument_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     block_argument_node: prism::BlockArgumentNode,
 ) {
     ps.emit_ident("&".to_string());
@@ -1329,7 +1329,7 @@ fn format_block_argument_node(
 }
 
 fn format_call_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     call_node: prism::CallNode,
     skip_receiver: bool,
 ) {
@@ -1478,7 +1478,7 @@ fn format_call_node(
 }
 
 fn call_chain_elements_are_user_multilined(
-    ps: &BaseParserState,
+    ps: &ParserState,
     call_chain_elements: Vec<&prism::Node>,
 ) -> bool {
     // Making a mutable copy since we may pop some items off later
@@ -1538,34 +1538,34 @@ fn call_chain_elements_are_user_multilined(
 }
 
 fn format_call_and_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _call_and_write_node: prism::CallAndWriteNode,
 ) {
     todo!()
 }
 
 fn format_call_operator_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _call_operator_write_node: prism::CallOperatorWriteNode,
 ) {
     todo!()
 }
 
 fn format_call_or_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _call_or_write_node: prism::CallOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_call_target_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _call_target_node: prism::CallTargetNode,
 ) {
     todo!()
 }
 
-fn format_symbol_node(ps: &mut BaseParserState, symbol_node: prism::SymbolNode) {
+fn format_symbol_node(ps: &mut ParserState, symbol_node: prism::SymbolNode) {
     if let Some(opening_loc) = symbol_node.opening_loc() {
         ps.emit_ident(loc_to_string(opening_loc));
     }
@@ -1574,7 +1574,7 @@ fn format_symbol_node(ps: &mut BaseParserState, symbol_node: prism::SymbolNode) 
     }
 }
 
-fn format_assoc_node(ps: &mut BaseParserState, assoc_node: prism::AssocNode) {
+fn format_assoc_node(ps: &mut ParserState, assoc_node: prism::AssocNode) {
     let as_symbol = if let Some(hash_type) = ps.hash_type_from_formatting_context() {
         matches!(hash_type, HashType::SymbolKey)
     } else {
@@ -1602,7 +1602,7 @@ fn format_assoc_node(ps: &mut BaseParserState, assoc_node: prism::AssocNode) {
 }
 
 fn format_assoc_splat_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     assoc_splat_node: prism::AssocSplatNode,
 ) {
     ps.with_start_of_line(
@@ -1616,7 +1616,7 @@ fn format_assoc_splat_node(
     );
 }
 
-fn format_block_node(ps: &mut BaseParserState, block_node: prism::BlockNode) {
+fn format_block_node(ps: &mut ParserState, block_node: prism::BlockNode) {
     if &loc_to_string(block_node.opening_loc()) == "do" {
         ps.new_block(Box::new(|ps| {
             ps.emit_do_keyword();
@@ -1704,7 +1704,7 @@ fn format_block_node(ps: &mut BaseParserState, block_node: prism::BlockNode) {
 }
 
 fn format_block_parameters_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     block_parameters_node: prism::BlockParametersNode,
 ) {
     // Exit early if there's no params
@@ -1741,7 +1741,7 @@ fn format_block_parameters_node(
 }
 
 fn format_block_local_variable_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     block_local_variable_node: prism::BlockLocalVariableNode,
 ) {
     handle_string_at_offset(
@@ -1751,7 +1751,7 @@ fn format_block_local_variable_node(
     );
 }
 
-fn format_array_node(ps: &mut BaseParserState, array_node: prism::ArrayNode) {
+fn format_array_node(ps: &mut ParserState, array_node: prism::ArrayNode) {
     if node_list_is_empty(&array_node.elements()) {
         if ps.has_comment_in_offset_span(
             array_node.location().start_offset(),
@@ -1796,14 +1796,14 @@ fn format_array_node(ps: &mut BaseParserState, array_node: prism::ArrayNode) {
 }
 
 fn format_array_pattern_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _array_pattern_node: prism::ArrayPatternNode,
 ) {
     todo!()
 }
 
 fn format_parentheses_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     parentheses_node: prism::ParenthesesNode,
 ) {
     ps.emit_open_paren();
@@ -1863,7 +1863,7 @@ fn collapse_nodes_to_call_chain(node: prism::Node) -> Vec<prism::Node> {
 }
 
 fn format_rest_parameter_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     rest_param: prism::RestParameterNode,
     special_case: SpecialCase,
 ) {
@@ -1888,7 +1888,7 @@ fn format_rest_parameter_node(
     );
 }
 
-fn format_arguments_node(ps: &mut BaseParserState, arguments_node: prism::ArgumentsNode) {
+fn format_arguments_node(ps: &mut ParserState, arguments_node: prism::ArgumentsNode) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -1903,7 +1903,7 @@ fn format_arguments_node(ps: &mut BaseParserState, arguments_node: prism::Argume
 }
 
 fn format_keyword_hash_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     keyword_hash_node: prism::KeywordHashNode,
 ) {
     let all_symbol_keys = keyword_hash_node
@@ -1937,7 +1937,7 @@ fn format_keyword_hash_node(
 }
 
 fn format_keyword_rest_parameter_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     keyword_rest_parameter_node: prism::KeywordRestParameterNode,
 ) {
     ps.emit_ident("**".to_string());
@@ -1949,7 +1949,7 @@ fn format_keyword_rest_parameter_node(
 }
 
 fn format_required_keyword_parameter_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     required_keyword_parameter_node: prism::RequiredKeywordParameterNode,
 ) {
     let name = const_to_string(required_keyword_parameter_node.name());
@@ -1959,7 +1959,7 @@ fn format_required_keyword_parameter_node(
 }
 
 fn format_required_parameter_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     required_parameter_node: prism::RequiredParameterNode,
 ) {
     let name = const_to_string(required_parameter_node.name());
@@ -1968,7 +1968,7 @@ fn format_required_parameter_node(
 }
 
 fn format_local_variable_and_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     local_variable_and_write_node: prism::LocalVariableAndWriteNode,
 ) {
     let variable_name = const_to_string(local_variable_and_write_node.name());
@@ -1986,7 +1986,7 @@ fn format_local_variable_and_write_node(
 }
 
 fn format_local_variable_operator_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     local_variable_operator_write_node: prism::LocalVariableOperatorWriteNode,
 ) {
     let variable_name = const_to_string(local_variable_operator_write_node.name());
@@ -2006,14 +2006,14 @@ fn format_local_variable_operator_write_node(
 }
 
 fn format_local_variable_or_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _local_variable_or_write_node: prism::LocalVariableOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_local_variable_target_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     local_variable_target_node: prism::LocalVariableTargetNode,
 ) {
     let variable_name = const_to_string(local_variable_target_node.name());
@@ -2022,7 +2022,7 @@ fn format_local_variable_target_node(
 }
 
 fn format_local_variable_read_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     local_variable_read_node: prism::LocalVariableReadNode,
 ) {
     let name = const_to_string(local_variable_read_node.name());
@@ -2031,7 +2031,7 @@ fn format_local_variable_read_node(
 }
 
 fn format_local_variable_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     local_variable_write_node: prism::LocalVariableWriteNode,
 ) {
     let name = const_to_string(local_variable_write_node.name());
@@ -2046,7 +2046,7 @@ fn format_local_variable_write_node(
     );
 }
 
-fn format_splat_node(ps: &mut BaseParserState, splat_node: prism::SplatNode) {
+fn format_splat_node(ps: &mut ParserState, splat_node: prism::SplatNode) {
     ps.emit_ident("*".to_string());
     if let Some(node) = splat_node.expression() {
         ps.with_start_of_line(
@@ -2058,12 +2058,12 @@ fn format_splat_node(ps: &mut BaseParserState, splat_node: prism::SplatNode) {
     }
 }
 
-fn format_ident(ps: &mut BaseParserState, ident: String, offset: usize) {
+fn format_ident(ps: &mut ParserState, ident: String, offset: usize) {
     handle_string_at_offset(ps, ident, offset);
 }
 
 fn format_instance_variable_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     instance_variable_write_node: prism::InstanceVariableWriteNode,
 ) {
     ps.at_offset(instance_variable_write_node.location().start_offset());
@@ -2078,7 +2078,7 @@ fn format_instance_variable_write_node(
     );
 }
 
-fn format_integer_node(ps: &mut BaseParserState, integer_node: prism::IntegerNode) {
+fn format_integer_node(ps: &mut ParserState, integer_node: prism::IntegerNode) {
     handle_string_at_offset(
         ps,
         loc_to_string(integer_node.location()),
@@ -2086,7 +2086,7 @@ fn format_integer_node(ps: &mut BaseParserState, integer_node: prism::IntegerNod
     );
 }
 
-fn format_float_node(ps: &mut BaseParserState, float_node: prism::FloatNode) {
+fn format_float_node(ps: &mut ParserState, float_node: prism::FloatNode) {
     handle_string_at_offset(
         ps,
         loc_to_string(float_node.location()),
@@ -2094,12 +2094,12 @@ fn format_float_node(ps: &mut BaseParserState, float_node: prism::FloatNode) {
     );
 }
 
-fn format_for_node(_ps: &mut BaseParserState, _for_node: prism::ForNode) {
+fn format_for_node(_ps: &mut ParserState, _for_node: prism::ForNode) {
     todo!()
 }
 
 fn format_forwarding_arguments_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     forwarding_arguments_node: prism::ForwardingArgumentsNode,
 ) {
     handle_string_at_offset(
@@ -2110,7 +2110,7 @@ fn format_forwarding_arguments_node(
 }
 
 fn format_forwarding_parameter_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     forwarding_parameter_node: prism::ForwardingParameterNode,
 ) {
     handle_string_at_offset(
@@ -2121,7 +2121,7 @@ fn format_forwarding_parameter_node(
 }
 
 fn format_forwarding_super_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     forwarding_super_node: prism::ForwardingSuperNode,
 ) {
     ps.emit_ident("super".to_string());
@@ -2131,7 +2131,7 @@ fn format_forwarding_super_node(
     }
 }
 
-fn format_super_node(ps: &mut BaseParserState, super_node: prism::SuperNode) {
+fn format_super_node(ps: &mut ParserState, super_node: prism::SuperNode) {
     ps.emit_ident("super".to_string());
     // Note that we always emit parens for SuperNodes,
     // since they're distinct from ForwardingSuperNode which never use parens
@@ -2155,48 +2155,48 @@ fn format_super_node(ps: &mut BaseParserState, super_node: prism::SuperNode) {
 }
 
 fn format_global_variable_and_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _global_variable_and_write_node: prism::GlobalVariableAndWriteNode,
 ) {
     todo!()
 }
 
 fn format_global_variable_operator_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _global_variable_operator_write_node: prism::GlobalVariableOperatorWriteNode,
 ) {
     todo!()
 }
 
 fn format_global_variable_or_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _global_variable_or_write_node: prism::GlobalVariableOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_global_variable_read_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _global_variable_read_node: prism::GlobalVariableReadNode,
 ) {
     todo!()
 }
 
 fn format_global_variable_target_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _global_variable_target_node: prism::GlobalVariableTargetNode,
 ) {
     todo!()
 }
 
 fn format_global_variable_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _global_variable_write_node: prism::GlobalVariableWriteNode,
 ) {
     todo!()
 }
 
-fn format_hash_node(ps: &mut BaseParserState, hash_node: prism::HashNode) {
+fn format_hash_node(ps: &mut ParserState, hash_node: prism::HashNode) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -2243,13 +2243,13 @@ fn format_hash_node(ps: &mut BaseParserState, hash_node: prism::HashNode) {
 }
 
 fn format_hash_pattern_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _hash_pattern_node: prism::HashPatternNode,
 ) {
     todo!()
 }
 
-fn format_if_node(ps: &mut BaseParserState, if_node: prism::IfNode) {
+fn format_if_node(ps: &mut ParserState, if_node: prism::IfNode) {
     // If a keyword is present, we're in an `if/elsif` block.
     // If it's not there, this is actually a ternary, which is sufficiently
     // different that we handle it in its own branch
@@ -2310,7 +2310,7 @@ fn format_if_node(ps: &mut BaseParserState, if_node: prism::IfNode) {
     }
 }
 
-fn format_imaginary_node(_ps: &mut BaseParserState, _imaginary_node: prism::ImaginaryNode) {
+fn format_imaginary_node(_ps: &mut ParserState, _imaginary_node: prism::ImaginaryNode) {
     todo!()
 }
 
@@ -2330,40 +2330,40 @@ fn format_implicit_rest_node() {
     // Since other machinery actually handles all of this, we don't really need to do anything if we end up here.
 }
 
-fn format_in_node(_ps: &mut BaseParserState, _in_node: prism::InNode) {
+fn format_in_node(_ps: &mut ParserState, _in_node: prism::InNode) {
     todo!()
 }
 
 fn format_index_and_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _index_and_write_node: prism::IndexAndWriteNode,
 ) {
     todo!()
 }
 
 fn format_index_operator_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _index_operator_write_node: prism::IndexOperatorWriteNode,
 ) {
     todo!()
 }
 
 fn format_index_or_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _index_or_write_node: prism::IndexOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_index_target_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _index_target_node: prism::IndexTargetNode,
 ) {
     todo!()
 }
 
 fn format_instance_variable_and_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     instance_variable_and_write_node: prism::InstanceVariableAndWriteNode,
 ) {
     ps.emit_ident(const_to_string(instance_variable_and_write_node.name()));
@@ -2381,7 +2381,7 @@ fn format_instance_variable_and_write_node(
 }
 
 fn format_instance_variable_operator_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     instance_variable_operator_write_node: prism::InstanceVariableOperatorWriteNode,
 ) {
     ps.emit_ident(const_to_string(
@@ -2401,7 +2401,7 @@ fn format_instance_variable_operator_write_node(
 }
 
 fn format_instance_variable_or_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     instance_variable_or_write_node: prism::InstanceVariableOrWriteNode,
 ) {
     ps.emit_ident(const_to_string(instance_variable_or_write_node.name()));
@@ -2419,21 +2419,21 @@ fn format_instance_variable_or_write_node(
 }
 
 fn format_instance_variable_read_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     instance_variable_read_node: prism::InstanceVariableReadNode,
 ) {
     ps.emit_ident(const_to_string(instance_variable_read_node.name()));
 }
 
 fn format_instance_variable_target_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     instance_variable_target_node: prism::InstanceVariableTargetNode,
 ) {
     ps.emit_ident(const_to_string(instance_variable_target_node.name()));
 }
 
 fn format_constant_read_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     constant_read_node: prism::ConstantReadNode,
 ) {
     handle_string_at_offset(
@@ -2444,7 +2444,7 @@ fn format_constant_read_node(
 }
 
 fn format_constant_path_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     constant_path_node: prism::ConstantPathNode,
 ) {
     ps.with_start_of_line(
@@ -2467,56 +2467,56 @@ fn format_constant_path_node(
 }
 
 fn format_constant_and_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _constant_and_write_node: prism::ConstantAndWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_operator_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _constant_operator_write_node: prism::ConstantOperatorWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_or_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _constant_or_write_node: prism::ConstantOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_path_and_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _constant_path_and_write_node: prism::ConstantPathAndWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_path_operator_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _constant_path_operator_write_node: prism::ConstantPathOperatorWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_path_or_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _constant_path_or_write_node: prism::ConstantPathOrWriteNode,
 ) {
     todo!()
 }
 
 fn format_constant_path_target_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _constant_path_target_node: prism::ConstantPathTargetNode,
 ) {
     todo!()
 }
 
 fn format_constant_path_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     constant_path_write_node: prism::ConstantPathWriteNode,
 ) {
     format_constant_path_node(ps, constant_path_write_node.target());
@@ -2528,14 +2528,14 @@ fn format_constant_path_write_node(
 }
 
 fn format_constant_target_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _constant_target_node: prism::ConstantTargetNode,
 ) {
     todo!()
 }
 
 fn format_constant_write_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     constant_write_node: prism::ConstantWriteNode,
 ) {
     ps.emit_ident(const_to_string(constant_write_node.name()));
@@ -2546,53 +2546,53 @@ fn format_constant_write_node(
     );
 }
 
-fn format_lambda_node(_ps: &mut BaseParserState, _lambda_node: prism::LambdaNode) {
+fn format_lambda_node(_ps: &mut ParserState, _lambda_node: prism::LambdaNode) {
     todo!()
 }
 
 fn format_match_last_line_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _match_last_line_node: prism::MatchLastLineNode,
 ) {
     todo!()
 }
 
 fn format_match_predicate_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _match_predicate_node: prism::MatchPredicateNode,
 ) {
     todo!()
 }
 
 fn format_match_required_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _match_required_node: prism::MatchRequiredNode,
 ) {
     todo!()
 }
 
 fn format_match_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _match_write_node: prism::MatchWriteNode,
 ) {
     todo!()
 }
 
 fn format_multi_target_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _multi_target_node: prism::MultiTargetNode,
 ) {
     todo!()
 }
 
 fn format_multi_write_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _multi_write_node: prism::MultiWriteNode,
 ) {
     todo!()
 }
 
-fn format_next_node(ps: &mut BaseParserState, next_node: prism::NextNode) {
+fn format_next_node(ps: &mut ParserState, next_node: prism::NextNode) {
     ps.emit_ident("next".to_string());
     if let Some(arguments_node) = next_node.arguments() {
         ps.with_start_of_line(
@@ -2609,33 +2609,33 @@ fn format_next_node(ps: &mut BaseParserState, next_node: prism::NextNode) {
     }
 }
 
-fn format_nil_node(ps: &mut BaseParserState, _nil_node: prism::NilNode) {
+fn format_nil_node(ps: &mut ParserState, _nil_node: prism::NilNode) {
     ps.emit_ident("nil".to_string());
 }
 
 fn format_no_keywords_parameter_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _no_keywords_parameter_node: prism::NoKeywordsParameterNode,
 ) {
     todo!()
 }
 
 fn format_numbered_parameters_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _numbered_parameters_node: prism::NumberedParametersNode,
 ) {
     todo!()
 }
 
 fn format_numbered_reference_read_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _numbered_reference_read_node: prism::NumberedReferenceReadNode,
 ) {
     todo!()
 }
 
 fn format_optional_keyword_parameter_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     optional_keyword_parameter_node: prism::OptionalKeywordParameterNode,
 ) {
     ps.emit_ident(const_to_string(optional_keyword_parameter_node.name()));
@@ -2649,7 +2649,7 @@ fn format_optional_keyword_parameter_node(
 }
 
 fn format_optional_parameter_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     optional_parameter_node: prism::OptionalParameterNode,
 ) {
     ps.emit_ident(const_to_string(optional_parameter_node.name()));
@@ -2657,39 +2657,39 @@ fn format_optional_parameter_node(
     format_node(ps, optional_parameter_node.value());
 }
 
-fn format_or_node(_ps: &mut BaseParserState, _or_node: prism::OrNode) {
+fn format_or_node(_ps: &mut ParserState, _or_node: prism::OrNode) {
     todo!()
 }
 
 fn format_pinned_expression_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _pinned_expression_node: prism::PinnedExpressionNode,
 ) {
     todo!()
 }
 
 fn format_pinned_variable_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _pinned_variable_node: prism::PinnedVariableNode,
 ) {
     todo!()
 }
 
 fn format_post_execution_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _post_execution_node: prism::PostExecutionNode,
 ) {
     todo!()
 }
 
 fn format_pre_execution_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _pre_execution_node: prism::PreExecutionNode,
 ) {
     todo!()
 }
 
-fn format_range_node(ps: &mut BaseParserState, range_node: prism::RangeNode) {
+fn format_range_node(ps: &mut ParserState, range_node: prism::RangeNode) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -2704,16 +2704,16 @@ fn format_range_node(ps: &mut BaseParserState, range_node: prism::RangeNode) {
     );
 }
 
-fn format_rational_node(_ps: &mut BaseParserState, _rational_node: prism::RationalNode) {
+fn format_rational_node(_ps: &mut ParserState, _rational_node: prism::RationalNode) {
     todo!()
 }
 
-fn format_redo_node(ps: &mut BaseParserState) {
+fn format_redo_node(ps: &mut ParserState) {
     ps.emit_ident("redo".to_string());
 }
 
 fn format_regular_expression_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     regular_expression_node: prism::RegularExpressionNode,
 ) {
     ps.emit_ident(loc_to_string(regular_expression_node.opening_loc()));
@@ -2722,13 +2722,13 @@ fn format_regular_expression_node(
 }
 
 fn format_rescue_modifier_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _rescue_modifier_node: prism::RescueModifierNode,
 ) {
     todo!()
 }
 
-fn format_rescue_node(ps: &mut BaseParserState, rescue_node: prism::RescueNode) {
+fn format_rescue_node(ps: &mut ParserState, rescue_node: prism::RescueNode) {
     // Double check that these offsets are correct, since begin/rescue/ensure/else
     // aren't always handled with `format_node`, which usually handles this
     ps.at_offset(rescue_node.location().start_offset());
@@ -2781,11 +2781,11 @@ fn format_rescue_node(ps: &mut BaseParserState, rescue_node: prism::RescueNode) 
     ps.at_offset(rescue_node.location().end_offset());
 }
 
-fn format_retry_node(ps: &mut BaseParserState) {
+fn format_retry_node(ps: &mut ParserState) {
     ps.emit_keyword("retry".to_string());
 }
 
-fn format_return_node(ps: &mut BaseParserState, return_node: prism::ReturnNode) {
+fn format_return_node(ps: &mut ParserState, return_node: prism::ReturnNode) {
     ps.emit_ident("return".to_string());
     ps.with_start_of_line(
         false,
@@ -2809,21 +2809,21 @@ fn format_return_node(ps: &mut BaseParserState, return_node: prism::ReturnNode) 
 }
 
 fn format_shareable_constant_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _shareable_constant_node: prism::ShareableConstantNode,
 ) {
     todo!()
 }
 
 fn format_singleton_class_node(
-    _ps: &mut BaseParserState,
+    _ps: &mut ParserState,
     _singleton_class_node: prism::SingletonClassNode,
 ) {
     todo!()
 }
 
 fn format_source_encoding_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     source_encoding_node: prism::SourceEncodingNode,
 ) {
     handle_string_at_offset(
@@ -2834,7 +2834,7 @@ fn format_source_encoding_node(
 }
 
 fn format_source_file_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     source_file_node: prism::SourceFileNode,
 ) {
     handle_string_at_offset(
@@ -2845,7 +2845,7 @@ fn format_source_file_node(
 }
 
 fn format_source_line_node(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     source_line_node: prism::SourceLineNode,
 ) {
     handle_string_at_offset(
@@ -2855,31 +2855,31 @@ fn format_source_line_node(
     );
 }
 
-fn format_self_node(ps: &mut BaseParserState, _self_node: prism::SelfNode) {
+fn format_self_node(ps: &mut ParserState, _self_node: prism::SelfNode) {
     ps.emit_ident("self".to_string());
 }
 
-fn format_true_node(ps: &mut BaseParserState, true_node: prism::TrueNode) {
+fn format_true_node(ps: &mut ParserState, true_node: prism::TrueNode) {
     handle_string_at_offset(ps, "true".to_string(), true_node.location().start_offset());
 }
 
-fn format_undef_node(_ps: &mut BaseParserState, _undef_node: prism::UndefNode) {
+fn format_undef_node(_ps: &mut ParserState, _undef_node: prism::UndefNode) {
     todo!()
 }
 
-fn format_unless_node(_ps: &mut BaseParserState, _unless_node: prism::UnlessNode) {
+fn format_unless_node(_ps: &mut ParserState, _unless_node: prism::UnlessNode) {
     todo!()
 }
 
-fn format_until_node(_ps: &mut BaseParserState, _until_node: prism::UntilNode) {
+fn format_until_node(_ps: &mut ParserState, _until_node: prism::UntilNode) {
     todo!()
 }
 
-fn format_when_node(_ps: &mut BaseParserState, _when_node: prism::WhenNode) {
+fn format_when_node(_ps: &mut ParserState, _when_node: prism::WhenNode) {
     todo!()
 }
 
-fn format_while_node(ps: &mut BaseParserState, while_node: prism::WhileNode) {
+fn format_while_node(ps: &mut ParserState, while_node: prism::WhileNode) {
     ps.with_start_of_line(
         false,
         Box::new(|ps| {
@@ -2900,13 +2900,13 @@ fn format_while_node(ps: &mut BaseParserState, while_node: prism::WhileNode) {
     ps.emit_end();
 }
 
-fn format_x_string_node(ps: &mut BaseParserState, x_string_node: prism::XStringNode) {
+fn format_x_string_node(ps: &mut ParserState, x_string_node: prism::XStringNode) {
     ps.emit_ident("`".to_string());
     ps.emit_string_content(loc_to_string(x_string_node.content_loc()));
     ps.emit_ident("`".to_string());
 }
 
-fn format_yield_node(ps: &mut BaseParserState, yield_node: prism::YieldNode) {
+fn format_yield_node(ps: &mut ParserState, yield_node: prism::YieldNode) {
     ps.emit_ident("yield".to_string());
     if let Some(arguments) = yield_node.arguments() {
         let use_parens =
@@ -2926,7 +2926,7 @@ fn format_yield_node(ps: &mut BaseParserState, yield_node: prism::YieldNode) {
     }
 }
 
-fn handle_string_at_offset(ps: &mut BaseParserState, ident: String, offset: usize) {
+fn handle_string_at_offset(ps: &mut ParserState, ident: String, offset: usize) {
     ps.at_offset(offset);
     ps.emit_ident(ident);
 }
@@ -2948,7 +2948,7 @@ fn node_list_is_empty(node_list: &prism::NodeList) -> bool {
 }
 
 fn format_list_like_thing(
-    ps: &mut BaseParserState,
+    ps: &mut ParserState,
     node_list: prism::NodeList,
     end_offset: SourceOffset,
     single_line: bool,

--- a/librubyfmt/src/lib.rs
+++ b/librubyfmt/src/lib.rs
@@ -37,7 +37,7 @@ mod types;
 mod util;
 
 use file_comments::FileComments;
-use parser_state::BaseParserState;
+use parser_state::ParserState;
 use ruby_ops::{ParseError, Parser, RipperTree, load_rubyfmt};
 
 #[cfg(debug_assertions)]
@@ -224,7 +224,7 @@ pub fn toplevel_format_program<W: Write>(
     file_comments: FileComments,
     end_data: Option<&str>,
 ) -> Result<(), RichFormatError> {
-    let mut ps = BaseParserState::new(file_comments);
+    let mut ps = ParserState::new(file_comments);
     let v: ripper_tree_types::Program =
         de::from_value(tree).map_err(RichFormatError::RipperParseFailure)?;
 
@@ -242,7 +242,7 @@ pub fn toplevel_format_program_with_prism<W: Write>(
     source: &[u8],
     data: Option<ruby_prism::Location>,
 ) -> Result<(), RichFormatError> {
-    let mut ps = BaseParserState::new(FileComments::from_prism_comments(comments, source));
+    let mut ps = ParserState::new(FileComments::from_prism_comments(comments, source));
     ps.flush_start_of_file_comments();
 
     format_prism::format_program(&mut ps, tree.as_program_node().unwrap(), data);

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -12,7 +12,7 @@ use log::debug;
 use std::io::{self, Cursor, Write};
 use std::str;
 
-pub type RenderFunc<'a> = Box<dyn FnOnce(&mut BaseParserState) + 'a>;
+pub type RenderFunc<'a> = Box<dyn FnOnce(&mut ParserState) + 'a>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FormattingContext {
@@ -57,7 +57,7 @@ impl IndentDepth {
 }
 
 #[derive(Debug)]
-pub struct BaseParserState {
+pub struct ParserState {
     depth_stack: Vec<IndentDepth>,
     start_of_line: Vec<bool>,
     suppress_comments_stack: Vec<bool>,
@@ -74,7 +74,7 @@ pub struct BaseParserState {
     scopes: Vec<Vec<String>>,
 }
 
-impl BaseParserState {
+impl ParserState {
     pub(crate) fn scope_has_variable(&self, s: &str) -> bool {
         self.scopes
             .last()
@@ -94,9 +94,9 @@ impl BaseParserState {
         symbol: String,
         kind: HeredocKind,
         end_line: LineNumber,
-        formatting_func: Box<dyn FnOnce(&mut BaseParserState) + 'a>,
+        formatting_func: Box<dyn FnOnce(&mut ParserState) + 'a>,
     ) {
-        let mut next_ps = BaseParserState::render_with_blank_state(self, formatting_func);
+        let mut next_ps = ParserState::render_with_blank_state(self, formatting_func);
 
         for hs in next_ps.heredoc_strings.drain(0..) {
             self.heredoc_strings.push(hs);
@@ -169,7 +169,7 @@ impl BaseParserState {
     }
 
     pub(crate) fn will_render_as_multiline<'a>(&mut self, f: RenderFunc) -> bool {
-        let mut next_ps = BaseParserState::new_with_depth_stack_from(self);
+        let mut next_ps = ParserState::new_with_depth_stack_from(self);
         // Ignore commments when determining line length
         next_ps.with_suppress_comments(true, f);
         let data = next_ps.render_to_buffer();
@@ -442,7 +442,7 @@ impl BaseParserState {
         }
 
         self.on_line(self.current_orig_line_number + 1);
-        let should_iter = |ps: &BaseParserState, ln| {
+        let should_iter = |ps: &ParserState, ln| {
             // If we have a max line number, it will be the last token
             // of an expression (e.g. the `end` of a `do`/`end` block), so it's
             // fine if we wind forward to that line
@@ -736,9 +736,9 @@ impl BaseParserState {
     }
 }
 
-impl BaseParserState {
+impl ParserState {
     pub(crate) fn new(fc: FileComments) -> Self {
-        BaseParserState {
+        ParserState {
             depth_stack: vec![IndentDepth::new()],
             start_of_line: vec![true],
             suppress_comments_stack: vec![false],
@@ -825,16 +825,16 @@ impl BaseParserState {
         }
     }
 
-    pub(crate) fn new_with_depth_stack_from(ps: &BaseParserState) -> Self {
-        let mut next_ps = BaseParserState::new_with_reset_depth_stack(ps);
+    pub(crate) fn new_with_depth_stack_from(ps: &ParserState) -> Self {
+        let mut next_ps = ParserState::new_with_reset_depth_stack(ps);
         next_ps.depth_stack = ps.depth_stack.clone();
         next_ps
     }
 
     // Creates a copy of the parser state *with the depth_stack reset*.
     // This is used for heredocs, where we explicitly want to ignore current indentation.
-    pub(crate) fn new_with_reset_depth_stack(ps: &BaseParserState) -> Self {
-        let mut next_ps = BaseParserState::new(FileComments::default());
+    pub(crate) fn new_with_reset_depth_stack(ps: &ParserState) -> Self {
+        let mut next_ps = ParserState::new(FileComments::default());
         next_ps.comments_hash = ps.comments_hash.clone();
         next_ps.start_of_line = ps.start_of_line.clone();
         next_ps.current_orig_line_number = ps.current_orig_line_number;
@@ -929,11 +929,11 @@ impl BaseParserState {
         }
     }
 
-    pub(crate) fn render_with_blank_state<F>(ps: &mut BaseParserState, f: F) -> BaseParserState
+    pub(crate) fn render_with_blank_state<F>(ps: &mut ParserState, f: F) -> ParserState
     where
-        F: FnOnce(&mut BaseParserState),
+        F: FnOnce(&mut ParserState),
     {
-        let mut next_ps = BaseParserState::new_with_reset_depth_stack(ps);
+        let mut next_ps = ParserState::new_with_reset_depth_stack(ps);
         f(&mut next_ps);
         next_ps
     }

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -81,7 +81,7 @@ impl ParserState {
             .expect("it's never empty")
             .contains(&s.to_string())
     }
-    pub(crate) fn new_scope<'a>(&mut self, f: RenderFunc) {
+    pub(crate) fn new_scope(&mut self, f: RenderFunc) {
         self.scopes.push(vec![]);
         f(self);
         self.scopes.pop();
@@ -127,7 +127,7 @@ impl ParserState {
         self.push_concrete_token(ConcreteLineToken::HeredocClose { symbol });
     }
 
-    pub(crate) fn magic_handle_comments_for_multiline_arrays<'a>(
+    pub(crate) fn magic_handle_comments_for_multiline_arrays(
         &mut self,
         end_line: Option<LineNumber>,
         f: RenderFunc,
@@ -168,7 +168,7 @@ impl ParserState {
         }
     }
 
-    pub(crate) fn will_render_as_multiline<'a>(&mut self, f: RenderFunc) -> bool {
+    pub(crate) fn will_render_as_multiline(&mut self, f: RenderFunc) -> bool {
         let mut next_ps = ParserState::new_with_depth_stack_from(self);
         // Ignore commments when determining line length
         next_ps.with_suppress_comments(true, f);
@@ -191,7 +191,7 @@ impl ParserState {
         self.spaces_after_last_newline = self.current_spaces();
     }
 
-    pub(crate) fn dedent<'a>(&mut self, f: RenderFunc) {
+    pub(crate) fn dedent(&mut self, f: RenderFunc) {
         let ds_length = self.depth_stack.len();
         self.depth_stack[ds_length - 1].decrement();
         f(self);
@@ -216,13 +216,13 @@ impl ParserState {
         self.depth_stack[ds_length - 1].decrement();
     }
 
-    pub(crate) fn with_start_of_line<'a>(&mut self, start_of_line: bool, f: RenderFunc) {
+    pub(crate) fn with_start_of_line(&mut self, start_of_line: bool, f: RenderFunc) {
         self.start_of_line.push(start_of_line);
         f(self);
         self.start_of_line.pop();
     }
 
-    pub(crate) fn breakable_of<'a>(&mut self, delims: BreakableDelims, f: RenderFunc) {
+    pub(crate) fn breakable_of(&mut self, delims: BreakableDelims, f: RenderFunc) {
         self.shift_comments();
         let mut be = BreakableEntry::new(delims, self.formatting_context.clone());
         be.push_line_number(self.current_orig_line_number);
@@ -255,7 +255,7 @@ impl ParserState {
 
     /// A version of `breakable_of` for list-like things that use whitespace delimiters.
     /// At the moment, this is only for conditions in a `when` clause
-    pub(crate) fn inline_breakable_of<'a>(&mut self, delims: BreakableDelims, f: RenderFunc) {
+    pub(crate) fn inline_breakable_of(&mut self, delims: BreakableDelims, f: RenderFunc) {
         self.shift_comments();
         let mut be = BreakableEntry::new(delims, self.formatting_context.clone());
         be.push_line_number(self.current_orig_line_number);
@@ -280,7 +280,7 @@ impl ParserState {
         self.push_target(ConcreteLineTokenAndTargets::BreakableEntry(insert_be));
     }
 
-    pub(crate) fn breakable_call_chain_of<'a>(
+    pub(crate) fn breakable_call_chain_of(
         &mut self,
         mulitiline_handling: MultilineHandling,
         f: RenderFunc,
@@ -304,13 +304,13 @@ impl ParserState {
         ));
     }
 
-    pub(crate) fn with_suppress_comments<'a>(&mut self, suppress: bool, f: RenderFunc) {
+    pub(crate) fn with_suppress_comments(&mut self, suppress: bool, f: RenderFunc) {
         self.suppress_comments_stack.push(suppress);
         f(self);
         self.suppress_comments_stack.pop();
     }
 
-    pub(crate) fn with_absorbing_indent_block<'a>(&mut self, f: RenderFunc) {
+    pub(crate) fn with_absorbing_indent_block(&mut self, f: RenderFunc) {
         let was_absorbing = self.absorbing_indents != 0;
         self.absorbing_indents += 1;
         if was_absorbing {
@@ -321,14 +321,14 @@ impl ParserState {
         self.absorbing_indents -= 1;
     }
 
-    pub(crate) fn new_block<'a>(&mut self, f: RenderFunc) {
+    pub(crate) fn new_block(&mut self, f: RenderFunc) {
         let ds_length = self.depth_stack.len();
         self.depth_stack[ds_length - 1].increment();
         f(self);
         self.depth_stack[ds_length - 1].decrement();
     }
 
-    pub(crate) fn with_formatting_context<'a>(&mut self, fc: FormattingContext, f: RenderFunc) {
+    pub(crate) fn with_formatting_context(&mut self, fc: FormattingContext, f: RenderFunc) {
         self.formatting_context.push(fc);
         f(self);
         self.formatting_context.pop();

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -187,19 +187,6 @@ impl BaseParserState {
             .has_comment_in_offsets(start_offset, end_offset)
     }
 
-    pub(crate) fn will_render_beyond_max_line_length<'a>(&mut self, f: RenderFunc) -> bool {
-        let mut next_ps = BaseParserState::new_with_depth_stack_from(self);
-        // Ignore commments when determining line length
-        next_ps.with_suppress_comments(true, f);
-        let data = next_ps.render_to_buffer();
-
-        let s = str::from_utf8(&data).expect("string is utf8").to_string();
-
-        // Add current spaces to account for current indentation level
-        (s.split_whitespace().collect::<String>().len() + (self.current_spaces() as usize))
-            > MAX_LINE_LENGTH
-    }
-
     pub(crate) fn reset_space_count(&mut self) {
         self.spaces_after_last_newline = self.current_spaces();
     }
@@ -396,10 +383,6 @@ impl BaseParserState {
     pub(crate) fn has_comments_in_line(&self, start_line: LineNumber, end_line: LineNumber) -> bool {
         self.comments_hash
             .has_comments_in_lines(start_line, end_line)
-    }
-
-    pub(crate) fn current_line_number(&self) -> u64 {
-        self.current_orig_line_number
     }
 
     pub(crate) fn emit_def(&mut self, def_name: String) {

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -380,7 +380,11 @@ impl ParserState {
             .expect("start of line is never_empty")
     }
 
-    pub(crate) fn has_comments_in_line(&self, start_line: LineNumber, end_line: LineNumber) -> bool {
+    pub(crate) fn has_comments_in_line(
+        &self,
+        start_line: LineNumber,
+        end_line: LineNumber,
+    ) -> bool {
         self.comments_hash
             .has_comments_in_lines(start_line, end_line)
     }
@@ -818,7 +822,7 @@ impl ParserState {
         }
     }
 
-    pub (crate) fn index_of_prev_hard_newline(&self) -> Option<usize> {
+    pub(crate) fn index_of_prev_hard_newline(&self) -> Option<usize> {
         match self.breakable_entry_stack.last() {
             Some(be) => be.index_of_prev_newline(),
             None => self.render_queue.index_of_prev_newline(),
@@ -848,7 +852,7 @@ impl ParserState {
         bufio.into_inner()
     }
 
-    pub (crate) fn write<W: Write>(self, writer: &mut W) -> io::Result<()> {
+    pub(crate) fn write<W: Write>(self, writer: &mut W) -> io::Result<()> {
         let rqw = RenderQueueWriter::new(self.consume_to_render_queue());
         rqw.write(writer)
     }
@@ -868,7 +872,7 @@ impl ParserState {
         }
     }
 
-    pub (crate) fn flush_start_of_file_comments(&mut self) {
+    pub(crate) fn flush_start_of_file_comments(&mut self) {
         match self
             .comments_hash
             .take_start_of_file_contiguous_comment_lines()
@@ -887,7 +891,11 @@ impl ParserState {
         }
     }
 
-    pub(crate) fn insert_concrete_tokens(&mut self, insert_idx: usize, clts: Vec<ConcreteLineToken>) {
+    pub(crate) fn insert_concrete_tokens(
+        &mut self,
+        insert_idx: usize,
+        clts: Vec<ConcreteLineToken>,
+    ) {
         match self.breakable_entry_stack.last_mut() {
             Some(be) => be.insert_at(
                 insert_idx,

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -12,7 +12,7 @@ use log::debug;
 use std::io::{self, Cursor, Write};
 use std::str;
 
-pub type RenderFunc<'a> = Box<dyn FnOnce(&mut dyn ConcreteParserState) + 'a>;
+pub type RenderFunc<'a> = Box<dyn FnOnce(&mut BaseParserState) + 'a>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FormattingContext {

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -56,127 +56,6 @@ impl IndentDepth {
     }
 }
 
-pub trait ConcreteParserState
-where
-    Self: std::fmt::Debug,
-{
-    // token emitters
-    fn emit_conditional_keyword(&mut self, contents: String);
-    fn emit_mod_keyword(&mut self, contents: String);
-    fn emit_keyword(&mut self, kw: String);
-    fn emit_def_keyword(&mut self);
-    fn emit_end_block(&mut self);
-    fn emit_colon_colon(&mut self);
-    fn emit_lonely_operator(&mut self);
-    fn emit_dot(&mut self);
-    fn emit_ellipsis(&mut self);
-    fn emit_else(&mut self);
-    fn emit_begin_block(&mut self);
-    fn emit_begin(&mut self);
-    fn emit_ensure(&mut self);
-    fn emit_module_keyword(&mut self);
-    fn emit_class_keyword(&mut self);
-    fn emit_do_keyword(&mut self);
-    fn emit_when_keyword(&mut self);
-    fn emit_case_keyword(&mut self);
-    fn emit_rescue(&mut self);
-    fn emit_open_square_bracket(&mut self);
-    fn emit_close_square_bracket(&mut self);
-    fn emit_open_curly_bracket(&mut self);
-    fn emit_close_curly_bracket(&mut self);
-    fn emit_slash(&mut self);
-    fn emit_close_paren(&mut self);
-    fn emit_comma_space(&mut self);
-    fn emit_open_paren(&mut self);
-    fn emit_space(&mut self);
-    fn emit_comma(&mut self);
-    fn emit_end(&mut self);
-    fn emit_newline(&mut self);
-    fn emit_ident(&mut self, ident: String);
-    fn emit_string_content(&mut self, s: String);
-    fn emit_double_quote(&mut self);
-    fn emit_op(&mut self, op: String);
-    fn emit_def(&mut self, def_name: String);
-    fn emit_indent(&mut self);
-    fn emit_heredoc_start(&mut self, symbol: String, kind: HeredocKind);
-    fn emit_heredoc_close(&mut self, symbol: String);
-    fn emit_after_call_chain(&mut self);
-    fn emit_data_end(&mut self);
-    fn emit_data(&mut self, data: &str);
-    fn emit_single_line_delims(&mut self, delims: BreakableDelims);
-
-    // other state changers
-    fn bind_variable(&mut self, s: String);
-    fn scope_has_variable(&self, s: &str) -> bool;
-    fn insert_comment_collection(&mut self, comments: CommentBlock);
-    fn on_line(&mut self, line_number: LineNumber);
-    fn at_offset(&mut self, source_offset: SourceOffset);
-    fn wind_dumping_comments_until_line(&mut self, line_number: LineNumber);
-    fn wind_dumping_comments_until_offset(&mut self, source_offset: SourceOffset);
-    fn wind_dumping_comments(&mut self, maybe_max_line_number: Option<LineNumber>);
-    fn shift_comments(&mut self);
-    fn shift_comments_at_index(&mut self, index: usize);
-    fn wind_line_forward(&mut self);
-    fn render_heredocs(&mut self, skip: bool);
-    fn push_heredoc_content<'a>(
-        &mut self,
-        symbol: String,
-        kind: HeredocKind,
-        end_line: LineNumber,
-        formatting_func: Box<dyn FnOnce(&mut BaseParserState) + 'a>,
-    );
-
-    // queries
-    fn at_start_of_line(&self) -> bool;
-    fn current_formatting_context_requires_parens(&self) -> bool;
-    fn hash_type_from_formatting_context(&self) -> Option<&HashType>;
-    fn current_formatting_context(&self) -> FormattingContext;
-    fn get_line_number_for_offset(&self, source_offset: SourceOffset) -> LineNumber;
-    fn is_absorbing_indents(&self) -> bool;
-    fn has_comments_in_line(&self, start_line: LineNumber, end_line: LineNumber) -> bool;
-
-    #[allow(unused)]
-    fn current_line_number(&self) -> u64;
-
-    // blocks
-    #[allow(unused)]
-    fn start_indent(&mut self);
-    fn start_indent_for_call_chain(&mut self);
-    fn end_indent_for_call_chain(&mut self);
-    #[allow(unused)]
-    fn end_indent(&mut self);
-    fn with_formatting_context(&mut self, fc: FormattingContext, f: RenderFunc);
-    fn new_scope(&mut self, f: RenderFunc);
-    fn new_block(&mut self, f: RenderFunc);
-    fn with_start_of_line(&mut self, start_of_line: bool, f: RenderFunc);
-    fn breakable_of(&mut self, delims: BreakableDelims, f: RenderFunc);
-    fn inline_breakable_of(&mut self, delims: BreakableDelims, f: RenderFunc);
-    fn breakable_call_chain_of(&mut self, multiline_handling: MultilineHandling, f: RenderFunc);
-    fn dedent(&mut self, f: RenderFunc);
-    fn reset_space_count(&mut self);
-    fn with_absorbing_indent_block(&mut self, f: RenderFunc);
-    fn magic_handle_comments_for_multiline_arrays(
-        &mut self,
-        end_line: Option<LineNumber>,
-        f: RenderFunc,
-    );
-    fn with_suppress_comments(&mut self, suppress: bool, f: RenderFunc);
-    fn will_render_as_multiline(&mut self, f: RenderFunc) -> bool;
-    fn has_comment_in_offset_span(
-        &self,
-        start_offset: SourceOffset,
-        end_offset: SourceOffset,
-    ) -> bool;
-
-    #[allow(unused)]
-    fn will_render_beyond_max_line_length(&mut self, f: RenderFunc) -> bool;
-
-    // stuff to remove from this enum
-    fn emit_soft_newline(&mut self);
-    fn emit_soft_indent(&mut self);
-    fn emit_collapsing_newline(&mut self);
-}
-
 #[derive(Debug)]
 pub struct BaseParserState {
     depth_stack: Vec<IndentDepth>,
@@ -195,22 +74,22 @@ pub struct BaseParserState {
     scopes: Vec<Vec<String>>,
 }
 
-impl ConcreteParserState for BaseParserState {
-    fn scope_has_variable(&self, s: &str) -> bool {
+impl BaseParserState {
+    pub(crate) fn scope_has_variable(&self, s: &str) -> bool {
         self.scopes
             .last()
             .expect("it's never empty")
             .contains(&s.to_string())
     }
-    fn new_scope<'a>(&mut self, f: RenderFunc) {
+    pub(crate) fn new_scope<'a>(&mut self, f: RenderFunc) {
         self.scopes.push(vec![]);
         f(self);
         self.scopes.pop();
     }
-    fn bind_variable(&mut self, s: String) {
+    pub(crate) fn bind_variable(&mut self, s: String) {
         self.scopes.last_mut().expect("it's never empty").push(s);
     }
-    fn push_heredoc_content<'a>(
+    pub(crate) fn push_heredoc_content<'a>(
         &mut self,
         symbol: String,
         kind: HeredocKind,
@@ -240,15 +119,15 @@ impl ConcreteParserState for BaseParserState {
         ));
     }
 
-    fn emit_heredoc_start(&mut self, symbol: String, kind: HeredocKind) {
+    pub(crate) fn emit_heredoc_start(&mut self, symbol: String, kind: HeredocKind) {
         self.push_concrete_token(ConcreteLineToken::HeredocStart { kind, symbol });
     }
 
-    fn emit_heredoc_close(&mut self, symbol: String) {
+    pub(crate) fn emit_heredoc_close(&mut self, symbol: String) {
         self.push_concrete_token(ConcreteLineToken::HeredocClose { symbol });
     }
 
-    fn magic_handle_comments_for_multiline_arrays<'a>(
+    pub(crate) fn magic_handle_comments_for_multiline_arrays<'a>(
         &mut self,
         end_line: Option<LineNumber>,
         f: RenderFunc,
@@ -289,7 +168,7 @@ impl ConcreteParserState for BaseParserState {
         }
     }
 
-    fn will_render_as_multiline<'a>(&mut self, f: RenderFunc) -> bool {
+    pub(crate) fn will_render_as_multiline<'a>(&mut self, f: RenderFunc) -> bool {
         let mut next_ps = BaseParserState::new_with_depth_stack_from(self);
         // Ignore commments when determining line length
         next_ps.with_suppress_comments(true, f);
@@ -299,7 +178,7 @@ impl ConcreteParserState for BaseParserState {
         s.trim().contains('\n') || s.len() > MAX_LINE_LENGTH
     }
 
-    fn has_comment_in_offset_span(
+    pub(crate) fn has_comment_in_offset_span(
         &self,
         start_offset: SourceOffset,
         end_offset: SourceOffset,
@@ -308,7 +187,7 @@ impl ConcreteParserState for BaseParserState {
             .has_comment_in_offsets(start_offset, end_offset)
     }
 
-    fn will_render_beyond_max_line_length<'a>(&mut self, f: RenderFunc) -> bool {
+    pub(crate) fn will_render_beyond_max_line_length<'a>(&mut self, f: RenderFunc) -> bool {
         let mut next_ps = BaseParserState::new_with_depth_stack_from(self);
         // Ignore commments when determining line length
         next_ps.with_suppress_comments(true, f);
@@ -321,42 +200,42 @@ impl ConcreteParserState for BaseParserState {
             > MAX_LINE_LENGTH
     }
 
-    fn reset_space_count(&mut self) {
+    pub(crate) fn reset_space_count(&mut self) {
         self.spaces_after_last_newline = self.current_spaces();
     }
 
-    fn dedent<'a>(&mut self, f: RenderFunc) {
+    pub(crate) fn dedent<'a>(&mut self, f: RenderFunc) {
         let ds_length = self.depth_stack.len();
         self.depth_stack[ds_length - 1].decrement();
         f(self);
         self.depth_stack[ds_length - 1].increment();
     }
 
-    fn start_indent(&mut self) {
+    pub(crate) fn start_indent(&mut self) {
         let ds_length = self.depth_stack.len();
         self.depth_stack[ds_length - 1].increment();
     }
 
-    fn start_indent_for_call_chain(&mut self) {
+    pub(crate) fn start_indent_for_call_chain(&mut self) {
         self.push_concrete_token(ConcreteLineToken::BeginCallChainIndent)
     }
 
-    fn end_indent_for_call_chain(&mut self) {
+    pub(crate) fn end_indent_for_call_chain(&mut self) {
         self.push_concrete_token(ConcreteLineToken::EndCallChainIndent)
     }
 
-    fn end_indent(&mut self) {
+    pub(crate) fn end_indent(&mut self) {
         let ds_length = self.depth_stack.len();
         self.depth_stack[ds_length - 1].decrement();
     }
 
-    fn with_start_of_line<'a>(&mut self, start_of_line: bool, f: RenderFunc) {
+    pub(crate) fn with_start_of_line<'a>(&mut self, start_of_line: bool, f: RenderFunc) {
         self.start_of_line.push(start_of_line);
         f(self);
         self.start_of_line.pop();
     }
 
-    fn breakable_of<'a>(&mut self, delims: BreakableDelims, f: RenderFunc) {
+    pub(crate) fn breakable_of<'a>(&mut self, delims: BreakableDelims, f: RenderFunc) {
         self.shift_comments();
         let mut be = BreakableEntry::new(delims, self.formatting_context.clone());
         be.push_line_number(self.current_orig_line_number);
@@ -389,7 +268,7 @@ impl ConcreteParserState for BaseParserState {
 
     /// A version of `breakable_of` for list-like things that use whitespace delimiters.
     /// At the moment, this is only for conditions in a `when` clause
-    fn inline_breakable_of<'a>(&mut self, delims: BreakableDelims, f: RenderFunc) {
+    pub(crate) fn inline_breakable_of<'a>(&mut self, delims: BreakableDelims, f: RenderFunc) {
         self.shift_comments();
         let mut be = BreakableEntry::new(delims, self.formatting_context.clone());
         be.push_line_number(self.current_orig_line_number);
@@ -414,7 +293,7 @@ impl ConcreteParserState for BaseParserState {
         self.push_target(ConcreteLineTokenAndTargets::BreakableEntry(insert_be));
     }
 
-    fn breakable_call_chain_of<'a>(
+    pub(crate) fn breakable_call_chain_of<'a>(
         &mut self,
         mulitiline_handling: MultilineHandling,
         f: RenderFunc,
@@ -438,13 +317,13 @@ impl ConcreteParserState for BaseParserState {
         ));
     }
 
-    fn with_suppress_comments<'a>(&mut self, suppress: bool, f: RenderFunc) {
+    pub(crate) fn with_suppress_comments<'a>(&mut self, suppress: bool, f: RenderFunc) {
         self.suppress_comments_stack.push(suppress);
         f(self);
         self.suppress_comments_stack.pop();
     }
 
-    fn with_absorbing_indent_block<'a>(&mut self, f: RenderFunc) {
+    pub(crate) fn with_absorbing_indent_block<'a>(&mut self, f: RenderFunc) {
         let was_absorbing = self.absorbing_indents != 0;
         self.absorbing_indents += 1;
         if was_absorbing {
@@ -455,20 +334,20 @@ impl ConcreteParserState for BaseParserState {
         self.absorbing_indents -= 1;
     }
 
-    fn new_block<'a>(&mut self, f: RenderFunc) {
+    pub(crate) fn new_block<'a>(&mut self, f: RenderFunc) {
         let ds_length = self.depth_stack.len();
         self.depth_stack[ds_length - 1].increment();
         f(self);
         self.depth_stack[ds_length - 1].decrement();
     }
 
-    fn with_formatting_context<'a>(&mut self, fc: FormattingContext, f: RenderFunc) {
+    pub(crate) fn with_formatting_context<'a>(&mut self, fc: FormattingContext, f: RenderFunc) {
         self.formatting_context.push(fc);
         f(self);
         self.formatting_context.pop();
     }
 
-    fn on_line(&mut self, line_number: LineNumber) {
+    pub(crate) fn on_line(&mut self, line_number: LineNumber) {
         if line_number < self.current_orig_line_number {
             return;
         }
@@ -497,79 +376,79 @@ impl ConcreteParserState for BaseParserState {
         self.current_orig_line_number = line_number;
     }
 
-    fn at_offset(&mut self, source_offset: SourceOffset) {
+    pub(crate) fn at_offset(&mut self, source_offset: SourceOffset) {
         self.on_line(self.get_line_number_for_offset(source_offset));
     }
 
-    fn emit_indent(&mut self) {
+    pub(crate) fn emit_indent(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Indent {
             depth: self.current_spaces(),
         });
     }
 
-    fn at_start_of_line(&self) -> bool {
+    pub(crate) fn at_start_of_line(&self) -> bool {
         *self
             .start_of_line
             .last()
             .expect("start of line is never_empty")
     }
 
-    fn has_comments_in_line(&self, start_line: LineNumber, end_line: LineNumber) -> bool {
+    pub(crate) fn has_comments_in_line(&self, start_line: LineNumber, end_line: LineNumber) -> bool {
         self.comments_hash
             .has_comments_in_lines(start_line, end_line)
     }
 
-    fn current_line_number(&self) -> u64 {
+    pub(crate) fn current_line_number(&self) -> u64 {
         self.current_orig_line_number
     }
 
-    fn emit_def(&mut self, def_name: String) {
+    pub(crate) fn emit_def(&mut self, def_name: String) {
         self.emit_def_keyword();
         self.push_concrete_token(ConcreteLineToken::DirectPart {
             part: format!(" {}", def_name),
         });
     }
 
-    fn insert_comment_collection(&mut self, comments: CommentBlock) {
+    pub(crate) fn insert_comment_collection(&mut self, comments: CommentBlock) {
         self.comments_to_insert
             .merge(comments.apply_spaces(self.spaces_after_last_newline));
     }
 
-    fn emit_op(&mut self, op: String) {
+    pub(crate) fn emit_op(&mut self, op: String) {
         self.push_concrete_token(ConcreteLineToken::Op { op });
     }
 
-    fn emit_double_quote(&mut self) {
+    pub(crate) fn emit_double_quote(&mut self) {
         self.push_concrete_token(ConcreteLineToken::DoubleQuote);
     }
 
-    fn emit_string_content(&mut self, s: String) {
+    pub(crate) fn emit_string_content(&mut self, s: String) {
         let newline_count = s.matches('\n').count() as u64;
         self.current_orig_line_number += newline_count;
 
         self.push_concrete_token(ConcreteLineToken::LTStringContent { content: s });
     }
 
-    fn emit_ident(&mut self, ident: String) {
+    pub(crate) fn emit_ident(&mut self, ident: String) {
         self.push_concrete_token(ConcreteLineToken::DirectPart { part: ident });
     }
 
-    fn emit_newline(&mut self) {
+    pub(crate) fn emit_newline(&mut self) {
         self.shift_comments();
         self.push_concrete_token(ConcreteLineToken::HardNewLine);
         self.render_heredocs(false);
         self.spaces_after_last_newline = self.current_spaces();
     }
 
-    fn wind_dumping_comments_until_line(&mut self, line_number: LineNumber) {
+    pub(crate) fn wind_dumping_comments_until_line(&mut self, line_number: LineNumber) {
         self.wind_dumping_comments(Some(line_number))
     }
 
-    fn wind_dumping_comments_until_offset(&mut self, source_offset: SourceOffset) {
+    pub(crate) fn wind_dumping_comments_until_offset(&mut self, source_offset: SourceOffset) {
         self.wind_dumping_comments_until_line(self.get_line_number_for_offset(source_offset))
     }
 
-    fn wind_dumping_comments(&mut self, maybe_max_line_number: Option<LineNumber>) {
+    pub(crate) fn wind_dumping_comments(&mut self, maybe_max_line_number: Option<LineNumber>) {
         // Return early if we're already at/past
         // the max line number
         if maybe_max_line_number
@@ -616,7 +495,7 @@ impl ConcreteParserState for BaseParserState {
         }
     }
 
-    fn emit_end(&mut self) {
+    pub(crate) fn emit_end(&mut self) {
         if !self.last_token_is_a_newline() {
             self.emit_newline();
         }
@@ -626,22 +505,22 @@ impl ConcreteParserState for BaseParserState {
         self.push_concrete_token(ConcreteLineToken::End);
     }
 
-    fn emit_comma(&mut self) {
+    pub(crate) fn emit_comma(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Comma);
     }
 
-    fn shift_comments(&mut self) {
+    pub(crate) fn shift_comments(&mut self) {
         let idx_of_prev_hard_newline = self.index_of_prev_hard_newline();
         self.shift_comments_at_index(idx_of_prev_hard_newline.unwrap_or(0));
     }
 
-    fn shift_comments_at_index(&mut self, index: usize) {
+    pub(crate) fn shift_comments_at_index(&mut self, index: usize) {
         if let Some(new_comments) = self.comments_to_insert.take() {
             self.insert_concrete_tokens(index, new_comments.into_line_tokens());
         }
     }
 
-    fn emit_soft_newline(&mut self) {
+    pub(crate) fn emit_soft_newline(&mut self) {
         self.new_block(Box::new(|ps| {
             ps.shift_comments();
         }));
@@ -650,13 +529,13 @@ impl ConcreteParserState for BaseParserState {
         self.spaces_after_last_newline = self.current_spaces();
     }
 
-    fn emit_soft_indent(&mut self) {
+    pub(crate) fn emit_soft_indent(&mut self) {
         self.push_abstract_token(AbstractLineToken::SoftIndent {
             depth: self.current_spaces(),
         });
     }
 
-    fn emit_collapsing_newline(&mut self) {
+    pub(crate) fn emit_collapsing_newline(&mut self) {
         if !self.last_token_is_a_newline() {
             let hd = self.gather_heredocs();
             self.push_abstract_token(AbstractLineToken::CollapsingNewLine(hd));
@@ -664,123 +543,123 @@ impl ConcreteParserState for BaseParserState {
         self.spaces_after_last_newline = self.current_spaces();
     }
 
-    fn emit_after_call_chain(&mut self) {
+    pub(crate) fn emit_after_call_chain(&mut self) {
         self.push_concrete_token(ConcreteLineToken::AfterCallChain)
     }
 
-    fn emit_space(&mut self) {
+    pub(crate) fn emit_space(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Space);
     }
 
-    fn emit_open_paren(&mut self) {
+    pub(crate) fn emit_open_paren(&mut self) {
         self.push_concrete_token(ConcreteLineToken::OpenParen);
     }
 
-    fn emit_single_line_delims(&mut self, delims: BreakableDelims) {
+    pub(crate) fn emit_single_line_delims(&mut self, delims: BreakableDelims) {
         self.push_concrete_token(delims.single_line_open());
         self.push_concrete_token(delims.single_line_close());
     }
 
-    fn emit_comma_space(&mut self) {
+    pub(crate) fn emit_comma_space(&mut self) {
         self.push_concrete_token(ConcreteLineToken::CommaSpace)
     }
 
-    fn emit_close_paren(&mut self) {
+    pub(crate) fn emit_close_paren(&mut self) {
         self.push_concrete_token(ConcreteLineToken::CloseParen);
     }
 
-    fn emit_slash(&mut self) {
+    pub(crate) fn emit_slash(&mut self) {
         self.push_concrete_token(ConcreteLineToken::SingleSlash);
     }
 
-    fn emit_close_curly_bracket(&mut self) {
+    pub(crate) fn emit_close_curly_bracket(&mut self) {
         self.push_concrete_token(ConcreteLineToken::CloseCurlyBracket);
     }
 
-    fn emit_open_curly_bracket(&mut self) {
+    pub(crate) fn emit_open_curly_bracket(&mut self) {
         self.push_concrete_token(ConcreteLineToken::OpenCurlyBracket);
     }
 
-    fn emit_close_square_bracket(&mut self) {
+    pub(crate) fn emit_close_square_bracket(&mut self) {
         self.push_concrete_token(ConcreteLineToken::CloseSquareBracket);
     }
 
-    fn emit_open_square_bracket(&mut self) {
+    pub(crate) fn emit_open_square_bracket(&mut self) {
         self.push_concrete_token(ConcreteLineToken::OpenSquareBracket);
     }
 
-    fn emit_rescue(&mut self) {
+    pub(crate) fn emit_rescue(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Keyword {
             keyword: "rescue".to_string(),
         });
     }
 
-    fn emit_case_keyword(&mut self) {
+    pub(crate) fn emit_case_keyword(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Keyword {
             keyword: "case".to_string(),
         });
     }
 
-    fn emit_when_keyword(&mut self) {
+    pub(crate) fn emit_when_keyword(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Keyword {
             keyword: "when".to_string(),
         });
     }
 
-    fn emit_do_keyword(&mut self) {
+    pub(crate) fn emit_do_keyword(&mut self) {
         self.push_concrete_token(ConcreteLineToken::DoKeyword);
     }
 
-    fn emit_class_keyword(&mut self) {
+    pub(crate) fn emit_class_keyword(&mut self) {
         self.push_concrete_token(ConcreteLineToken::ClassKeyword);
     }
 
-    fn emit_module_keyword(&mut self) {
+    pub(crate) fn emit_module_keyword(&mut self) {
         self.push_concrete_token(ConcreteLineToken::ModuleKeyword);
     }
 
-    fn emit_ensure(&mut self) {
+    pub(crate) fn emit_ensure(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Keyword {
             keyword: "ensure".to_string(),
         });
     }
 
-    fn emit_begin(&mut self) {
+    pub(crate) fn emit_begin(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Keyword {
             keyword: "begin".to_string(),
         });
     }
 
-    fn emit_begin_block(&mut self) {
+    pub(crate) fn emit_begin_block(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Keyword {
             keyword: "BEGIN".to_string(),
         });
     }
 
-    fn emit_else(&mut self) {
+    pub(crate) fn emit_else(&mut self) {
         self.emit_conditional_keyword("else".to_string());
     }
 
-    fn emit_data_end(&mut self) {
+    pub(crate) fn emit_data_end(&mut self) {
         self.push_concrete_token(ConcreteLineToken::DataEnd);
     }
 
-    fn emit_data(&mut self, data: &str) {
+    pub(crate) fn emit_data(&mut self, data: &str) {
         self.push_concrete_token(ConcreteLineToken::DirectPart {
             part: data.to_string(),
         })
     }
 
-    fn wind_line_forward(&mut self) {
+    pub(crate) fn wind_line_forward(&mut self) {
         self.on_line(self.current_orig_line_number + 1);
     }
 
-    fn current_formatting_context_requires_parens(&self) -> bool {
+    pub(crate) fn current_formatting_context_requires_parens(&self) -> bool {
         self.current_formatting_context() == FormattingContext::Binary
             || self.current_formatting_context() == FormattingContext::IfOp
     }
 
-    fn hash_type_from_formatting_context(&self) -> Option<&HashType> {
+    pub(crate) fn hash_type_from_formatting_context(&self) -> Option<&HashType> {
         self.formatting_context
             .iter()
             .filter_map(|fc| match fc {
@@ -790,40 +669,40 @@ impl ConcreteParserState for BaseParserState {
             .last()
     }
 
-    fn emit_dot(&mut self) {
+    pub(crate) fn emit_dot(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Dot);
     }
 
-    fn emit_ellipsis(&mut self) {
+    pub(crate) fn emit_ellipsis(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Ellipsis)
     }
 
-    fn emit_lonely_operator(&mut self) {
+    pub(crate) fn emit_lonely_operator(&mut self) {
         self.push_concrete_token(ConcreteLineToken::LonelyOperator);
     }
 
-    fn emit_colon_colon(&mut self) {
+    pub(crate) fn emit_colon_colon(&mut self) {
         self.push_concrete_token(ConcreteLineToken::ColonColon);
     }
 
-    fn current_formatting_context(&self) -> FormattingContext {
+    pub(crate) fn current_formatting_context(&self) -> FormattingContext {
         *self
             .formatting_context
             .last()
             .expect("formatting context is never empty")
     }
 
-    fn get_line_number_for_offset(&self, source_offset: SourceOffset) -> LineNumber {
+    pub(crate) fn get_line_number_for_offset(&self, source_offset: SourceOffset) -> LineNumber {
         self.comments_hash.get_line_number_for_offset(source_offset)
     }
 
-    fn emit_end_block(&mut self) {
+    pub(crate) fn emit_end_block(&mut self) {
         self.push_concrete_token(ConcreteLineToken::Keyword {
             keyword: "END".to_string(),
         });
     }
 
-    fn render_heredocs(&mut self, skip: bool) {
+    pub(crate) fn render_heredocs(&mut self, skip: bool) {
         while let Some(next_heredoc) = self.heredoc_strings.pop() {
             let want_newline = !self.last_token_is_a_newline();
             if want_newline {
@@ -853,29 +732,29 @@ impl ConcreteParserState for BaseParserState {
         }
     }
 
-    fn is_absorbing_indents(&self) -> bool {
+    pub(crate) fn is_absorbing_indents(&self) -> bool {
         self.absorbing_indents >= 1
     }
 
-    fn emit_def_keyword(&mut self) {
+    pub(crate) fn emit_def_keyword(&mut self) {
         self.push_concrete_token(ConcreteLineToken::DefKeyword);
     }
 
-    fn emit_keyword(&mut self, kw: String) {
+    pub(crate) fn emit_keyword(&mut self, kw: String) {
         self.push_concrete_token(ConcreteLineToken::Keyword { keyword: kw });
     }
 
-    fn emit_mod_keyword(&mut self, contents: String) {
+    pub(crate) fn emit_mod_keyword(&mut self, contents: String) {
         self.push_concrete_token(ConcreteLineToken::ModKeyword { contents });
     }
 
-    fn emit_conditional_keyword(&mut self, contents: String) {
+    pub(crate) fn emit_conditional_keyword(&mut self, contents: String) {
         self.push_concrete_token(ConcreteLineToken::ConditionalKeyword { contents });
     }
 }
 
 impl BaseParserState {
-    pub fn new(fc: FileComments) -> Self {
+    pub(crate) fn new(fc: FileComments) -> Self {
         BaseParserState {
             depth_stack: vec![IndentDepth::new()],
             start_of_line: vec![true],
@@ -894,11 +773,11 @@ impl BaseParserState {
         }
     }
 
-    fn consume_to_render_queue(self) -> Vec<ConcreteLineTokenAndTargets> {
+    pub(crate) fn consume_to_render_queue(self) -> Vec<ConcreteLineTokenAndTargets> {
         self.render_queue.into_tokens()
     }
 
-    fn gather_heredocs(&mut self) -> Option<Vec<HeredocString>> {
+    pub(crate) fn gather_heredocs(&mut self) -> Option<Vec<HeredocString>> {
         if self.heredoc_strings.is_empty() {
             None
         } else {
@@ -906,7 +785,7 @@ impl BaseParserState {
         }
     }
 
-    fn push_comments(&mut self, comments: CommentBlock) {
+    pub(crate) fn push_comments(&mut self, comments: CommentBlock) {
         if !self
             .suppress_comments_stack
             .last()
@@ -921,7 +800,7 @@ impl BaseParserState {
         }
     }
 
-    fn insert_extra_newline_at_last_newline(&mut self) {
+    pub(crate) fn insert_extra_newline_at_last_newline(&mut self) {
         let idx = self.index_of_prev_hard_newline();
         let insert_idx = idx.unwrap_or(0);
 
@@ -937,7 +816,7 @@ impl BaseParserState {
         }
     }
 
-    fn current_spaces(&self) -> ColNumber {
+    pub(crate) fn current_spaces(&self) -> ColNumber {
         2 * self
             .depth_stack
             .last()
@@ -945,25 +824,25 @@ impl BaseParserState {
             .get()
     }
 
-    pub fn disable_user_newlines(&mut self) {
+    pub(crate) fn disable_user_newlines(&mut self) {
         self.insert_user_newlines = false;
     }
 
-    fn last_token_is_a_newline(&self) -> bool {
+    pub(crate) fn last_token_is_a_newline(&self) -> bool {
         match self.breakable_entry_stack.last() {
             Some(be) => be.last_token_is_a_newline(),
             None => self.render_queue.last_token_is_a_newline(),
         }
     }
 
-    pub fn index_of_prev_hard_newline(&self) -> Option<usize> {
+    pub (crate) fn index_of_prev_hard_newline(&self) -> Option<usize> {
         match self.breakable_entry_stack.last() {
             Some(be) => be.index_of_prev_newline(),
             None => self.render_queue.index_of_prev_newline(),
         }
     }
 
-    fn new_with_depth_stack_from(ps: &BaseParserState) -> Self {
+    pub(crate) fn new_with_depth_stack_from(ps: &BaseParserState) -> Self {
         let mut next_ps = BaseParserState::new_with_reset_depth_stack(ps);
         next_ps.depth_stack = ps.depth_stack.clone();
         next_ps
@@ -971,7 +850,7 @@ impl BaseParserState {
 
     // Creates a copy of the parser state *with the depth_stack reset*.
     // This is used for heredocs, where we explicitly want to ignore current indentation.
-    fn new_with_reset_depth_stack(ps: &BaseParserState) -> Self {
+    pub(crate) fn new_with_reset_depth_stack(ps: &BaseParserState) -> Self {
         let mut next_ps = BaseParserState::new(FileComments::default());
         next_ps.comments_hash = ps.comments_hash.clone();
         next_ps.start_of_line = ps.start_of_line.clone();
@@ -979,19 +858,19 @@ impl BaseParserState {
         next_ps
     }
 
-    fn render_to_buffer(self) -> Vec<u8> {
+    pub(crate) fn render_to_buffer(self) -> Vec<u8> {
         let mut bufio = Cursor::new(Vec::new());
         self.write(&mut bufio).expect("in memory io cannot fail");
         bufio.set_position(0);
         bufio.into_inner()
     }
 
-    pub fn write<W: Write>(self, writer: &mut W) -> io::Result<()> {
+    pub (crate) fn write<W: Write>(self, writer: &mut W) -> io::Result<()> {
         let rqw = RenderQueueWriter::new(self.consume_to_render_queue());
         rqw.write(writer)
     }
 
-    fn dangerously_convert(t: AbstractLineToken) -> ConcreteLineTokenAndTargets {
+    pub(crate) fn dangerously_convert(t: AbstractLineToken) -> ConcreteLineTokenAndTargets {
         match t {
             AbstractLineToken::ConcreteLineToken(clt) => {
                 ConcreteLineTokenAndTargets::ConcreteLineToken(clt)
@@ -1006,7 +885,7 @@ impl BaseParserState {
         }
     }
 
-    pub fn flush_start_of_file_comments(&mut self) {
+    pub (crate) fn flush_start_of_file_comments(&mut self) {
         match self
             .comments_hash
             .take_start_of_file_contiguous_comment_lines()
@@ -1025,7 +904,7 @@ impl BaseParserState {
         }
     }
 
-    fn insert_concrete_tokens(&mut self, insert_idx: usize, clts: Vec<ConcreteLineToken>) {
+    pub(crate) fn insert_concrete_tokens(&mut self, insert_idx: usize, clts: Vec<ConcreteLineToken>) {
         match self.breakable_entry_stack.last_mut() {
             Some(be) => be.insert_at(
                 insert_idx,
@@ -1044,7 +923,7 @@ impl BaseParserState {
         }
     }
 
-    fn push_concrete_token(&mut self, t: ConcreteLineToken) {
+    pub(crate) fn push_concrete_token(&mut self, t: ConcreteLineToken) {
         match self.breakable_entry_stack.last_mut() {
             Some(be) => be.push(AbstractLineToken::ConcreteLineToken(t)),
             None => self
@@ -1053,21 +932,21 @@ impl BaseParserState {
         }
     }
 
-    fn push_target(&mut self, t: ConcreteLineTokenAndTargets) {
+    pub(crate) fn push_target(&mut self, t: ConcreteLineTokenAndTargets) {
         match self.breakable_entry_stack.last_mut() {
             Some(be) => be.push(t.into()),
             None => self.render_queue.push(t),
         }
     }
 
-    fn push_abstract_token(&mut self, t: AbstractLineToken) {
+    pub(crate) fn push_abstract_token(&mut self, t: AbstractLineToken) {
         match self.breakable_entry_stack.last_mut() {
             Some(be) => be.push(t),
             None => self.render_queue.push(Self::dangerously_convert(t)),
         }
     }
 
-    fn render_with_blank_state<F>(ps: &mut BaseParserState, f: F) -> BaseParserState
+    pub(crate) fn render_with_blank_state<F>(ps: &mut BaseParserState, f: F) -> BaseParserState
     where
         F: FnOnce(&mut BaseParserState),
     {


### PR DESCRIPTION
`ParserState` was split into `ConcreteParserState` and `BaseParserState` in 05807c966612ebb2512c617381229d24cc16cd0a , which required the introduction of boxing closures passed to `ConcreteParserState` methods.  (You can't just use `impl FnOnce(&mut dyn ConcreteParserState)` or similar, or `rustc` yells at you.)  I don't think the split has been successful:

1. `ConcreteParserState` is pretty big.
2. We have trait methods that explicitly know about the presence of `BaseParserState` (to be fair, this is probably a bit of oversight, and those methods could just as easily be modified to use `ConcreteParserState`).
3. The boxing of closures is verbose and inefficient.
4. The naming is a little strange -- I'm sure the names were chosen to make the refactoring easier, but it seems odd to me to have the trait named something `Concrete*`.
5. I don't think we ever intend to have another implementation of `ConcreteParserState`.
6. Probably some other things that I am overlooking.

To be fair, I do think `ConcreteParserState` did provide a reasonable division between the "API" of the parser state and the strictly private helper functions on `BaseParserState`.  But I think that can be accomplished mostly as easily with visibility attributes, and doesn't require duplication of e.g. method signatures for no particular reason.

This PR undoes the naming part of the above; I have follow on patches to undo the closure boxing.  I admit to being lazy in just `pub (crate)`'ing all the functions on `BaseParserState`, and there are probably some that could be deleted.

wdyt @elliottt ?