### PR TITLE
[prism] Support imaginary numbers

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2558,8 +2558,12 @@ fn format_if_node(ps: &mut ParserState, if_node: prism::IfNode) {
     }
 }
 
-fn format_imaginary_node(_ps: &mut ParserState, _imaginary_node: prism::ImaginaryNode) {
-    todo!()
+fn format_imaginary_node(ps: &mut ParserState, imaginary_node: prism::ImaginaryNode) {
+    handle_string_at_offset(
+        ps,
+        loc_to_string(imaginary_node.location()),
+        imaginary_node.location().start_offset(),
+    );
 }
 
 fn format_implicit_node() {

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -70,7 +70,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_command_call_raise",
     "small_comments_at_indentation_changes",
     "small_comments_with_breaks",
-    "small_complex_numbers",
     "small_const_call",
     "small_dotcall",
     "small_dyna_symbol_with_escapes",


### PR DESCRIPTION
On the tin. I had made a PR before but we didn't have proper infix operator support. We do now, so this can land.

(This also gets us under 100 failing fixtures for Prism! :tada:)