### PR TITLE
Bump to latest Rust version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85.0
+          toolchain: 1.91.1
           components: clippy
           override: true
       - uses: actions/cache@v4
@@ -69,13 +69,13 @@ jobs:
     - if: runner.os == 'macOS'
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: 1.85.0
+        toolchain: 1.91.1
         target: aarch64-apple-darwin
         override: true
     - if: runner.os != 'macOS'
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: 1.85.0
+        toolchain: 1.91.1
         override: true
         target: aarch64-unknown-linux-gnu
     - uses: actions/cache@v4

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -44,13 +44,13 @@ jobs:
       - if: runner.os == 'macOS'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85.0
+          toolchain: 1.91.1
           target: aarch64-apple-darwin
           override: true
       - if: runner.os != 'macOS'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85.0
+          toolchain: 1.91.1
           override: true
           target: aarch64-unknown-linux-gnu
       - if: runner.os == 'macOS'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,13 +28,13 @@ jobs:
       - if: runner.os == 'macOS'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85.0
+          toolchain: 1.91.1
           target: aarch64-apple-darwin
           override: true
       - if: runner.os != 'macOS'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85.0
+          toolchain: 1.91.1
           override: true
           target: aarch64-unknown-linux-gnu
       - if: runner.os == 'macOS'

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2674,7 +2674,7 @@ fn can_elide_parens_for_reserved_names(cc: &[CallChainElement]) -> bool {
         return true;
     }
 
-    let is_rspec_describe = match (cc.first(), cc.get(2)) {
+    match (cc.first(), cc.get(2)) {
         (
             Some(CallChainElement::VarRef(VarRef(_, VarRefType::Const(Const(_, c, _))))),
             Some(CallChainElement::IdentOrOpOrKeywordOrConst(IdentOrOpOrKeywordOrConst::Ident(
@@ -2682,9 +2682,7 @@ fn can_elide_parens_for_reserved_names(cc: &[CallChainElement]) -> bool {
             ))),
         ) => c == "RSpec" && i == "describe",
         _ => false,
-    };
-
-    is_rspec_describe
+    }
 }
 
 /// Returns `true` if the call chain is indented, `false` if not

--- a/librubyfmt/src/intermediary.rs
+++ b/librubyfmt/src/intermediary.rs
@@ -90,10 +90,11 @@ impl Intermediary {
 
         match &lt {
             ConcreteLineToken::HardNewLine => {
-                if let Some(prev) = &self.previous_line_metadata {
-                    if !self.current_line_metadata.has_require() && prev.has_require() {
-                        self.insert_trailing_blankline(BlanklineReason::EndOfRequireBlock);
-                    }
+                if let Some(prev) = &self.previous_line_metadata
+                    && !self.current_line_metadata.has_require()
+                    && prev.has_require()
+                {
+                    self.insert_trailing_blankline(BlanklineReason::EndOfRequireBlock);
                 }
 
                 let mut md = LineMetadata::new();
@@ -101,17 +102,17 @@ impl Intermediary {
                 self.previous_line_metadata = Some(md);
                 self.index_of_last_hard_newline = self.tokens.len();
 
-                if self.tokens.len() >= 2 {
-                    if let (
+                if self.tokens.len() >= 2
+                    && let (
                         Some(&ConcreteLineToken::HardNewLine),
                         Some(&ConcreteLineToken::HardNewLine),
                     ) = (
                         self.tokens.get(self.index_of_last_hard_newline - 2),
                         self.tokens.get(self.index_of_last_hard_newline - 1),
-                    ) {
-                        do_push = false;
-                        self.index_of_last_hard_newline = self.tokens.len() - 1;
-                    }
+                    )
+                {
+                    do_push = false;
+                    self.index_of_last_hard_newline = self.tokens.len() - 1;
                 }
             }
             ConcreteLineToken::ModuleKeyword | ConcreteLineToken::ClassKeyword => {
@@ -126,13 +127,13 @@ impl Intermediary {
             ConcreteLineToken::Indent { depth } => {
                 self.current_line_metadata.observe_indent_level(*depth);
 
-                if let Some(prev) = &mut self.previous_line_metadata {
-                    if LineMetadata::indent_level_increases_between(
+                if let Some(prev) = &mut self.previous_line_metadata
+                    && LineMetadata::indent_level_increases_between(
                         prev,
                         &self.current_line_metadata,
-                    ) {
-                        prev.set_gets_indented()
-                    }
+                    )
+                {
+                    prev.set_gets_indented()
                 }
             }
             ConcreteLineToken::DirectPart { part } => {
@@ -195,10 +196,10 @@ impl Intermediary {
     }
 
     fn handle_class_or_module(&mut self) {
-        if let Some(prev) = &self.previous_line_metadata {
-            if !prev.gets_indented() {
-                self.insert_trailing_blankline(BlanklineReason::ClassOrModule);
-            }
+        if let Some(prev) = &self.previous_line_metadata
+            && !prev.gets_indented()
+        {
+            self.insert_trailing_blankline(BlanklineReason::ClassOrModule);
         }
     }
 

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -653,7 +653,7 @@ impl ParserState {
                 FormattingContext::HashType(hash_type) => Some(hash_type),
                 _ => None,
             })
-            .last()
+            .next_back()
     }
 
     pub(crate) fn emit_dot(&mut self) {

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -142,18 +142,16 @@ impl RenderQueueWriter {
                     x,
                 ],
             ) = accum.last::<4>()
+                && x.is_in_need_of_a_trailing_blankline()
             {
-                if x.is_in_need_of_a_trailing_blankline() {
-                    accum.insert_trailing_blankline(BlanklineReason::ComesAfterEnd);
-                }
+                accum.insert_trailing_blankline(BlanklineReason::ComesAfterEnd);
             }
 
             if let Some([HardNewLine, HardNewLine, Comment { contents }, HardNewLine]) =
                 accum.last::<4>()
+                && contents.is_empty()
             {
-                if contents.is_empty() {
-                    accum.pop_require_comment_whitespace();
-                }
+                accum.pop_require_comment_whitespace();
             }
 
             if let Some(

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -285,23 +285,21 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
             } else if let AbstractLineToken::BreakableEntry(BreakableEntry {
                 delims, tokens, ..
             }) = token
+                && *delims == BreakableDelims::for_brace_block()
             {
-                if *delims == BreakableDelims::for_brace_block() {
-                    if let Some(AbstractLineToken::BreakableEntry(BreakableEntry {
-                        delims, ..
-                    })) = tokens.first()
-                    {
-                        if *delims == BreakableDelims::for_block_params() {
-                            // Wipe away the body of the block and leave only the params
-                            *tokens = vec![tokens.first().unwrap().clone()];
-                        } else {
-                            // No params, so wipe away the whole thing
-                            *tokens = Vec::new();
-                        }
+                if let Some(AbstractLineToken::BreakableEntry(BreakableEntry { delims, .. })) =
+                    tokens.first()
+                {
+                    if *delims == BreakableDelims::for_block_params() {
+                        // Wipe away the body of the block and leave only the params
+                        *tokens = vec![tokens.first().unwrap().clone()];
                     } else {
                         // No params, so wipe away the whole thing
                         *tokens = Vec::new();
                     }
+                } else {
+                    // No params, so wipe away the whole thing
+                    *tokens = Vec::new();
                 }
             }
         }
@@ -330,13 +328,12 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
         //
         // However, if there's only one item in the chain, try our best to leave that in place.
         // `foo\n.bar` is always a little awkward.
-        if let Some(AbstractLineToken::BreakableEntry(be)) = tokens.last() {
-            if (call_count == 1 || be.is_multiline())
-                && be.delims != BreakableDelims::for_brace_block()
-                && be.delims != BreakableDelims::for_block_params()
-            {
-                tokens.pop();
-            }
+        if let Some(AbstractLineToken::BreakableEntry(be)) = tokens.last()
+            && (call_count == 1 || be.is_multiline())
+            && be.delims != BreakableDelims::for_brace_block()
+            && be.delims != BreakableDelims::for_block_params()
+        {
+            tokens.pop();
         }
         tokens.insert(
             0,
@@ -403,14 +400,12 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
                     call_chain_to_check = &call_chain_to_check[1..];
                 }
 
-                let chain_is_user_multilined = call_chain_to_check
+                call_chain_to_check
                     .iter()
                     .filter_map(|cc_elem| cc_elem.start_line())
                     .collect::<HashSet<_>>()
                     .len()
-                    > 1;
-
-                chain_is_user_multilined
+                    > 1
             }
         }
     }

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -869,10 +869,10 @@ pub enum ArgsAddStarOrExpressionListOrArgsForward {
 
 impl ArgsAddStarOrExpressionListOrArgsForward {
     pub fn is_empty(&self) -> bool {
-        if let ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(el, ..) = self {
-            if el.is_empty() {
-                return true;
-            }
+        if let ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(el, ..) = self
+            && el.is_empty()
+        {
+            return true;
         }
 
         false


### PR DESCRIPTION
On the tin -- this bumps us to `1.91.1` (latest as of today) and updates some failing clippy lints, most of which are basically just converting nested `if` statements into conditionals now that if-let chains are stabilized.