### PR TITLE
Wrap some `yield` fixtures with method definitions

### DIFF
--- a/fixtures/small/yield_hash_args_actual.rb
+++ b/fixtures/small/yield_hash_args_actual.rb
@@ -1,2 +1,4 @@
-yield({name: "faketag1"})
-yield a: b
+def bees!
+  yield({name: "faketag1"})
+  yield a: b
+end

--- a/fixtures/small/yield_hash_args_expected.rb
+++ b/fixtures/small/yield_hash_args_expected.rb
@@ -1,2 +1,4 @@
-yield({name: "faketag1"})
-yield(a: b)
+def bees!
+  yield({name: "faketag1"})
+  yield(a: b)
+end

--- a/fixtures/small/yield_with_paren_actual.rb
+++ b/fixtures/small/yield_with_paren_actual.rb
@@ -1,1 +1,3 @@
-return path if yield(path)
+def bees!
+  return path if yield(path)
+end

--- a/fixtures/small/yield_with_paren_expected.rb
+++ b/fixtures/small/yield_with_paren_expected.rb
@@ -1,1 +1,3 @@
-return path if yield(path)
+def bees!
+  return path if yield(path)
+end


### PR DESCRIPTION
Prism will error out on parsing `yield` outside the scope of a method def, so some of our fixtures won't run at all with Prism at the moment.

```bash
% echo "return path if yield(path)" | ruby -c          
-:1: Invalid yield
return path if yield(path)
-: compile error (SyntaxError)

% echo "def foo; return path if yield(path); end" | ruby -c
Syntax OK
```

Here I wrapped them in a stub method definition for them to compile correctly.