### PR TITLE
don't allocate an entire `String` in `will_render_as_multiline`

### DIFF
--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -174,7 +174,7 @@ impl ParserState {
         next_ps.with_suppress_comments(true, f);
         let data = next_ps.render_to_buffer();
 
-        let s = str::from_utf8(&data).expect("string is utf8").to_string();
+        let s = str::from_utf8(&data).expect("string is utf8");
         s.trim().contains('\n') || s.len() > MAX_LINE_LENGTH
     }
 


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

All the methods we need here are already present on `str`, so we don't need to convert to a full-blown `String`.
