### PR TITLE
Use `&str` for `DelimiterPair`

### DIFF
--- a/librubyfmt/src/delimiters.rs
+++ b/librubyfmt/src/delimiters.rs
@@ -2,12 +2,12 @@ use crate::line_tokens::ConcreteLineToken;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct DelimiterPair {
-    open: String,
-    close: String,
+    open: &'static str,
+    close: &'static str,
 }
 
 impl DelimiterPair {
-    fn new(open: String, close: String) -> Self {
+    fn new(open: &'static str, close: &'static str) -> Self {
         DelimiterPair { open, close }
     }
 }
@@ -21,88 +21,88 @@ pub struct BreakableDelims {
 impl BreakableDelims {
     pub fn for_method_call() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new("(".to_string(), ")".to_string()),
-            multi_line: DelimiterPair::new("(".to_string(), ")".to_string()),
+            single_line: DelimiterPair::new("(", ")"),
+            multi_line: DelimiterPair::new("(", ")"),
         }
     }
 
     pub fn for_return_kw() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new(" ".to_string(), "".to_string()),
-            multi_line: DelimiterPair::new(" [".to_string(), "]".to_string()),
+            single_line: DelimiterPair::new(" ", ""),
+            multi_line: DelimiterPair::new(" [", "]"),
         }
     }
 
     pub fn for_kw() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new(" ".to_string(), "".to_string()),
-            multi_line: DelimiterPair::new("(".to_string(), ")".to_string()),
+            single_line: DelimiterPair::new(" ", ""),
+            multi_line: DelimiterPair::new("(", ")"),
         }
     }
 
     pub fn for_block_params() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new(" |".to_string(), "|".to_string()),
-            multi_line: DelimiterPair::new(" |".to_string(), "|".to_string()),
+            single_line: DelimiterPair::new(" |", "|"),
+            multi_line: DelimiterPair::new(" |", "|"),
         }
     }
 
     pub fn for_array() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new("[".to_string(), "]".to_string()),
-            multi_line: DelimiterPair::new("[".to_string(), "]".to_string()),
+            single_line: DelimiterPair::new("[", "]"),
+            multi_line: DelimiterPair::new("[", "]"),
         }
     }
 
     pub fn for_when() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new(" ".to_string(), "".to_string()),
-            multi_line: DelimiterPair::new("".to_string(), "".to_string()),
+            single_line: DelimiterPair::new(" ", ""),
+            multi_line: DelimiterPair::new("", ""),
         }
     }
 
     pub fn for_hash() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new("{".to_string(), "}".to_string()),
-            multi_line: DelimiterPair::new("{".to_string(), "}".to_string()),
+            single_line: DelimiterPair::new("{", "}"),
+            multi_line: DelimiterPair::new("{", "}"),
         }
     }
 
     pub fn for_brace_block() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new("{".to_string(), " }".to_string()),
-            multi_line: DelimiterPair::new("{".to_string(), "}".to_string()),
+            single_line: DelimiterPair::new("{", " }"),
+            multi_line: DelimiterPair::new("{", "}"),
         }
     }
 
     pub fn for_binary_op() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new("".to_string(), "".to_string()),
-            multi_line: DelimiterPair::new("".to_string(), "".to_string()),
+            single_line: DelimiterPair::new("", ""),
+            multi_line: DelimiterPair::new("", ""),
         }
     }
 
     pub fn single_line_open(&self) -> ConcreteLineToken {
         ConcreteLineToken::Delim {
-            contents: self.single_line.open.clone(),
+            contents: self.single_line.open,
         }
     }
 
     pub fn single_line_close(&self) -> ConcreteLineToken {
         ConcreteLineToken::Delim {
-            contents: self.single_line.close.clone(),
+            contents: self.single_line.close,
         }
     }
 
     pub fn multi_line_open(&self) -> ConcreteLineToken {
         ConcreteLineToken::Delim {
-            contents: self.multi_line.open.clone(),
+            contents: self.multi_line.open,
         }
     }
 
     pub fn multi_line_close(&self) -> ConcreteLineToken {
         ConcreteLineToken::Delim {
-            contents: self.multi_line.close.clone(),
+            contents: self.multi_line.close,
         }
     }
 

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -53,7 +53,7 @@ pub enum ConcreteLineToken {
     LTStringContent { content: String },
     SingleSlash,
     Comment { contents: String },
-    Delim { contents: String },
+    Delim { contents: &'static str },
     End,
     HeredocClose { symbol: String },
     DataEnd,
@@ -96,7 +96,7 @@ impl ConcreteLineToken {
             Self::LTStringContent { content } => Cow::Owned(content),
             Self::SingleSlash => Cow::Borrowed("\\"),
             Self::Comment { contents } => Cow::Owned(contents),
-            Self::Delim { contents } => Cow::Owned(contents),
+            Self::Delim { contents } => Cow::Borrowed(contents),
             Self::End => Cow::Borrowed("end"),
             Self::HeredocClose { symbol } => Cow::Owned(symbol),
             Self::DataEnd => Cow::Borrowed("__END__"),
@@ -118,13 +118,13 @@ impl ConcreteLineToken {
         match self {
             AfterCallChain | BeginCallChainIndent | EndCallChainIndent => 0, // purely semantic tokens, don't render
             HeredocStart { symbol, .. } => symbol.len(),
+            Delim { contents } => contents.len(),
             Indent { depth } => *depth as usize,
             Keyword { keyword: contents }
             | Op { op: contents }
             | DirectPart { part: contents }
             | LTStringContent { content: contents }
             | Comment { contents }
-            | Delim { contents }
             | ConditionalKeyword { contents }
             | HeredocClose { symbol: contents }
             | ModKeyword { contents } => contents.len(),


### PR DESCRIPTION
See #587 for additional context.

`DelimiterPair`, which is the struct used to hold the delimiters for breakables, always uses static strings. They previously were converted to `String` for the reasons discussed in #587, but that's no longer the case, so we can avoid quite a few allocations by making them `&str` instead.
