### PR TITLE
Use `Cow` for some static string values

### DIFF
--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -3,6 +3,7 @@ use crate::render_targets::{
     AbstractTokenTarget, BreakableCallChainEntry, BreakableEntry, ConvertType,
 };
 use crate::types::ColNumber;
+use std::borrow::Cow;
 
 pub fn cltats_hard_newline() -> ConcreteLineTokenAndTargets {
     ConcreteLineTokenAndTargets::ConcreteLineToken(ConcreteLineToken::HardNewLine)
@@ -65,45 +66,45 @@ pub enum ConcreteLineToken {
 }
 
 impl ConcreteLineToken {
-    pub fn into_ruby(self) -> String {
+    pub fn into_ruby(self) -> Cow<'static, str> {
         match self {
-            Self::HardNewLine => "\n".to_string(),
-            Self::Indent { depth } => (0..depth).map(|_| ' ').collect(),
-            Self::Keyword { keyword } => keyword,
-            Self::ModKeyword { contents } => contents,
-            Self::ConditionalKeyword { contents } => contents,
-            Self::DoKeyword => "do".to_string(),
-            Self::ClassKeyword => "class".to_string(),
-            Self::DefKeyword => "def".to_string(),
-            Self::ModuleKeyword => "module".to_string(),
-            Self::DirectPart { part } => part,
-            Self::CommaSpace => ", ".to_string(),
-            Self::Comma => ",".to_string(),
-            Self::Space => " ".to_string(),
-            Self::Dot => ".".to_string(),
-            Self::Ellipsis => "...".to_string(),
-            Self::ColonColon => "::".to_string(),
-            Self::LonelyOperator => "&.".to_string(),
-            Self::OpenSquareBracket => "[".to_string(),
-            Self::CloseSquareBracket => "]".to_string(),
-            Self::OpenCurlyBracket => "{".to_string(),
-            Self::CloseCurlyBracket => "}".to_string(),
-            Self::OpenParen => "(".to_string(),
-            Self::CloseParen => ")".to_string(),
-            Self::Op { op } => op,
-            Self::DoubleQuote => "\"".to_string(),
-            Self::LTStringContent { content } => content,
-            Self::SingleSlash => "\\".to_string(),
-            Self::Comment { contents } => contents,
-            Self::Delim { contents } => contents,
-            Self::End => "end".to_string(),
-            Self::HeredocClose { symbol } => symbol,
-            Self::DataEnd => "__END__".to_string(),
-            Self::HeredocStart { symbol, .. } => symbol,
+            Self::HardNewLine => Cow::Borrowed("\n"),
+            Self::Indent { depth } => Cow::Owned((0..depth).map(|_| ' ').collect()),
+            Self::Keyword { keyword } => Cow::Owned(keyword),
+            Self::ModKeyword { contents } => Cow::Owned(contents),
+            Self::ConditionalKeyword { contents } => Cow::Owned(contents),
+            Self::DoKeyword => Cow::Borrowed("do"),
+            Self::ClassKeyword => Cow::Borrowed("class"),
+            Self::DefKeyword => Cow::Borrowed("def"),
+            Self::ModuleKeyword => Cow::Borrowed("module"),
+            Self::DirectPart { part } => Cow::Owned(part),
+            Self::CommaSpace => Cow::Borrowed(", "),
+            Self::Comma => Cow::Borrowed(","),
+            Self::Space => Cow::Borrowed(" "),
+            Self::Dot => Cow::Borrowed("."),
+            Self::Ellipsis => Cow::Borrowed("..."),
+            Self::ColonColon => Cow::Borrowed("::"),
+            Self::LonelyOperator => Cow::Borrowed("&."),
+            Self::OpenSquareBracket => Cow::Borrowed("["),
+            Self::CloseSquareBracket => Cow::Borrowed("]"),
+            Self::OpenCurlyBracket => Cow::Borrowed("{"),
+            Self::CloseCurlyBracket => Cow::Borrowed("}"),
+            Self::OpenParen => Cow::Borrowed("("),
+            Self::CloseParen => Cow::Borrowed(")"),
+            Self::Op { op } => Cow::Owned(op),
+            Self::DoubleQuote => Cow::Borrowed("\""),
+            Self::LTStringContent { content } => Cow::Owned(content),
+            Self::SingleSlash => Cow::Borrowed("\\"),
+            Self::Comment { contents } => Cow::Owned(contents),
+            Self::Delim { contents } => Cow::Owned(contents),
+            Self::End => Cow::Borrowed("end"),
+            Self::HeredocClose { symbol } => Cow::Owned(symbol),
+            Self::DataEnd => Cow::Borrowed("__END__"),
+            Self::HeredocStart { symbol, .. } => Cow::Owned(symbol),
             // no-op, this is purely semantic information
             // for the render queue
             Self::AfterCallChain | Self::BeginCallChainIndent | Self::EndCallChainIndent => {
-                "".to_string()
+                Cow::Borrowed("")
             }
         }
     }
@@ -142,7 +143,7 @@ impl ConcreteLineToken {
         match self {
             Self::End => true,
             Self::DirectPart { part } => part == "}" || part == "]" || part == ")",
-            Self::Delim { contents } => contents == "}" || contents == "]" || contents == ")",
+            Self::Delim { contents } => *contents == "}" || *contents == "]" || *contents == ")",
             _ => false,
         }
     }
@@ -235,22 +236,26 @@ impl ConcreteLineTokenAndTargets {
         }
     }
 
-    pub fn into_ruby(self) -> String {
+    pub fn into_ruby(self) -> Cow<'static, str> {
         match self {
-            Self::BreakableEntry(be) => be.into_tokens(ConvertType::SingleLine).into_iter().fold(
-                "".to_string(),
-                |mut accum, tok| {
-                    accum.push_str(&tok.into_ruby());
-                    accum
-                },
-            ),
-            Self::BreakableCallChainEntry(bcce) => bcce
-                .into_tokens(ConvertType::SingleLine)
-                .into_iter()
-                .fold("".to_string(), |mut accum, tok| {
-                    accum.push_str(&tok.into_ruby());
-                    accum
-                }),
+            Self::BreakableEntry(be) => {
+                Cow::Owned(be.into_tokens(ConvertType::SingleLine).into_iter().fold(
+                    String::new(),
+                    |mut accum, tok| {
+                        accum.push_str(&tok.into_ruby());
+                        accum
+                    },
+                ))
+            }
+            Self::BreakableCallChainEntry(bcce) => {
+                Cow::Owned(bcce.into_tokens(ConvertType::SingleLine).into_iter().fold(
+                    String::new(),
+                    |mut accum, tok| {
+                        accum.push_str(&tok.into_ruby());
+                        accum
+                    },
+                ))
+            }
             Self::ConcreteLineToken(clt) => clt.into_ruby(),
         }
     }


### PR DESCRIPTION
Many keywords, operators, delimiters, and so on in `rubyfmt` are static strings, but all throughout the codebase we heap-allocate them with `to_string` a bit willy-nilly, and these are often later cloned, creating more allocations etc. I think we've mostly just used `String` out of inertia, but it's probably unnecessary for most call sites. In reality, a ton of these could eventually should just use `&str`, and `String` should be limited to dynamically-sized use cases like breakables. 

This PR is just the first step in reducing a whole host of these allocations by making the return type of `into_ruby()` be a `Cow<'static, str>` instead of a `String` and converting the easiest ones (keywords for which we already have special tokens, like `def`, `do`, `class`, etc.) to use `Cow::Borrowed`.

In later PRs, I'll convert even more call sites to use `&str` instead of `String`, like delimiters and such which are extremely common in most files. However, even just this PR, by a very rough allocation check, reduces the number of total allocations by something like 3% (for the Ripper implementation on `fixtures/large/concurrent-ruby/ruby_non_concurrent_priority_queue_actual.rb`), implying that we could meaningfully reduce those allocations even more down the line.