### PR TITLE
Convert more keyword token types to use `&str`

### DIFF
--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2120,7 +2120,7 @@ pub fn format_conditional(
     ps: &mut ParserState,
     cond_expr: Expression,
     body: Vec<Expression>,
-    kw: String,
+    kw: &'static str,
     tail: Option<ElsifOrElse>,
     start_end: Option<StartEnd>,
 ) {
@@ -2153,7 +2153,7 @@ pub fn format_conditional(
                 ps,
                 *elsif.1,
                 elsif.2,
-                "elsif".to_string(),
+                "elsif",
                 (elsif.3).map(|v| *v),
                 Some(elsif.4),
             );
@@ -2183,7 +2183,7 @@ pub fn format_conditional(
 
 pub fn format_if(ps: &mut ParserState, ifs: If) {
     let vifs = ifs.clone();
-    format_conditional(ps, *ifs.1, ifs.2, "if".to_string(), ifs.3, Some(ifs.4));
+    format_conditional(ps, *ifs.1, ifs.2, "if", ifs.3, Some(ifs.4));
 
     ps.with_start_of_line(true, |ps| {
         ps.wind_dumping_comments_until_line(vifs.4.1);
@@ -2200,7 +2200,7 @@ pub fn format_unless(ps: &mut ParserState, unless: Unless) {
         ps,
         *unless.1,
         unless.2,
-        "unless".to_string(),
+        "unless",
         (unless.3).map(ElsifOrElse::Else),
         Some(unless.4),
     );
@@ -2778,7 +2778,7 @@ pub fn format_do_block(ps: &mut ParserState, do_block: DoBlock) {
 pub fn format_keyword(
     ps: &mut ParserState,
     args: ParenOrArgsAddBlock,
-    kw: String,
+    kw: &'static str,
     start_end: StartEnd,
 ) {
     if ps.at_start_of_line() {
@@ -2833,7 +2833,7 @@ pub fn format_while(
     ps: &mut ParserState,
     conditional: Expression,
     exprs: Vec<Expression>,
-    kw: String,
+    kw: &'static str,
     start_end: StartEnd,
 ) {
     format_conditional(ps, conditional, exprs, kw, None, Some(start_end));
@@ -2867,7 +2867,7 @@ pub fn format_inline_mod(
     ps: &mut ParserState,
     conditional: Box<Expression>,
     body: Box<Expression>,
-    name: String,
+    name: &'static str,
 ) {
     if ps.at_start_of_line() {
         ps.emit_indent();
@@ -2876,7 +2876,9 @@ pub fn format_inline_mod(
     ps.with_start_of_line(false, |ps| {
         format_expression(ps, *body);
 
-        ps.emit_mod_keyword(format!(" {} ", name));
+        ps.emit_space();
+        ps.emit_mod_keyword(name);
+        ps.emit_space();
         format_expression(ps, *conditional);
     });
 
@@ -2891,10 +2893,10 @@ pub fn format_multilinable_mod(
     ps: &mut ParserState,
     conditional: Box<Expression>,
     body: Box<Expression>,
-    name: String,
+    name: &'static str,
 ) {
     let is_multiline = ps.will_render_as_multiline(|next_ps| {
-        format_inline_mod(next_ps, conditional.clone(), body.clone(), name.clone())
+        format_inline_mod(next_ps, conditional.clone(), body.clone(), name)
     });
 
     if is_multiline {
@@ -3004,21 +3006,11 @@ pub fn format_case(ps: &mut ParserState, case: Case) {
 }
 
 pub fn format_retry(ps: &mut ParserState, r: Retry) {
-    format_keyword(
-        ps,
-        ParenOrArgsAddBlock::Empty(Vec::new()),
-        "retry".to_string(),
-        r.1,
-    );
+    format_keyword(ps, ParenOrArgsAddBlock::Empty(Vec::new()), "retry", r.1);
 }
 
 pub fn format_redo(ps: &mut ParserState, r: Redo) {
-    format_keyword(
-        ps,
-        ParenOrArgsAddBlock::Empty(Vec::new()),
-        "redo".to_string(),
-        r.1,
-    );
+    format_keyword(ps, ParenOrArgsAddBlock::Empty(Vec::new()), "redo", r.1);
 }
 
 pub fn format_sclass(ps: &mut ParserState, sc: SClass) {
@@ -3066,7 +3058,7 @@ pub fn format_stabby_lambda(ps: &mut ParserState, sl: StabbyLambda) {
     let body = sl.2;
 
     ps.with_start_of_line(false, |ps| {
-        ps.emit_keyword("->".to_string());
+        ps.emit_keyword("->");
         if params.is_present() {
             ps.emit_space();
         }
@@ -3141,7 +3133,7 @@ pub fn format_for(ps: &mut ParserState, forloop: For) {
     let body = forloop.3;
 
     ps.with_start_of_line(false, |ps| {
-        ps.emit_keyword("for".to_string());
+        ps.emit_keyword("for");
         ps.emit_space();
         match variables {
             VarFieldOrVarFields::VarField(vf) => {
@@ -3159,7 +3151,7 @@ pub fn format_for(ps: &mut ParserState, forloop: For) {
         }
 
         ps.emit_space();
-        ps.emit_keyword("in".to_string());
+        ps.emit_keyword("in");
         ps.emit_space();
         format_expression(ps, *collection);
         ps.emit_newline();
@@ -3189,11 +3181,11 @@ pub fn format_ifop(ps: &mut ParserState, ifop: IfOp) {
         ps.with_formatting_context(FormattingContext::IfOp, |ps| {
             format_expression(ps, *ifop.1);
             ps.emit_space();
-            ps.emit_keyword("?".to_string());
+            ps.emit_keyword("?");
             ps.emit_space();
             format_expression(ps, *ifop.2);
             ps.emit_space();
-            ps.emit_keyword(":".to_string());
+            ps.emit_keyword(":");
             ps.emit_space();
             format_expression(ps, *ifop.3);
         });
@@ -3205,12 +3197,7 @@ pub fn format_ifop(ps: &mut ParserState, ifop: IfOp) {
 }
 
 pub fn format_return0(ps: &mut ParserState, r: Return0) {
-    format_keyword(
-        ps,
-        ParenOrArgsAddBlock::Empty(Vec::new()),
-        "return".to_string(),
-        r.1,
-    );
+    format_keyword(ps, ParenOrArgsAddBlock::Empty(Vec::new()), "return", r.1);
 }
 
 pub fn format_opassign(ps: &mut ParserState, opassign: OpAssign) {
@@ -3243,7 +3230,7 @@ pub fn format_zsuper(ps: &mut ParserState, start_end: StartEnd) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
-        "super".to_string(),
+        "super",
         start_end,
     )
 }
@@ -3252,7 +3239,7 @@ pub fn format_yield0(ps: &mut ParserState, start_end: StartEnd) {
     format_keyword(
         ps,
         ParenOrArgsAddBlock::Empty(Vec::new()),
-        "yield".to_string(),
+        "yield",
         start_end,
     )
 }
@@ -3271,7 +3258,7 @@ pub fn format_return(ps: &mut ParserState, ret: Return) {
     }
 
     let args = normalize_args(args);
-    ps.emit_keyword("return".to_string());
+    ps.emit_keyword("return");
 
     ps.with_start_of_line(false, |ps| {
         if !args.is_empty() {
@@ -3372,14 +3359,14 @@ pub fn format_expression(ps: &mut ParserState, expression: Expression) {
         Expression::RegexpLiteral(regexp) => format_regexp_literal(ps, regexp),
         Expression::Backref(backref) => format_backref(ps, backref),
         Expression::Yield(y) => format_yield(ps, y),
-        Expression::Break(b) => format_keyword(ps, b.1, "break".to_string(), b.2),
+        Expression::Break(b) => format_keyword(ps, b.1, "break", b.2),
         Expression::MethodAddBlock(mab) => format_method_add_block(ps, mab),
-        Expression::While(w) => format_while(ps, *w.1, w.2, "while".to_string(), w.3),
-        Expression::Until(u) => format_while(ps, *u.1, u.2, "until".to_string(), u.3),
-        Expression::WhileMod(wm) => format_inline_mod(ps, wm.1, wm.2, "while".to_string()),
-        Expression::UntilMod(um) => format_inline_mod(ps, um.1, um.2, "until".to_string()),
-        Expression::IfMod(wm) => format_multilinable_mod(ps, wm.1, wm.2, "if".to_string()),
-        Expression::UnlessMod(um) => format_multilinable_mod(ps, um.1, um.2, "unless".to_string()),
+        Expression::While(w) => format_while(ps, *w.1, w.2, "while", w.3),
+        Expression::Until(u) => format_while(ps, *u.1, u.2, "until", u.3),
+        Expression::WhileMod(wm) => format_inline_mod(ps, wm.1, wm.2, "while"),
+        Expression::UntilMod(um) => format_inline_mod(ps, um.1, um.2, "until"),
+        Expression::IfMod(wm) => format_multilinable_mod(ps, wm.1, wm.2, "if"),
+        Expression::UnlessMod(um) => format_multilinable_mod(ps, um.1, um.2, "unless"),
         Expression::Case(c) => format_case(ps, c),
         Expression::Retry(r) => format_retry(ps, r),
         Expression::Redo(r) => format_redo(ps, r),

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -3023,7 +3023,7 @@ pub fn format_sclass(ps: &mut ParserState, sc: SClass) {
     let end_line = sc.3.end_line();
 
     ps.with_start_of_line(false, |ps| {
-        ps.emit_keyword("class".into());
+        ps.emit_keyword("class");
         ps.emit_space();
         ps.emit_ident("<<".to_string());
         ps.emit_space();

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -468,7 +468,7 @@ fn format_begin_node(ps: &mut ParserState, begin_node: prism::BeginNode) {
         // the body of a `def`
         ps.end_indent();
     } else {
-        ps.emit_keyword("begin".to_string());
+        ps.emit_keyword("begin");
     }
     ps.new_block(|ps| {
         // For implicit nodes, this newline was already emitted by the caller
@@ -882,7 +882,7 @@ fn format_ensure_node(ps: &mut ParserState, ensure_node: prism::EnsureNode) {
     // aren't always handled with `format_node`, which usually handles this
     ps.at_offset(ensure_node.location().start_offset());
 
-    ps.emit_keyword("ensure".to_string());
+    ps.emit_keyword("ensure");
     ps.new_block(|ps| {
         ps.emit_newline();
         if let Some(statements) = ensure_node.statements() {
@@ -1033,7 +1033,7 @@ fn format_module_node(ps: &mut ParserState, module_node: prism::ModuleNode) {
 }
 
 fn format_def_node(ps: &mut ParserState, def_node: prism::DefNode) {
-    ps.emit_keyword("def".to_string());
+    ps.emit_keyword("def");
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -1149,9 +1149,11 @@ fn format_else_node(ps: &mut ParserState, else_node: prism::ElseNode) {
 
     // `else_keyword_loc` is somewhat misleading, since this can be either the `else`
     // keyword or the `:` separator in a ternary
-    let keyword = loc_to_string(else_node.else_keyword_loc());
-    if &keyword == "else" {
-        ps.emit_conditional_keyword(keyword);
+    // Given those two options, we can check the length to avoid copying the loc.
+    let else_keyword_loc = else_node.else_keyword_loc();
+    let keyword_len = else_keyword_loc.end_offset() - else_keyword_loc.start_offset();
+    if keyword_len == 4 {
+        ps.emit_else();
 
         ps.new_block(|ps| {
             ps.emit_newline();
@@ -1162,7 +1164,7 @@ fn format_else_node(ps: &mut ParserState, else_node: prism::ElseNode) {
     } else {
         // In a ternary
         ps.emit_space();
-        ps.emit_conditional_keyword(keyword);
+        ps.emit_conditional_keyword(":");
         ps.emit_space();
         ps.with_start_of_line(false, |ps| {
             format_node(
@@ -2221,14 +2223,14 @@ fn format_float_node(ps: &mut ParserState, float_node: prism::FloatNode) {
 }
 
 fn format_for_node(ps: &mut ParserState, for_node: prism::ForNode) {
-    ps.emit_keyword("for".to_string());
+    ps.emit_keyword("for");
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
         format_node(ps, for_node.index());
 
         ps.emit_space();
-        ps.emit_keyword("in".to_string());
+        ps.emit_keyword("in");
         ps.emit_space();
 
         format_node(ps, for_node.collection());
@@ -2381,7 +2383,7 @@ fn format_inline_conditional(
     ps: &mut ParserState,
     predicate: prism::Node,
     statements: Option<prism::StatementsNode>,
-    keyword: String,
+    keyword: &'static str,
 ) {
     if let Some(statements) = statements {
         // There can only be a single statement in modifier form.
@@ -2453,7 +2455,7 @@ impl<'pr> Conditional<'pr> {
 
 fn format_conditional_node(
     ps: &mut ParserState,
-    conditional_keyword: &str,
+    conditional_keyword: &'static str,
     requires_end_keyword: bool,
     conditional: &Conditional,
 ) {
@@ -2473,7 +2475,7 @@ fn format_conditional_node(
         ps.with_start_of_line(false, |ps| {
             format_begin_node(ps, begin_node);
             ps.emit_space();
-            ps.emit_keyword(conditional_keyword.to_string());
+            ps.emit_keyword(conditional_keyword);
             ps.emit_space();
             format_node(ps, conditional.predicate());
         });
@@ -2508,7 +2510,7 @@ fn format_conditional_node(
                             next_ps,
                             predicate,
                             statements,
-                            conditional_keyword.to_string(),
+                            conditional_keyword,
                         )
                     })
                 }
@@ -2529,7 +2531,7 @@ fn format_conditional_node(
                 ps,
                 conditional.predicate(),
                 conditional.statements(),
-                conditional_keyword.to_string(),
+                conditional_keyword,
             );
         }
     } else {
@@ -2546,13 +2548,13 @@ fn format_conditional_node(
 
 fn format_conditional_block_form<'pr>(
     ps: &mut ParserState,
-    conditional_keyword: &str,
+    conditional_keyword: &'static str,
     predicate: prism::Node<'pr>,
     statements: Option<prism::StatementsNode<'pr>>,
     subsequent_or_else: Option<prism::Node<'pr>>,
     requires_end_keyword: bool,
 ) {
-    ps.emit_conditional_keyword(conditional_keyword.to_string());
+    ps.emit_conditional_keyword(conditional_keyword);
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -2584,15 +2586,15 @@ fn format_if_node(ps: &mut ParserState, if_node: prism::IfNode) {
     // If it's not there, this is actually a ternary, which is sufficiently
     // different that we handle it in its own branch
     if let Some(if_loc) = if_node.if_keyword_loc() {
-        let conditional_keyword = loc_to_string(if_loc);
-        // `elsif` nodes don't need an `else` keyword, that's handled
-        // by the parent `if` node.
-        let requires_end_keyword = &conditional_keyword == "if";
+        let is_if_keyword = (if_loc.end_offset() - if_loc.start_offset()) == 2;
+        let conditional_keyword = if is_if_keyword { "if" } else { "elsif" };
 
         format_conditional_node(
             ps,
-            &conditional_keyword,
-            requires_end_keyword,
+            conditional_keyword,
+            // `elsif` nodes don't need an `else` keyword, that's handled
+            // by the parent `if` node.
+            is_if_keyword,
             &Conditional::If(if_node),
         );
     } else {
@@ -3028,7 +3030,7 @@ fn format_pinned_variable_node(
 }
 
 fn format_post_execution_node(ps: &mut ParserState, post_execution_node: prism::PostExecutionNode) {
-    ps.emit_keyword("END".to_string());
+    ps.emit_keyword("END");
     ps.emit_space();
     ps.emit_open_curly_bracket();
 
@@ -3048,7 +3050,7 @@ fn format_post_execution_node(ps: &mut ParserState, post_execution_node: prism::
 }
 
 fn format_pre_execution_node(ps: &mut ParserState, pre_execution_node: prism::PreExecutionNode) {
-    ps.emit_keyword("BEGIN".to_string());
+    ps.emit_keyword("BEGIN");
     ps.emit_space();
     ps.emit_open_curly_bracket();
 
@@ -3112,7 +3114,7 @@ fn format_rescue_node(ps: &mut ParserState, rescue_node: prism::RescueNode) {
     // aren't always handled with `format_node`, which usually handles this
     ps.at_offset(rescue_node.location().start_offset());
 
-    ps.emit_keyword("rescue".to_string());
+    ps.emit_keyword("rescue");
     let exceptions = rescue_node.exceptions();
     if !node_list_is_empty(&exceptions) {
         ps.with_start_of_line(false, |ps| {
@@ -3155,7 +3157,7 @@ fn format_rescue_node(ps: &mut ParserState, rescue_node: prism::RescueNode) {
 }
 
 fn format_retry_node(ps: &mut ParserState) {
-    ps.emit_keyword("retry".to_string());
+    ps.emit_keyword("retry");
 }
 
 fn format_return_node(ps: &mut ParserState, return_node: prism::ReturnNode) {

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -27,13 +27,13 @@ pub fn clats_indent(depth: ColNumber) -> ConcreteLineTokenAndTargets {
 pub enum ConcreteLineToken {
     HardNewLine,
     Indent { depth: u32 },
-    Keyword { keyword: String },
+    Keyword { keyword: &'static str },
     DefKeyword,
     ClassKeyword,
     ModuleKeyword,
     DoKeyword,
-    ModKeyword { contents: String },
-    ConditionalKeyword { contents: String },
+    ModKeyword { contents: &'static str },
+    ConditionalKeyword { contents: &'static str },
     DirectPart { part: String },
     CommaSpace,
     Comma,
@@ -70,9 +70,9 @@ impl ConcreteLineToken {
         match self {
             Self::HardNewLine => Cow::Borrowed("\n"),
             Self::Indent { depth } => Cow::Owned((0..depth).map(|_| ' ').collect()),
-            Self::Keyword { keyword } => Cow::Owned(keyword),
-            Self::ModKeyword { contents } => Cow::Owned(contents),
-            Self::ConditionalKeyword { contents } => Cow::Owned(contents),
+            Self::Keyword { keyword } => Cow::Borrowed(keyword),
+            Self::ModKeyword { contents } => Cow::Borrowed(contents),
+            Self::ConditionalKeyword { contents } => Cow::Borrowed(contents),
             Self::DoKeyword => Cow::Borrowed("do"),
             Self::ClassKeyword => Cow::Borrowed("class"),
             Self::DefKeyword => Cow::Borrowed("def"),
@@ -121,13 +121,13 @@ impl ConcreteLineToken {
             Delim { contents } => contents.len(),
             Indent { depth } => *depth as usize,
             Keyword { keyword: contents }
-            | Op { op: contents }
+            | ModKeyword { contents }
+            | ConditionalKeyword { contents } => contents.len(),
+            Op { op: contents }
             | DirectPart { part: contents }
             | LTStringContent { content: contents }
             | Comment { contents }
-            | ConditionalKeyword { contents }
-            | HeredocClose { symbol: contents }
-            | ModKeyword { contents } => contents.len(),
+            | HeredocClose { symbol: contents } => contents.len(),
             HardNewLine | Comma | Space | Dot | OpenSquareBracket | CloseSquareBracket
             | OpenCurlyBracket | CloseCurlyBracket | OpenParen | CloseParen | SingleSlash
             | DoubleQuote => 1,
@@ -150,7 +150,7 @@ impl ConcreteLineToken {
 
     fn is_conditional_spaced_token(&self) -> bool {
         match self {
-            Self::ConditionalKeyword { contents } => !(contents == "else" || contents == "elsif"),
+            Self::ConditionalKeyword { contents } => !(*contents == "else" || *contents == "elsif"),
             Self::Dot => false,
             Self::DirectPart { part } => part != "&.",
             _ => true,

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -606,21 +606,15 @@ impl ParserState {
     }
 
     pub(crate) fn emit_rescue(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::Keyword {
-            keyword: "rescue".to_string(),
-        });
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "rescue" });
     }
 
     pub(crate) fn emit_case_keyword(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::Keyword {
-            keyword: "case".to_string(),
-        });
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "case" });
     }
 
     pub(crate) fn emit_when_keyword(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::Keyword {
-            keyword: "when".to_string(),
-        });
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "when" });
     }
 
     pub(crate) fn emit_do_keyword(&mut self) {
@@ -636,25 +630,19 @@ impl ParserState {
     }
 
     pub(crate) fn emit_ensure(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::Keyword {
-            keyword: "ensure".to_string(),
-        });
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "ensure" });
     }
 
     pub(crate) fn emit_begin(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::Keyword {
-            keyword: "begin".to_string(),
-        });
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "begin" });
     }
 
     pub(crate) fn emit_begin_block(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::Keyword {
-            keyword: "BEGIN".to_string(),
-        });
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "BEGIN" });
     }
 
     pub(crate) fn emit_else(&mut self) {
-        self.emit_conditional_keyword("else".to_string());
+        self.emit_conditional_keyword("else");
     }
 
     pub(crate) fn emit_data_end(&mut self) {
@@ -714,9 +702,7 @@ impl ParserState {
     }
 
     pub(crate) fn emit_end_block(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::Keyword {
-            keyword: "END".to_string(),
-        });
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "END" });
     }
 
     pub(crate) fn render_heredocs(&mut self, skip: bool) {
@@ -757,15 +743,15 @@ impl ParserState {
         self.push_concrete_token(ConcreteLineToken::DefKeyword);
     }
 
-    pub(crate) fn emit_keyword(&mut self, kw: String) {
-        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: kw });
+    pub(crate) fn emit_keyword(&mut self, keyword: &'static str) {
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword });
     }
 
-    pub(crate) fn emit_mod_keyword(&mut self, contents: String) {
+    pub(crate) fn emit_mod_keyword(&mut self, contents: &'static str) {
         self.push_concrete_token(ConcreteLineToken::ModKeyword { contents });
     }
 
-    pub(crate) fn emit_conditional_keyword(&mut self, contents: String) {
+    pub(crate) fn emit_conditional_keyword(&mut self, contents: &'static str) {
         self.push_concrete_token(ConcreteLineToken::ConditionalKeyword { contents });
     }
 }


### PR DESCRIPTION
On the tin -- follow on from #587. Keywords are another place where `&str` is the best choice, since we basically always know what it will be from the node type and we're never performing additional operations on them.