### PR TITLE
[prism] Fix comment rendering after last call arg

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1482,7 +1482,7 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
                                     format_block_argument_node(ps, block_argument_node);
                                 }
 
-                                // Ensure that we render comments between the last argument and closign parens
+                                // Ensure that we render comments between the last argument and closing parens
                                 if let Some(closing_loc) = call_node.closing_loc() {
                                     ps.wind_dumping_comments_until_offset(closing_loc.end_offset());
                                 }

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1481,6 +1481,11 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
                                     }
                                     format_block_argument_node(ps, block_argument_node);
                                 }
+
+                                // Ensure that we render comments between the last argument and closign parens
+                                if let Some(closing_loc) = call_node.closing_loc() {
+                                    ps.wind_dumping_comments_until_offset(closing_loc.end_offset());
+                                }
                             }),
                         );
                     }),

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -74,7 +74,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_heredocs_ending_blocks",
     "small_inline_rescue",
     "small_lambda",
-    "small_list_like_things_with_comments",
     "small_long_raise",
     "small_many_opassigns",
     "small_massign",


### PR DESCRIPTION
This fixes a small bug in the Prism call comment rendering by making sure that we wind forward all the way to the closing loc of the call, which in most cases is the closing paren. This ensures that we appropriately render all the comments in between the last argument and the closing paren.