### PR TITLE
Don't `Box` closures for parser state methods

### DIFF
--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 
 use crate::delimiters::BreakableDelims;
 use crate::heredoc_string::HeredocKind;
-use crate::parser_state::{FormattingContext, ParserState, RenderFunc};
+use crate::parser_state::{FormattingContext, ParserState};
 use crate::render_targets::MultilineHandling;
 use crate::ripper_tree_types::*;
 use crate::types::LineNumber;
@@ -34,47 +34,35 @@ fn format_def_body(
     end_line: LineNumber,
 ) {
     let has_end = matches!(bodystmt, DefBodyStmt::EndBodyStmt(..));
-    ps.new_scope(Box::new(|ps| {
+    ps.new_scope(|ps| {
         format_paren_or_params(ps, pp);
 
-        ps.with_formatting_context(
-            FormattingContext::Def,
-            Box::new(|ps| match bodystmt {
-                DefBodyStmt::EndBodyStmt(bodystmt) => {
-                    ps.new_block(Box::new(|ps| {
-                        ps.emit_newline();
-                        ps.with_start_of_line(
-                            true,
-                            Box::new(|ps| {
-                                format_bodystmt(ps, Box::new(bodystmt), end_line);
-                            }),
-                        );
-                    }));
-                }
-                DefBodyStmt::EndlessBodyStmt(bodystmt) => {
-                    ps.emit_space();
-                    ps.emit_op("=".to_string());
-                    ps.emit_space();
+        ps.with_formatting_context(FormattingContext::Def, |ps| match bodystmt {
+            DefBodyStmt::EndBodyStmt(bodystmt) => {
+                ps.new_block(|ps| {
+                    ps.emit_newline();
+                    ps.with_start_of_line(true, |ps| {
+                        format_bodystmt(ps, Box::new(bodystmt), end_line);
+                    });
+                });
+            }
+            DefBodyStmt::EndlessBodyStmt(bodystmt) => {
+                ps.emit_space();
+                ps.emit_op("=".to_string());
+                ps.emit_space();
 
-                    ps.with_start_of_line(
-                        false,
-                        Box::new(|ps| {
-                            format_expression(ps, bodystmt.1);
-                        }),
-                    )
-                }
-            }),
-        );
-    }));
+                ps.with_start_of_line(false, |ps| {
+                    format_expression(ps, bodystmt.1);
+                })
+            }
+        });
+    });
 
     if has_end {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.wind_dumping_comments_until_line(end_line);
-                ps.emit_end();
-            }),
-        );
+        ps.with_start_of_line(true, |ps| {
+            ps.wind_dumping_comments_until_line(end_line);
+            ps.emit_end();
+        });
     }
 }
 
@@ -148,38 +136,32 @@ pub fn format_blockvar(ps: &mut ParserState, bv: BlockVar) {
         return;
     }
 
-    ps.new_block(Box::new(|ps| {
-        ps.breakable_of(
-            BreakableDelims::for_block_params(),
-            Box::new(|ps| {
-                if let Some(params) = params {
-                    inner_format_params(ps, params);
-                }
+    ps.new_block(|ps| {
+        ps.breakable_of(BreakableDelims::for_block_params(), |ps| {
+            if let Some(params) = params {
+                inner_format_params(ps, params);
+            }
 
-                match f_params {
-                    None => {}
-                    Some(f_params) => {
-                        if !f_params.is_empty() {
-                            ps.emit_ident(";".to_string());
+            match f_params {
+                None => {}
+                Some(f_params) => {
+                    if !f_params.is_empty() {
+                        ps.emit_ident(";".to_string());
 
-                            ps.with_start_of_line(
-                                false,
-                                Box::new(|ps| {
-                                    format_list_like_thing_items(
-                                        ps,
-                                        f_params.into_iter().map(Expression::Ident).collect(),
-                                        None,
-                                        true,
-                                    );
-                                }),
+                        ps.with_start_of_line(false, |ps| {
+                            format_list_like_thing_items(
+                                ps,
+                                f_params.into_iter().map(Expression::Ident).collect(),
+                                None,
+                                true,
                             );
-                        }
+                        });
                     }
                 }
-                ps.emit_collapsing_newline();
-            }),
-        );
-    }));
+            }
+            ps.emit_collapsing_newline();
+        });
+    });
 
     ps.on_line(start_end.end_line());
 }
@@ -192,14 +174,11 @@ pub fn format_params(ps: &mut ParserState, params: Box<Params>, delims: Breakabl
 
     let end_line = params.8.end_line();
 
-    ps.breakable_of(
-        delims,
-        Box::new(|ps| {
-            inner_format_params(ps, params);
-            ps.emit_collapsing_newline();
-            ps.wind_dumping_comments_until_line(end_line);
-        }),
-    );
+    ps.breakable_of(delims, |ps| {
+        inner_format_params(ps, params);
+        ps.emit_collapsing_newline();
+        ps.wind_dumping_comments_until_line(end_line);
+    });
 }
 
 pub fn format_kwrest_params(
@@ -212,18 +191,15 @@ pub fn format_kwrest_params(
 
     match kwrest_params.unwrap() {
         KwRestParamOrArgsForward::KwRestParam(kwrest_params) => {
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    ps.emit_soft_indent();
-                    ps.emit_ident("**".to_string());
-                    let ident = kwrest_params.1;
-                    if let Some(ident) = ident {
-                        bind_ident(ps, &ident);
-                        format_ident(ps, ident);
-                    }
-                }),
-            );
+            ps.with_start_of_line(false, |ps| {
+                ps.emit_soft_indent();
+                ps.emit_ident("**".to_string());
+                let ident = kwrest_params.1;
+                if let Some(ident) = ident {
+                    bind_ident(ps, &ident);
+                    format_ident(ps, ident);
+                }
+            });
         }
         KwRestParamOrArgsForward::ArgsForward(ArgsForward(..)) => ps.emit_ellipsis(),
     }
@@ -234,17 +210,14 @@ pub fn format_block_arg(ps: &mut ParserState, block_arg: Option<BlockArgOrTag>) 
     match block_arg {
         None | Some(BlockArgOrTag::Tag(..)) => false,
         Some(BlockArgOrTag::BlockArg(ba)) => {
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    ps.emit_soft_indent();
-                    ps.emit_ident("&".to_string());
-                    if let Some(ident) = ba.1 {
-                        bind_ident(ps, &ident);
-                        format_ident(ps, ident);
-                    }
-                }),
-            );
+            ps.with_start_of_line(false, |ps| {
+                ps.emit_soft_indent();
+                ps.emit_ident("&".to_string());
+                if let Some(ident) = ba.1 {
+                    bind_ident(ps, &ident);
+                    format_ident(ps, ident);
+                }
+            });
 
             true
         }
@@ -256,31 +229,28 @@ pub fn format_kwargs(ps: &mut ParserState, kwargs: Vec<(Label, ExpressionOrFalse
         return false;
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            let len = kwargs.len();
-            for (idx, (label, expr_or_false)) in kwargs.into_iter().enumerate() {
-                ps.emit_soft_indent();
-                ps.bind_variable(
-                    (label.1)
-                        .strip_suffix(':')
-                        .expect("Labels are passed through with trailing colons")
-                        .to_string(),
-                );
-                handle_string_and_linecol(ps, label.1, label.2);
+    ps.with_start_of_line(false, |ps| {
+        let len = kwargs.len();
+        for (idx, (label, expr_or_false)) in kwargs.into_iter().enumerate() {
+            ps.emit_soft_indent();
+            ps.bind_variable(
+                (label.1)
+                    .strip_suffix(':')
+                    .expect("Labels are passed through with trailing colons")
+                    .to_string(),
+            );
+            handle_string_and_linecol(ps, label.1, label.2);
 
-                match expr_or_false {
-                    ExpressionOrFalse::Expression(e) => {
-                        ps.emit_space();
-                        format_expression(ps, e);
-                    }
-                    ExpressionOrFalse::False(_) => {}
+            match expr_or_false {
+                ExpressionOrFalse::Expression(e) => {
+                    ps.emit_space();
+                    format_expression(ps, e);
                 }
-                emit_params_separator(ps, idx, len);
+                ExpressionOrFalse::False(_) => {}
             }
-        }),
-    );
+            emit_params_separator(ps, idx, len);
+        }
+    });
 
     true
 }
@@ -291,46 +261,40 @@ pub fn format_rest_param(
     special_case: SpecialCase,
 ) -> bool {
     let mut res = false;
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            match rest_param {
-                None => {}
-                Some(RestParamOr0OrExcessedComma::ExcessedComma(_)) => {}
-                Some(RestParamOr0OrExcessedComma::Zero(_)) => {}
-                Some(RestParamOr0OrExcessedComma::RestParam(rp)) => {
-                    if special_case != SpecialCase::RestParamOutsideOfParamDef {
-                        ps.emit_soft_indent();
-                    }
-                    ps.emit_ident("*".to_string());
-                    ps.with_start_of_line(
-                        false,
-                        Box::new(|ps| {
-                            match rp.1 {
-                                Some(RestParamAssignable::Ident(i)) => {
-                                    bind_ident(ps, &i);
-                                    format_ident(ps, i);
-                                }
-                                Some(RestParamAssignable::VarField(vf)) => {
-                                    bind_var_field(ps, &vf);
-                                    format_var_field(ps, vf);
-                                }
-                                Some(RestParamAssignable::ArefField(aref_field)) => {
-                                    // No need to bind, hash value must have been previously bound
-                                    format_aref_field(ps, aref_field);
-                                }
-                                None => {
-                                    // deliberately do nothing
-                                }
-                            }
-                        }),
-                    );
-
-                    res = true;
+    ps.with_start_of_line(false, |ps| {
+        match rest_param {
+            None => {}
+            Some(RestParamOr0OrExcessedComma::ExcessedComma(_)) => {}
+            Some(RestParamOr0OrExcessedComma::Zero(_)) => {}
+            Some(RestParamOr0OrExcessedComma::RestParam(rp)) => {
+                if special_case != SpecialCase::RestParamOutsideOfParamDef {
+                    ps.emit_soft_indent();
                 }
+                ps.emit_ident("*".to_string());
+                ps.with_start_of_line(false, |ps| {
+                    match rp.1 {
+                        Some(RestParamAssignable::Ident(i)) => {
+                            bind_ident(ps, &i);
+                            format_ident(ps, i);
+                        }
+                        Some(RestParamAssignable::VarField(vf)) => {
+                            bind_var_field(ps, &vf);
+                            format_var_field(ps, vf);
+                        }
+                        Some(RestParamAssignable::ArefField(aref_field)) => {
+                            // No need to bind, hash value must have been previously bound
+                            format_aref_field(ps, aref_field);
+                        }
+                        None => {
+                            // deliberately do nothing
+                        }
+                    }
+                });
+
+                res = true;
             }
-        }),
-    );
+        }
+    });
     res
 }
 
@@ -342,20 +306,17 @@ pub fn format_optional_params(
         return false;
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            let len = optional_params.len();
-            for (idx, (left, right)) in optional_params.into_iter().enumerate() {
-                ps.emit_soft_indent();
-                bind_ident(ps, &left);
-                format_ident(ps, left);
-                ps.emit_ident(" = ".to_string());
-                format_expression(ps, right);
-                emit_params_separator(ps, idx, len);
-            }
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        let len = optional_params.len();
+        for (idx, (left, right)) in optional_params.into_iter().enumerate() {
+            ps.emit_soft_indent();
+            bind_ident(ps, &left);
+            format_ident(ps, left);
+            ps.emit_ident(" = ".to_string());
+            format_expression(ps, right);
+            emit_params_separator(ps, idx, len);
+        }
+    });
 
     true
 }
@@ -363,32 +324,29 @@ pub fn format_optional_params(
 pub fn format_mlhs(ps: &mut ParserState, mlhs: MLhs) {
     ps.emit_open_paren();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            let mut first = true;
-            for inner in mlhs.0 {
-                if !first {
-                    ps.emit_comma_space();
-                }
-                first = false;
-
-                match inner {
-                    MLhsInner::Field(f) => format_field(ps, f),
-                    MLhsInner::Ident(i) => format_ident(ps, i),
-                    MLhsInner::RestParam(rp) => {
-                        format_rest_param(
-                            ps,
-                            Some(RestParamOr0OrExcessedComma::RestParam(rp)),
-                            SpecialCase::NoSpecialCase,
-                        );
-                    }
-                    MLhsInner::VarField(vf) => format_var_field(ps, vf),
-                    MLhsInner::MLhs(mlhs) => format_mlhs(ps, *mlhs),
-                }
+    ps.with_start_of_line(false, |ps| {
+        let mut first = true;
+        for inner in mlhs.0 {
+            if !first {
+                ps.emit_comma_space();
             }
-        }),
-    );
+            first = false;
+
+            match inner {
+                MLhsInner::Field(f) => format_field(ps, f),
+                MLhsInner::Ident(i) => format_ident(ps, i),
+                MLhsInner::RestParam(rp) => {
+                    format_rest_param(
+                        ps,
+                        Some(RestParamOr0OrExcessedComma::RestParam(rp)),
+                        SpecialCase::NoSpecialCase,
+                    );
+                }
+                MLhsInner::VarField(vf) => format_var_field(ps, vf),
+                MLhsInner::MLhs(mlhs) => format_mlhs(ps, *mlhs),
+            }
+        }
+    });
 
     ps.emit_close_paren();
 }
@@ -424,26 +382,23 @@ pub fn format_required_params(ps: &mut ParserState, required_params: Vec<IdentOr
         return false;
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            let len = required_params.len();
-            for (idx, ident) in required_params.into_iter().enumerate() {
-                ps.emit_soft_indent();
-                match ident {
-                    IdentOrMLhs::Ident(ident) => {
-                        bind_ident(ps, &ident);
-                        format_ident(ps, ident);
-                    }
-                    IdentOrMLhs::MLhs(mlhs) => {
-                        bind_mlhs(ps, &mlhs);
-                        format_mlhs(ps, mlhs);
-                    }
+    ps.with_start_of_line(false, |ps| {
+        let len = required_params.len();
+        for (idx, ident) in required_params.into_iter().enumerate() {
+            ps.emit_soft_indent();
+            match ident {
+                IdentOrMLhs::Ident(ident) => {
+                    bind_ident(ps, &ident);
+                    format_ident(ps, ident);
                 }
-                emit_params_separator(ps, idx, len);
+                IdentOrMLhs::MLhs(mlhs) => {
+                    bind_mlhs(ps, &mlhs);
+                    format_mlhs(ps, mlhs);
+                }
             }
-        }),
-    );
+            emit_params_separator(ps, idx, len);
+        }
+    });
     true
 }
 
@@ -537,31 +492,28 @@ pub fn format_rescue(ps: &mut ParserState, rescue_part: Option<Rescue>) {
         Some(Rescue(_, class, capture, expressions, more_rescue, start_end)) => {
             ps.on_line(start_end.start_line());
 
-            ps.dedent(Box::new(|ps| {
+            ps.dedent(|ps| {
                 ps.emit_indent();
                 ps.emit_rescue();
-                ps.with_start_of_line(
-                    false,
-                    Box::new(|ps| {
-                        if class.is_none()
-                            && capture.is_none()
-                            && expressions
-                                .as_ref()
-                                .map(|expr| !is_empty_bodystmt(expr))
-                                .unwrap_or(false)
-                        {
-                            return;
-                        }
-                        let cs = class.is_some();
-                        if cs || capture.is_some() {
-                            ps.emit_space();
-                        }
+                ps.with_start_of_line(false, |ps| {
+                    if class.is_none()
+                        && capture.is_none()
+                        && expressions
+                            .as_ref()
+                            .map(|expr| !is_empty_bodystmt(expr))
+                            .unwrap_or(false)
+                    {
+                        return;
+                    }
+                    let cs = class.is_some();
+                    if cs || capture.is_some() {
+                        ps.emit_space();
+                    }
 
-                        format_mrhs(ps, class);
-                        format_rescue_capture(ps, capture, cs);
-                    }),
-                );
-            }));
+                    format_mrhs(ps, class);
+                    format_rescue_capture(ps, capture, cs);
+                });
+            });
 
             match expressions {
                 None => {}
@@ -588,41 +540,35 @@ pub fn format_else(
     match else_part {
         None => {}
         Some(RescueElseOrExpressionList::ExpressionList(exprs)) => {
-            ps.dedent(Box::new(|ps| {
+            ps.dedent(|ps| {
                 ps.emit_indent();
                 ps.emit_else();
-            }));
+            });
             ps.emit_newline();
-            ps.with_start_of_line(
-                true,
-                Box::new(|ps| {
-                    for expr in exprs {
-                        format_expression(ps, expr);
-                    }
-                }),
-            );
+            ps.with_start_of_line(true, |ps| {
+                for expr in exprs {
+                    format_expression(ps, expr);
+                }
+            });
             ps.wind_dumping_comments_until_line(end_line);
         }
         Some(RescueElseOrExpressionList::RescueElse(re)) => {
             ps.on_line(re.2.start_line());
 
-            ps.dedent(Box::new(|ps| {
+            ps.dedent(|ps| {
                 ps.emit_indent();
                 ps.emit_else();
-            }));
+            });
 
             match re.1 {
                 None => {}
                 Some(exprs) => {
                     ps.emit_newline();
-                    ps.with_start_of_line(
-                        true,
-                        Box::new(|ps| {
-                            for expr in exprs {
-                                format_expression(ps, expr);
-                            }
-                        }),
-                    );
+                    ps.with_start_of_line(true, |ps| {
+                        for expr in exprs {
+                            format_expression(ps, expr);
+                        }
+                    });
                 }
             }
 
@@ -637,23 +583,20 @@ pub fn format_ensure(ps: &mut ParserState, ensure_part: Option<Ensure>) {
         Some(e) => {
             ps.on_line(e.2.start_line());
 
-            ps.dedent(Box::new(|ps| {
+            ps.dedent(|ps| {
                 ps.emit_indent();
                 ps.emit_ensure();
-            }));
+            });
 
             match e.1 {
                 None => {}
                 Some(exprs) => {
                     ps.emit_newline();
-                    ps.with_start_of_line(
-                        true,
-                        Box::new(|ps| {
-                            for expr in exprs {
-                                format_expression(ps, expr);
-                            }
-                        }),
-                    );
+                    ps.with_start_of_line(true, |ps| {
+                        for expr in exprs {
+                            format_expression(ps, expr);
+                        }
+                    });
                 }
             }
             ps.wind_dumping_comments_until_line(e.2.end_line());
@@ -821,12 +764,9 @@ pub fn format_method_call(ps: &mut ParserState, method_call: MethodCall) {
         CallChainElement::ArgsAddStarOrExpressionListOrArgsForward(args, start_end),
     ]);
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_call_chain(ps, chain, Some(use_parens));
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_call_chain(ps, chain, Some(use_parens));
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -851,7 +791,7 @@ pub fn format_list_like_thing_items(
         .iter()
         .any(|i| matches!(i, Expression::StringConcat(..)));
     let args_count = args.len();
-    let cls: RenderFunc = Box::new(|ps| {
+    let cls = |ps: &mut ParserState| {
         for (idx, expr) in args.into_iter().enumerate() {
             if single_line {
                 match expr {
@@ -862,32 +802,29 @@ pub fn format_list_like_thing_items(
                     ps.emit_comma_space();
                 }
             } else {
-                ps.with_start_of_line(
-                    false,
-                    Box::new(|ps| {
-                        match expr {
-                            Expression::BareAssocHash(bah) => format_assocs(
-                                ps,
-                                bah.1,
-                                SpecialCase::NoLeadingTrailingCollectionMarkers,
-                            ),
-                            expr => {
-                                ps.emit_soft_indent();
-                                format_expression(ps, expr);
-                            }
+                ps.with_start_of_line(false, |ps| {
+                    match expr {
+                        Expression::BareAssocHash(bah) => format_assocs(
+                            ps,
+                            bah.1,
+                            SpecialCase::NoLeadingTrailingCollectionMarkers,
+                        ),
+                        expr => {
+                            ps.emit_soft_indent();
+                            format_expression(ps, expr);
                         }
-                        if idx != args_count - 1 {
-                            ps.emit_comma();
-                            ps.emit_soft_newline();
-                        } else {
-                            ps.shift_comments();
-                        }
-                    }),
-                );
+                    }
+                    if idx != args_count - 1 {
+                        ps.emit_comma();
+                        ps.emit_soft_newline();
+                    } else {
+                        ps.shift_comments();
+                    }
+                });
             };
             emitted_args = true;
         }
-    });
+    };
 
     if skip_magic_comments {
         cls(ps)
@@ -944,14 +881,11 @@ pub fn format_alias(ps: &mut ParserState, alias: Alias) {
 
     ps.emit_ident("alias ".to_string());
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_symbol_literal_or_dyna_symbol(ps, alias.1);
-            ps.emit_space();
-            format_symbol_literal_or_dyna_symbol(ps, alias.2);
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_symbol_literal_or_dyna_symbol(ps, alias.1);
+        ps.emit_space();
+        format_symbol_literal_or_dyna_symbol(ps, alias.2);
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1032,16 +966,13 @@ pub fn format_symbol_literal(ps: &mut ParserState, symbol_literal: SymbolLiteral
 
     ps.on_line(symbol_literal.2.start_line());
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| match symbol_literal.1 {
-            SymbolOrBare::Ident(ident) => format_ident(ps, ident),
-            SymbolOrBare::Kw(kw) => format_kw(ps, kw),
-            SymbolOrBare::Op(op) => format_op(ps, op),
-            SymbolOrBare::Symbol(symbol) => format_symbol(ps, symbol),
-            SymbolOrBare::GVar(gvar) => format_var_ref_type(ps, VarRefType::GVar(gvar)),
-        }),
-    );
+    ps.with_start_of_line(false, |ps| match symbol_literal.1 {
+        SymbolOrBare::Ident(ident) => format_ident(ps, ident),
+        SymbolOrBare::Kw(kw) => format_kw(ps, kw),
+        SymbolOrBare::Op(op) => format_op(ps, op),
+        SymbolOrBare::Symbol(symbol) => format_symbol(ps, symbol),
+        SymbolOrBare::GVar(gvar) => format_var_ref_type(ps, VarRefType::GVar(gvar)),
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1085,42 +1016,39 @@ pub fn format_assocs_single_line(ps: &mut ParserState, assocs: Vec<AssocNewOrAss
 }
 
 pub fn format_assoc(ps: &mut ParserState, assoc: AssocNewOrAssocSplat, all_labelish: bool) {
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| match assoc {
-            AssocNewOrAssocSplat::AssocNew(new) => {
-                match new.1 {
-                    AssocKey::Label(label) => {
-                        if all_labelish {
-                            handle_string_and_linecol(ps, label.1, label.2);
-                        } else {
-                            let colonless_label = label
-                                .1
-                                .strip_suffix(':')
-                                .expect("labels end with a colon")
-                                .to_owned();
-                            format_symbol(ps, Symbol::from_string(colonless_label, label.2));
-                            ps.emit_space();
-                            ps.emit_ident("=>".to_string());
-                        }
-                    }
-                    AssocKey::Expression(expression) => {
-                        format_expression(ps, expression);
+    ps.with_start_of_line(false, |ps| match assoc {
+        AssocNewOrAssocSplat::AssocNew(new) => {
+            match new.1 {
+                AssocKey::Label(label) => {
+                    if all_labelish {
+                        handle_string_and_linecol(ps, label.1, label.2);
+                    } else {
+                        let colonless_label = label
+                            .1
+                            .strip_suffix(':')
+                            .expect("labels end with a colon")
+                            .to_owned();
+                        format_symbol(ps, Symbol::from_string(colonless_label, label.2));
                         ps.emit_space();
                         ps.emit_ident("=>".to_string());
                     }
                 }
-                if let Some(expr) = new.2 {
+                AssocKey::Expression(expression) => {
+                    format_expression(ps, expression);
                     ps.emit_space();
-                    format_expression(ps, expr);
+                    ps.emit_ident("=>".to_string());
                 }
             }
-            AssocNewOrAssocSplat::AssocSplat(splat) => {
-                ps.emit_ident("**".to_string());
-                format_expression(ps, splat.1);
+            if let Some(expr) = new.2 {
+                ps.emit_space();
+                format_expression(ps, expr);
             }
-        }),
-    );
+        }
+        AssocNewOrAssocSplat::AssocSplat(splat) => {
+            ps.emit_ident("**".to_string());
+            format_expression(ps, splat.1);
+        }
+    });
 }
 
 pub fn format_begin(ps: &mut ParserState, begin: Begin) {
@@ -1133,23 +1061,17 @@ pub fn format_begin(ps: &mut ParserState, begin: Begin) {
 
     ps.emit_begin();
 
-    ps.new_block(Box::new(|ps| {
+    ps.new_block(|ps| {
         ps.emit_newline();
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                format_bodystmt(ps, begin.2, end_line);
-                ps.wind_dumping_comments_until_line(end_line);
-            }),
-        );
-    }));
+        ps.with_start_of_line(true, |ps| {
+            format_bodystmt(ps, begin.2, end_line);
+            ps.wind_dumping_comments_until_line(end_line);
+        });
+    });
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_end();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        ps.emit_end();
+    });
     if ps.at_start_of_line() {
         ps.emit_newline();
     }
@@ -1165,23 +1087,17 @@ pub fn format_begin_block(ps: &mut ParserState, begin: BeginBlock) {
     ps.emit_space();
     ps.emit_open_curly_bracket();
     ps.emit_newline();
-    ps.new_block(Box::new(|ps| {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                for expr in begin.1 {
-                    format_expression(ps, expr);
-                }
-            }),
-        );
-    }));
+    ps.new_block(|ps| {
+        ps.with_start_of_line(true, |ps| {
+            for expr in begin.1 {
+                format_expression(ps, expr);
+            }
+        });
+    });
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_close_curly_bracket();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        ps.emit_close_curly_bracket();
+    });
     if ps.at_start_of_line() {
         ps.emit_newline();
     }
@@ -1198,23 +1114,17 @@ pub fn format_end_block(ps: &mut ParserState, end: EndBlock) {
     ps.emit_open_curly_bracket();
     ps.emit_newline();
 
-    ps.new_block(Box::new(|ps| {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                for expr in end.1 {
-                    format_expression(ps, expr);
-                }
-            }),
-        );
-    }));
+    ps.new_block(|ps| {
+        ps.with_start_of_line(true, |ps| {
+            for expr in end.1 {
+                format_expression(ps, expr);
+            }
+        });
+    });
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_close_curly_bracket();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        ps.emit_close_curly_bracket();
+    });
     if ps.at_start_of_line() {
         ps.emit_newline();
     }
@@ -1247,21 +1157,18 @@ pub fn format_paren(ps: &mut ParserState, paren: ParenExpr) {
         ParenExpressionOrExpressions::Expressions(exps) => {
             if exps.len() == 1 {
                 let p = exps.into_iter().next().expect("we know this isn't empty");
-                ps.with_start_of_line(false, Box::new(|ps| format_expression(ps, p)));
+                ps.with_start_of_line(false, |ps| format_expression(ps, p));
             } else {
                 // We don't have a line for the opening paren, so just wind until we see an expression
                 ps.wind_dumping_comments(None);
                 ps.emit_newline();
-                ps.new_block(Box::new(|ps| {
-                    ps.with_start_of_line(
-                        true,
-                        Box::new(|ps| {
-                            for expr in exps.into_iter() {
-                                format_expression(ps, expr);
-                            }
-                        }),
-                    );
-                }));
+                ps.new_block(|ps| {
+                    ps.with_start_of_line(true, |ps| {
+                        for expr in exps.into_iter() {
+                            format_expression(ps, expr);
+                        }
+                    });
+                });
                 ps.emit_indent();
             }
         }
@@ -1294,20 +1201,17 @@ pub fn format_dot2_or_3(
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            if let Some(expr) = left {
-                format_expression(ps, *expr)
-            }
+    ps.with_start_of_line(false, |ps| {
+        if let Some(expr) = left {
+            format_expression(ps, *expr)
+        }
 
-            ps.emit_ident(dots);
+        ps.emit_ident(dots);
 
-            if let Some(expr) = right {
-                format_expression(ps, *expr)
-            }
-        }),
-    );
+        if let Some(expr) = right {
+            format_expression(ps, *expr)
+        }
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1326,25 +1230,19 @@ pub fn percent_symbol_for(tag: String) -> String {
 
 pub fn format_percent_array(ps: &mut ParserState, tag: String, parts: Vec<Vec<StringContentPart>>) {
     ps.emit_ident(percent_symbol_for(tag));
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.breakable_of(
-                BreakableDelims::for_array(),
-                Box::new(|ps| {
-                    let parts_length = parts.len();
-                    for (idx, part) in parts.into_iter().enumerate() {
-                        ps.emit_soft_indent();
-                        format_inner_string(ps, part, StringType::Array);
-                        if idx != parts_length - 1 {
-                            ps.emit_soft_newline();
-                        }
-                    }
-                    ps.emit_collapsing_newline();
-                }),
-            );
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.breakable_of(BreakableDelims::for_array(), |ps| {
+            let parts_length = parts.len();
+            for (idx, part) in parts.into_iter().enumerate() {
+                ps.emit_soft_indent();
+                format_inner_string(ps, part, StringType::Array);
+                if idx != parts_length - 1 {
+                    ps.emit_soft_newline();
+                }
+            }
+            ps.emit_collapsing_newline();
+        });
+    });
 }
 
 pub fn format_array(ps: &mut ParserState, array: Array) {
@@ -1389,25 +1287,19 @@ pub fn format_array_fast_path(
         None => {
             let is_multiline = start_line != end_line;
             if is_multiline && ps.has_comments_in_line(start_line, end_line) {
-                ps.breakable_of(
-                    BreakableDelims::for_array(),
-                    Box::new(|ps| {
-                        ps.wind_dumping_comments_until_line(end_line);
-                    }),
-                );
+                ps.breakable_of(BreakableDelims::for_array(), |ps| {
+                    ps.wind_dumping_comments_until_line(end_line);
+                });
             } else {
                 ps.emit_open_square_bracket();
                 ps.emit_close_square_bracket();
             }
         }
         Some(a) => {
-            ps.breakable_of(
-                BreakableDelims::for_array(),
-                Box::new(|ps| {
-                    format_list_like_thing(ps, a, Some(end_line), false);
-                    ps.emit_collapsing_newline();
-                }),
-            );
+            ps.breakable_of(BreakableDelims::for_array(), |ps| {
+                format_list_like_thing(ps, a, Some(end_line), false);
+                ps.emit_collapsing_newline();
+            });
         }
     }
 }
@@ -1445,35 +1337,32 @@ pub fn format_list_like_thing(
 
             emitted_args = true;
 
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    ps.emit_ident("*".to_string());
-                    format_expression(ps, *star);
+            ps.with_start_of_line(false, |ps| {
+                ps.emit_ident("*".to_string());
+                format_expression(ps, *star);
 
-                    for expr in right {
-                        match expr {
-                            Expression::BareAssocHash(bah) => {
-                                ps.emit_comma();
-                                ps.emit_soft_newline();
-                                format_assocs(
-                                    ps,
-                                    bah.1,
-                                    SpecialCase::NoLeadingTrailingCollectionMarkers,
-                                );
-                            }
-                            e => {
-                                emit_intermediate_array_separator(ps, single_line);
-                                format_expression(ps, e);
-                            }
+                for expr in right {
+                    match expr {
+                        Expression::BareAssocHash(bah) => {
+                            ps.emit_comma();
+                            ps.emit_soft_newline();
+                            format_assocs(
+                                ps,
+                                bah.1,
+                                SpecialCase::NoLeadingTrailingCollectionMarkers,
+                            );
+                        }
+                        e => {
+                            emit_intermediate_array_separator(ps, single_line);
+                            format_expression(ps, e);
                         }
                     }
-                    if let Some(end_line) = end_line {
-                        ps.wind_dumping_comments_until_line(end_line);
-                        ps.shift_comments();
-                    }
-                }),
-            );
+                }
+                if let Some(end_line) = end_line {
+                    ps.wind_dumping_comments_until_line(end_line);
+                    ps.shift_comments();
+                }
+            });
 
             emitted_args
         }
@@ -1527,32 +1416,25 @@ fn format_inner_string(ps: &mut ParserState, parts: Vec<StringContentPart>, tipe
                     ps.emit_string_content(t.1);
                 }
             },
-            StringContentPart::StringEmbexpr(e) => ps.with_formatting_context(
-                FormattingContext::StringEmbexpr,
-                Box::new(|ps| {
+            StringContentPart::StringEmbexpr(e) => {
+                ps.with_formatting_context(FormattingContext::StringEmbexpr, |ps| {
                     ps.emit_string_content("#{".to_string());
                     // Embexpr must have at least one expression.
                     // If they have multiple, render them with an expression per line
                     // just like they are outside of embexprs.
                     if (e.1).len() == 1 {
-                        ps.with_start_of_line(
-                            false,
-                            Box::new(|ps| {
-                                format_expression(ps, (e.1).first().unwrap().to_owned());
-                            }),
-                        )
+                        ps.with_start_of_line(false, |ps| {
+                            format_expression(ps, (e.1).first().unwrap().to_owned());
+                        })
                     } else {
-                        ps.with_start_of_line(
-                            true,
-                            Box::new(|ps| {
-                                ps.new_block(Box::new(|ps| {
-                                    ps.emit_newline();
-                                    for expression in e.1 {
-                                        format_expression(ps, expression);
-                                    }
-                                }));
-                            }),
-                        );
+                        ps.with_start_of_line(true, |ps| {
+                            ps.new_block(|ps| {
+                                ps.emit_newline();
+                                for expression in e.1 {
+                                    format_expression(ps, expression);
+                                }
+                            });
+                        });
                     }
                     ps.emit_string_content("}".to_string());
 
@@ -1566,17 +1448,14 @@ fn format_inner_string(ps: &mut ParserState, parts: Vec<StringContentPart>, tipe
                     if on_line_skip {
                         ps.render_heredocs(true)
                     }
-                }),
-            ),
+                })
+            }
             StringContentPart::StringDVar(dv) => {
                 ps.emit_string_content("#{".to_string());
-                ps.with_start_of_line(
-                    false,
-                    Box::new(|ps| {
-                        let expr = *(dv.1);
-                        format_expression(ps, expr);
-                    }),
-                );
+                ps.with_start_of_line(false, |ps| {
+                    let expr = *(dv.1);
+                    format_expression(ps, expr);
+                });
                 ps.emit_string_content("}".to_string());
             }
         }
@@ -1595,25 +1474,17 @@ pub fn format_heredoc_string_literal(
     let end_line = hd.2.end_line();
     ps.on_line(hd.2.start_line());
 
-    ps.with_suppress_comments(
-        true,
-        Box::new(|ps| {
-            let heredoc_type = (hd.1).0;
-            let heredoc_symbol = (hd.1).1;
-            let kind = HeredocKind::from_string(&heredoc_type);
-            ps.emit_heredoc_start(format!("{}{}", heredoc_type, heredoc_symbol), kind);
+    ps.with_suppress_comments(true, |ps| {
+        let heredoc_type = (hd.1).0;
+        let heredoc_symbol = (hd.1).1;
+        let kind = HeredocKind::from_string(&heredoc_type);
+        ps.emit_heredoc_start(format!("{}{}", heredoc_type, heredoc_symbol), kind);
 
-            ps.push_heredoc_content(
-                heredoc_symbol,
-                kind,
-                end_line,
-                Box::new(|n: &mut ParserState| {
-                    n.disable_user_newlines();
-                    format_inner_string(n, parts, StringType::Heredoc);
-                }),
-            );
-        }),
-    );
+        ps.push_heredoc_content(heredoc_symbol, kind, end_line, |n: &mut ParserState| {
+            n.disable_user_newlines();
+            format_inner_string(n, parts, StringType::Heredoc);
+        });
+    });
 
     if ps.at_start_of_line() && !ps.is_absorbing_indents() {
         ps.emit_newline();
@@ -1664,14 +1535,11 @@ pub fn format_const_path_field(ps: &mut ParserState, cf: ConstPathField) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_expression(ps, *cf.1);
-            ps.emit_colon_colon();
-            format_const(ps, cf.2);
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_expression(ps, *cf.1);
+        ps.emit_colon_colon();
+        format_const(ps, cf.2);
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1683,13 +1551,10 @@ pub fn format_top_const_field(ps: &mut ParserState, tcf: TopConstField) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.emit_colon_colon();
-            format_const(ps, tcf.1);
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_colon_colon();
+        format_const(ps, tcf.1);
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1709,24 +1574,21 @@ pub fn format_aref_field(ps: &mut ParserState, af: ArefField) {
     // Aref fields are always on a single line, so we construct a single-line StartEnd here
     let start_end = StartEnd((af.3).0, (af.3).0);
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_expression(ps, *af.1);
+    ps.with_start_of_line(false, |ps| {
+        format_expression(ps, *af.1);
 
-            let index_expr = af.2;
-            let arr_contents = match index_expr {
-                None => None,
-                Some(ArgsAddBlockOrExpressionList::ArgsAddBlock(aab)) => {
-                    Some(aab.1.into_args_add_star_or_expression_list())
-                }
-                Some(ArgsAddBlockOrExpressionList::ExpressionList(expr_list)) => Some(
-                    ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(expr_list),
-                ),
-            };
-            format_array_fast_path(ps, &start_end, arr_contents);
-        }),
-    );
+        let index_expr = af.2;
+        let arr_contents = match index_expr {
+            None => None,
+            Some(ArgsAddBlockOrExpressionList::ArgsAddBlock(aab)) => {
+                Some(aab.1.into_args_add_star_or_expression_list())
+            }
+            Some(ArgsAddBlockOrExpressionList::ExpressionList(expr_list)) => Some(
+                ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(expr_list),
+            ),
+        };
+        format_array_fast_path(ps, &start_end, arr_contents);
+    });
 
     ps.wind_dumping_comments_until_line(start_end.end_line());
 
@@ -1740,17 +1602,14 @@ pub fn format_field(ps: &mut ParserState, f: Field) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_expression(ps, *f.1);
-            format_dot(ps, f.2);
-            match f.3 {
-                IdentOrConst::Const(c) => format_const(ps, c),
-                IdentOrConst::Ident(i) => format_ident(ps, i),
-            }
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_expression(ps, *f.1);
+        format_dot(ps, f.2);
+        match f.3 {
+            IdentOrConst::Const(c) => format_const(ps, c),
+            IdentOrConst::Ident(i) => format_ident(ps, i),
+        }
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1797,27 +1656,19 @@ pub fn format_assign(ps: &mut ParserState, assign: Assign) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_assignable(ps, assign.1);
-            let right = assign.2;
+    ps.with_start_of_line(false, |ps| {
+        format_assignable(ps, assign.1);
+        let right = assign.2;
 
-            ps.emit_space();
-            ps.emit_op("=".to_string());
-            ps.emit_space();
+        ps.emit_space();
+        ps.emit_op("=".to_string());
+        ps.emit_space();
 
-            ps.with_formatting_context(
-                FormattingContext::Assign,
-                Box::new(|ps| match right {
-                    ExpressionOrMRHSNewFromArgs::Expression(e) => format_expression(ps, *e),
-                    ExpressionOrMRHSNewFromArgs::MRHSNewFromArgs(m) => {
-                        format_mrhs_new_from_args(ps, m)
-                    }
-                }),
-            );
-        }),
-    );
+        ps.with_formatting_context(FormattingContext::Assign, |ps| match right {
+            ExpressionOrMRHSNewFromArgs::Expression(e) => format_expression(ps, *e),
+            ExpressionOrMRHSNewFromArgs::MRHSNewFromArgs(m) => format_mrhs_new_from_args(ps, m),
+        });
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1829,43 +1680,40 @@ pub fn format_massign(ps: &mut ParserState, massign: MAssign) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            match massign.1 {
-                AssignableListOrMLhs::AssignableList(al) => {
-                    let length = al.len();
-                    for (idx, v) in al.into_iter().enumerate() {
-                        let is_rest_param = matches!(v, Assignable::RestParam(..));
-                        format_assignable(ps, v);
-                        let last = idx == length - 1;
-                        if !last {
-                            ps.emit_comma_space();
-                        }
-                        // `*foo = []` is valid ruby, but
-                        // `*foo, = []` is not (but `foo, = []` is!),
-                        // so in cases where the only assignable is a rest param,
-                        // leave the comma out
-                        if length == 1 && !is_rest_param {
-                            ps.emit_comma();
-                        }
+    ps.with_start_of_line(false, |ps| {
+        match massign.1 {
+            AssignableListOrMLhs::AssignableList(al) => {
+                let length = al.len();
+                for (idx, v) in al.into_iter().enumerate() {
+                    let is_rest_param = matches!(v, Assignable::RestParam(..));
+                    format_assignable(ps, v);
+                    let last = idx == length - 1;
+                    if !last {
+                        ps.emit_comma_space();
+                    }
+                    // `*foo = []` is valid ruby, but
+                    // `*foo, = []` is not (but `foo, = []` is!),
+                    // so in cases where the only assignable is a rest param,
+                    // leave the comma out
+                    if length == 1 && !is_rest_param {
+                        ps.emit_comma();
                     }
                 }
-                AssignableListOrMLhs::MLhs(mlhs) => format_mlhs(ps, mlhs),
             }
-            ps.emit_space();
-            ps.emit_ident("=".to_string());
-            ps.emit_space();
-            match massign.2 {
-                MRHSOrArray::MRHS(mrhs) => {
-                    format_mrhs(ps, Some(mrhs));
-                }
-                MRHSOrArray::Array(array) => {
-                    format_array(ps, array);
-                }
+            AssignableListOrMLhs::MLhs(mlhs) => format_mlhs(ps, mlhs),
+        }
+        ps.emit_space();
+        ps.emit_ident("=".to_string());
+        ps.emit_space();
+        match massign.2 {
+            MRHSOrArray::MRHS(mrhs) => {
+                format_mrhs(ps, Some(mrhs));
             }
-        }),
-    );
+            MRHSOrArray::Array(array) => {
+                format_array(ps, array);
+            }
+        }
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1905,14 +1753,11 @@ pub fn format_const_path_ref(ps: &mut ParserState, cpr: ConstPathRef) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_expression(ps, *cpr.1);
-            ps.emit_colon_colon();
-            format_const(ps, cpr.2);
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_expression(ps, *cpr.1);
+        ps.emit_colon_colon();
+        format_const(ps, cpr.2);
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1924,13 +1769,10 @@ pub fn format_top_const_ref(ps: &mut ParserState, tcr: TopConstRef) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.emit_colon_colon();
-            format_const(ps, tcr.1);
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_colon_colon();
+        format_const(ps, tcr.1);
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1942,15 +1784,12 @@ pub fn format_defined(ps: &mut ParserState, defined: Defined) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.emit_ident("defined?".to_string());
-            ps.emit_open_paren();
-            format_expression(ps, *defined.1);
-            ps.emit_close_paren();
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_ident("defined?".to_string());
+        ps.emit_open_paren();
+        format_expression(ps, *defined.1);
+        ps.emit_close_paren();
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1962,16 +1801,13 @@ pub fn format_rescue_mod(ps: &mut ParserState, rescue_mod: RescueMod) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_expression(ps, *rescue_mod.1);
-            ps.emit_space();
-            ps.emit_rescue();
-            ps.emit_space();
-            format_expression(ps, *rescue_mod.2);
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_expression(ps, *rescue_mod.1);
+        ps.emit_space();
+        ps.emit_rescue();
+        ps.emit_space();
+        format_expression(ps, *rescue_mod.2);
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -1990,29 +1826,23 @@ pub fn format_mrhs_new_from_args(ps: &mut ParserState, mnfa: MRHSNewFromArgs) {
 pub fn format_mrhs_add_star(ps: &mut ParserState, mrhs: MRHSAddStar) {
     let first = mrhs.1;
     let second = mrhs.2;
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            match first {
-                MRHSNewFromArgsOrEmpty::Empty(e) => {
-                    if !e.is_empty() {
-                        panic!("this should be impossible, got non-empty mrhs empty");
-                    }
-                }
-                MRHSNewFromArgsOrEmpty::MRHSNewFromArgs(mnfa) => {
-                    format_mrhs_new_from_args(ps, mnfa);
-                    ps.emit_comma_space();
+    ps.with_start_of_line(false, |ps| {
+        match first {
+            MRHSNewFromArgsOrEmpty::Empty(e) => {
+                if !e.is_empty() {
+                    panic!("this should be impossible, got non-empty mrhs empty");
                 }
             }
-            ps.emit_ident("*".to_string());
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    format_expression(ps, *second);
-                }),
-            );
-        }),
-    );
+            MRHSNewFromArgsOrEmpty::MRHSNewFromArgs(mnfa) => {
+                format_mrhs_new_from_args(ps, mnfa);
+                ps.emit_comma_space();
+            }
+        }
+        ps.emit_ident("*".to_string());
+        ps.with_start_of_line(false, |ps| {
+            format_expression(ps, *second);
+        });
+    });
 }
 
 pub fn format_next(ps: &mut ParserState, next: Next) {
@@ -2020,36 +1850,33 @@ pub fn format_next(ps: &mut ParserState, next: Next) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.on_line((next.2).0);
-            ps.emit_ident("next".to_string());
-            match next.1 {
-                ArgsAddBlockOrExpressionList::ExpressionList(e) => {
-                    if !e.is_empty() {
-                        ps.emit_space();
-                        format_list_like_thing_items(ps, e, Some((next.2).1), true);
-                    }
+    ps.with_start_of_line(false, |ps| {
+        ps.on_line((next.2).0);
+        ps.emit_ident("next".to_string());
+        match next.1 {
+            ArgsAddBlockOrExpressionList::ExpressionList(e) => {
+                if !e.is_empty() {
+                    ps.emit_space();
+                    format_list_like_thing_items(ps, e, Some((next.2).1), true);
                 }
-                ArgsAddBlockOrExpressionList::ArgsAddBlock(aab) => match aab.2 {
-                    Some(ToProcExpr::Present(_)) => {
-                        panic!("got a block in a next, should be impossible");
-                    }
-                    None => unreachable!("got an anonymous block in a next, should be impossible"),
-                    Some(ToProcExpr::NotPresent(_)) => {
-                        ps.emit_space();
-                        format_list_like_thing(
-                            ps,
-                            (aab.1).into_args_add_star_or_expression_list(),
-                            Some((next.2).1),
-                            true,
-                        );
-                    }
-                },
             }
-        }),
-    );
+            ArgsAddBlockOrExpressionList::ArgsAddBlock(aab) => match aab.2 {
+                Some(ToProcExpr::Present(_)) => {
+                    panic!("got a block in a next, should be impossible");
+                }
+                None => unreachable!("got an anonymous block in a next, should be impossible"),
+                Some(ToProcExpr::NotPresent(_)) => {
+                    ps.emit_space();
+                    format_list_like_thing(
+                        ps,
+                        (aab.1).into_args_add_star_or_expression_list(),
+                        Some((next.2).1),
+                        true,
+                    );
+                }
+            },
+        }
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -2061,31 +1888,28 @@ pub fn format_unary(ps: &mut ParserState, unary: Unary) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            match unary.1 {
-                UnaryType::Not => {
-                    ps.emit_ident("not".to_string());
-                    ps.emit_space();
-                }
-                UnaryType::Positive => {
-                    ps.emit_ident("+".to_string());
-                }
-                UnaryType::Negative => {
-                    ps.emit_ident("-".to_string());
-                }
-                UnaryType::BooleanNot => {
-                    ps.emit_ident("!".to_string());
-                }
-                UnaryType::BitwiseNot => {
-                    ps.emit_ident("~".to_string());
-                }
+    ps.with_start_of_line(false, |ps| {
+        match unary.1 {
+            UnaryType::Not => {
+                ps.emit_ident("not".to_string());
+                ps.emit_space();
             }
+            UnaryType::Positive => {
+                ps.emit_ident("+".to_string());
+            }
+            UnaryType::Negative => {
+                ps.emit_ident("-".to_string());
+            }
+            UnaryType::BooleanNot => {
+                ps.emit_ident("!".to_string());
+            }
+            UnaryType::BitwiseNot => {
+                ps.emit_ident("~".to_string());
+            }
+        }
 
-            format_expression(ps, *unary.2);
-        }),
-    );
+        format_expression(ps, *unary.2);
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -2096,27 +1920,24 @@ pub fn format_string_concat(ps: &mut ParserState, sc: StringConcat) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }
-    ps.with_absorbing_indent_block(Box::new(|ps| {
+    ps.with_absorbing_indent_block(|ps| {
         let nested = sc.1;
         let sl = sc.2;
 
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                match nested {
-                    StringConcatOrStringLiteral::StringConcat(sc) => format_string_concat(ps, *sc),
-                    StringConcatOrStringLiteral::StringLiteral(sl) => format_string_literal(ps, sl),
-                }
+        ps.with_start_of_line(false, |ps| {
+            match nested {
+                StringConcatOrStringLiteral::StringConcat(sc) => format_string_concat(ps, *sc),
+                StringConcatOrStringLiteral::StringLiteral(sl) => format_string_literal(ps, sl),
+            }
 
-                ps.emit_space();
-                ps.emit_slash();
-                ps.emit_newline();
+            ps.emit_space();
+            ps.emit_slash();
+            ps.emit_newline();
 
-                ps.emit_indent();
-                format_string_literal(ps, sl);
-            }),
-        );
-    }));
+            ps.emit_indent();
+            format_string_literal(ps, sl);
+        });
+    });
     if ps.at_start_of_line() && !ps.is_absorbing_indents() {
         ps.emit_newline();
     }
@@ -2128,12 +1949,9 @@ pub fn format_dyna_symbol(ps: &mut ParserState, ds: DynaSymbol) {
     }
 
     ps.emit_ident(":".to_string());
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_string_literal(ps, ds.to_string_literal());
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_string_literal(ps, ds.to_string_literal());
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -2148,10 +1966,9 @@ pub fn format_undef(ps: &mut ParserState, undef: Undef) {
     ps.emit_ident("undef ".to_string());
     let length = undef.1.len();
     for (idx, literal) in undef.1.into_iter().enumerate() {
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| format_symbol_literal_or_dyna_symbol(ps, literal)),
-        );
+        ps.with_start_of_line(false, |ps| {
+            format_symbol_literal_or_dyna_symbol(ps, literal)
+        });
         if idx != length - 1 {
             ps.emit_comma_space();
         }
@@ -2176,26 +1993,23 @@ pub fn format_defs(ps: &mut ParserState, defs: Defs) {
     ps.emit_def_keyword();
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            match singleton {
-                Singleton::VarRef(vr) => {
-                    format_var_ref(ps, vr);
-                }
-                Singleton::Paren(pe) => {
-                    format_paren(ps, pe);
-                }
-                Singleton::VCall(vc) => {
-                    format_method_call(ps, vc.to_method_call());
-                }
+    ps.with_start_of_line(false, |ps| {
+        match singleton {
+            Singleton::VarRef(vr) => {
+                format_var_ref(ps, vr);
             }
+            Singleton::Paren(pe) => {
+                format_paren(ps, pe);
+            }
+            Singleton::VCall(vc) => {
+                format_method_call(ps, vc.to_method_call());
+            }
+        }
 
-            ps.emit_dot();
-            let (ident, linecol) = ident_or_kw.to_def_parts();
-            handle_string_and_linecol(ps, ident, linecol);
-        }),
-    );
+        ps.emit_dot();
+        let (ident, linecol) = ident_or_kw.to_def_parts();
+        handle_string_and_linecol(ps, ident, linecol);
+    });
 
     format_def_body(ps, paren_or_params, *bodystmt, end_line);
 
@@ -2224,28 +2038,19 @@ pub fn format_paren_or_params(ps: &mut ParserState, pp: ParenOrParams) {
 // Modules and classes bodies should be treated the same,
 // the only real difference is in the module/class name and inheritance
 fn format_constant_body(ps: &mut ParserState, bodystmt: Box<BodyStmt>, end_line: u64) {
-    ps.new_block(Box::new(|ps| {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.with_formatting_context(
-                    FormattingContext::ClassOrModule,
-                    Box::new(|ps| {
-                        ps.emit_newline();
-                        format_bodystmt(ps, bodystmt, end_line);
-                    }),
-                );
-            }),
-        );
-    }));
+    ps.new_block(|ps| {
+        ps.with_start_of_line(true, |ps| {
+            ps.with_formatting_context(FormattingContext::ClassOrModule, |ps| {
+                ps.emit_newline();
+                format_bodystmt(ps, bodystmt, end_line);
+            });
+        });
+    });
 
     ps.on_line(end_line);
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_end();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        ps.emit_end();
+    });
     if ps.at_start_of_line() {
         ps.emit_newline();
     }
@@ -2262,29 +2067,24 @@ pub fn format_class(ps: &mut ParserState, class: Class) {
     let end_line = (class.4).1;
 
     ps.emit_class_keyword();
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.emit_space();
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_space();
 
-            match class_name {
-                ConstPathRefOrConstRefOrTopConstRef::ConstPathRef(cpr) => {
-                    format_const_path_ref(ps, cpr);
-                }
-                ConstPathRefOrConstRefOrTopConstRef::ConstRef(cr) => {
-                    handle_string_and_linecol(ps, (cr.1).1, (cr.1).2);
-                }
-                ConstPathRefOrConstRefOrTopConstRef::TopConstRef(tcr) => {
-                    format_top_const_ref(ps, tcr)
-                }
+        match class_name {
+            ConstPathRefOrConstRefOrTopConstRef::ConstPathRef(cpr) => {
+                format_const_path_ref(ps, cpr);
             }
+            ConstPathRefOrConstRefOrTopConstRef::ConstRef(cr) => {
+                handle_string_and_linecol(ps, (cr.1).1, (cr.1).2);
+            }
+            ConstPathRefOrConstRefOrTopConstRef::TopConstRef(tcr) => format_top_const_ref(ps, tcr),
+        }
 
-            if let Some(inherit_expression) = inherit {
-                ps.emit_ident(" < ".to_string());
-                format_expression(ps, *inherit_expression);
-            }
-        }),
-    );
+        if let Some(inherit_expression) = inherit {
+            ps.emit_ident(" < ".to_string());
+            format_expression(ps, *inherit_expression);
+        }
+    });
 
     format_constant_body(ps, bodystmt, end_line);
 }
@@ -2299,24 +2099,19 @@ pub fn format_module(ps: &mut ParserState, module: Module) {
     let end_line = (module.3).1;
 
     ps.emit_module_keyword();
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.emit_space();
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_space();
 
-            match module_name {
-                ConstPathRefOrConstRefOrTopConstRef::ConstPathRef(cpr) => {
-                    format_const_path_ref(ps, cpr);
-                }
-                ConstPathRefOrConstRefOrTopConstRef::ConstRef(cr) => {
-                    handle_string_and_linecol(ps, (cr.1).1, (cr.1).2);
-                }
-                ConstPathRefOrConstRefOrTopConstRef::TopConstRef(tcr) => {
-                    format_top_const_ref(ps, tcr)
-                }
+        match module_name {
+            ConstPathRefOrConstRefOrTopConstRef::ConstPathRef(cpr) => {
+                format_const_path_ref(ps, cpr);
             }
-        }),
-    );
+            ConstPathRefOrConstRefOrTopConstRef::ConstRef(cr) => {
+                handle_string_and_linecol(ps, (cr.1).1, (cr.1).2);
+            }
+            ConstPathRefOrConstRefOrTopConstRef::TopConstRef(tcr) => format_top_const_ref(ps, tcr),
+        }
+    });
 
     format_constant_body(ps, bodystmt, end_line);
 }
@@ -2337,61 +2132,49 @@ pub fn format_conditional(
     }
     ps.emit_conditional_keyword(kw);
     ps.emit_space();
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.new_block(Box::new(|ps| {
-                format_expression(ps, cond_expr);
-            }))
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.new_block(|ps| {
+            format_expression(ps, cond_expr);
+        });
+    });
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.new_block(Box::new(|ps| {
+    ps.with_start_of_line(true, |ps| {
+        ps.new_block(|ps| {
+            ps.emit_newline();
+            for expr in body.into_iter() {
+                format_expression(ps, expr);
+            }
+        });
+    });
+    ps.with_start_of_line(true, |ps| match tail {
+        None => {}
+        Some(ElsifOrElse::Elsif(elsif)) => {
+            format_conditional(
+                ps,
+                *elsif.1,
+                elsif.2,
+                "elsif".to_string(),
+                (elsif.3).map(|v| *v),
+                Some(elsif.4),
+            );
+        }
+        Some(ElsifOrElse::Else(els)) => {
+            ps.emit_indent();
+            ps.emit_else();
+            ps.new_block(|ps| {
+                ps.on_line(els.2.start_line());
                 ps.emit_newline();
-                for expr in body.into_iter() {
-                    format_expression(ps, expr);
-                }
-            }));
-        }),
-    );
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| match tail {
-            None => {}
-            Some(ElsifOrElse::Elsif(elsif)) => {
-                format_conditional(
-                    ps,
-                    *elsif.1,
-                    elsif.2,
-                    "elsif".to_string(),
-                    (elsif.3).map(|v| *v),
-                    Some(elsif.4),
-                );
-            }
-            Some(ElsifOrElse::Else(els)) => {
-                ps.emit_indent();
-                ps.emit_else();
-                ps.new_block(Box::new(|ps| {
-                    ps.on_line(els.2.start_line());
-                    ps.emit_newline();
-                }));
-                ps.with_start_of_line(
-                    true,
-                    Box::new(|ps| {
-                        ps.new_block(Box::new(|ps| {
-                            for expr in els.1 {
-                                format_expression(ps, expr);
-                            }
-                            ps.wind_dumping_comments_until_line(els.2.end_line());
-                        }));
-                    }),
-                );
-            }
-        }),
-    );
+            });
+            ps.with_start_of_line(true, |ps| {
+                ps.new_block(|ps| {
+                    for expr in els.1 {
+                        format_expression(ps, expr);
+                    }
+                    ps.wind_dumping_comments_until_line(els.2.end_line());
+                });
+            });
+        }
+    });
 
     if let Some(StartEnd(_, end_line)) = start_end {
         ps.wind_dumping_comments_until_line(end_line);
@@ -2402,13 +2185,10 @@ pub fn format_if(ps: &mut ParserState, ifs: If) {
     let vifs = ifs.clone();
     format_conditional(ps, *ifs.1, ifs.2, "if".to_string(), ifs.3, Some(ifs.4));
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.wind_dumping_comments_until_line(vifs.4.1);
-            ps.emit_end();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        ps.wind_dumping_comments_until_line(vifs.4.1);
+        ps.emit_end();
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -2424,12 +2204,9 @@ pub fn format_unless(ps: &mut ParserState, unless: Unless) {
         (unless.3).map(ElsifOrElse::Else),
         Some(unless.4),
     );
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_end();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        ps.emit_end();
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -2450,12 +2227,9 @@ pub fn format_binary(ps: &mut ParserState, binary: Binary) {
         ps.on_line(binary.2.1.start_line());
     }
 
-    ps.inline_breakable_of(
-        BreakableDelims::for_binary_op(),
-        Box::new(|ps| {
-            format_binary_inner(ps, binary);
-        }),
-    );
+    ps.inline_breakable_of(BreakableDelims::for_binary_op(), |ps| {
+        format_binary_inner(ps, binary);
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -2466,49 +2240,43 @@ pub fn format_binary(ps: &mut ParserState, binary: Binary) {
 // inside of a breakable, but it's separated out so that it can recurse inside of
 // nested breakables so that nested breakables stay at the same indentation level.
 fn format_binary_inner(ps: &mut ParserState, binary: Binary) {
-    ps.with_formatting_context(
-        FormattingContext::Binary,
-        Box::new(|ps| {
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    let op = binary.2;
-                    let left_hand_side = *binary.1;
+    ps.with_formatting_context(FormattingContext::Binary, |ps| {
+        ps.with_start_of_line(false, |ps| {
+            let op = binary.2;
+            let left_hand_side = *binary.1;
 
-                    if let Expression::Binary(bin) = left_hand_side {
-                        format_binary_inner(ps, bin);
-                    } else {
-                        ps.dedent(Box::new(|ps| {
-                            format_expression(ps, left_hand_side);
-                        }));
-                    }
+            if let Expression::Binary(bin) = left_hand_side {
+                format_binary_inner(ps, bin);
+            } else {
+                ps.dedent(|ps| {
+                    format_expression(ps, left_hand_side);
+                });
+            }
 
-                    let comparison_operators = [">", ">=", "===", "==", "<", "<=", "<=>", "!="];
-                    let is_not_comparison = !comparison_operators.iter().any(|o| o == &op.0);
+            let comparison_operators = [">", ">=", "===", "==", "<", "<=", "<=>", "!="];
+            let is_not_comparison = !comparison_operators.iter().any(|o| o == &op.0);
 
-                    let next_expr = *binary.3;
+            let next_expr = *binary.3;
 
-                    ps.emit_space();
-                    ps.emit_ident(op.0);
-                    if is_not_comparison {
-                        ps.emit_soft_newline();
-                        ps.emit_soft_indent();
-                    } else {
-                        ps.emit_space();
-                    }
-                    // In some cases, previous expressions changed the space
-                    // count but haven't reset it, so we force a reset here in
-                    // case we shift comments during the _next_ expression
-                    ps.reset_space_count();
-                    if let Expression::Binary(bin) = next_expr {
-                        format_binary_inner(ps, bin);
-                    } else {
-                        format_expression(ps, next_expr);
-                    }
-                }),
-            );
-        }),
-    );
+            ps.emit_space();
+            ps.emit_ident(op.0);
+            if is_not_comparison {
+                ps.emit_soft_newline();
+                ps.emit_soft_indent();
+            } else {
+                ps.emit_space();
+            }
+            // In some cases, previous expressions changed the space
+            // count but haven't reset it, so we force a reset here in
+            // case we shift comments during the _next_ expression
+            ps.reset_space_count();
+            if let Expression::Binary(bin) = next_expr {
+                format_binary_inner(ps, bin);
+            } else {
+                format_expression(ps, next_expr);
+            }
+        });
+    });
 }
 
 pub fn format_float(ps: &mut ParserState, float: Float) {
@@ -2531,22 +2299,19 @@ pub fn format_aref(ps: &mut ParserState, aref: Aref) {
     // Aref fields are always on a single line, so we construct a single-line StartEnd here
     let start_end = StartEnd((aref.3).0, (aref.3).0);
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_expression(ps, *aref.1);
-            match aref.2 {
-                None => {
-                    ps.emit_open_square_bracket();
-                    ps.emit_close_square_bracket();
-                }
-                Some(arg_node) => {
-                    let args_list = normalize_args(arg_node);
-                    format_array_fast_path(ps, &start_end, Some(args_list));
-                }
+    ps.with_start_of_line(false, |ps| {
+        format_expression(ps, *aref.1);
+        match aref.2 {
+            None => {
+                ps.emit_open_square_bracket();
+                ps.emit_close_square_bracket();
             }
-        }),
-    );
+            Some(arg_node) => {
+                let args_list = normalize_args(arg_node);
+                format_array_fast_path(ps, &start_end, Some(args_list));
+            }
+        }
+    });
 
     ps.wind_dumping_comments_until_line(start_end.end_line());
 
@@ -2587,25 +2352,19 @@ pub fn format_hash(ps: &mut ParserState, hash: Hash) {
                 // a breakable and know that it will always be the multiline form
                 // instead of manually inserting all of the newlines/indents for
                 // a multiline hash
-                ps.breakable_of(
-                    BreakableDelims::for_hash(),
-                    Box::new(|ps| {
-                        ps.wind_dumping_comments_until_line(end_line);
-                    }),
-                );
+                ps.breakable_of(BreakableDelims::for_hash(), |ps| {
+                    ps.wind_dumping_comments_until_line(end_line);
+                });
             } else {
                 ps.emit_ident("{}".to_string());
                 ps.wind_dumping_comments_until_line(end_line);
             }
         }
         Some(assoc_list_from_args) => {
-            ps.breakable_of(
-                BreakableDelims::for_hash(),
-                Box::new(|ps| {
-                    format_assocs(ps, assoc_list_from_args.1, SpecialCase::NoSpecialCase);
-                    ps.wind_dumping_comments_until_line(end_line);
-                }),
-            );
+            ps.breakable_of(BreakableDelims::for_hash(), |ps| {
+                format_assocs(ps, assoc_list_from_args.1, SpecialCase::NoSpecialCase);
+                ps.wind_dumping_comments_until_line(end_line);
+            });
         }
     };
 
@@ -2699,10 +2458,9 @@ fn format_call_chain(
         ps.on_line(first_elem_line);
     }
 
-    ps.breakable_call_chain_of(
-        MultilineHandling::Ripper(cc.clone()),
-        Box::new(|ps| format_call_chain_elements(ps, cc, last_call_use_parens)),
-    );
+    ps.breakable_call_chain_of(MultilineHandling::Ripper(cc.clone()), |ps| {
+        format_call_chain_elements(ps, cc, last_call_use_parens)
+    });
 
     ps.emit_after_call_chain();
 }
@@ -2790,12 +2548,9 @@ fn format_call_chain_elements(
                             ps.shift_comments();
                         }
                     } else {
-                        ps.breakable_of(
-                            delims,
-                            Box::new(|ps| {
-                                format_list_like_thing(ps, aas, end_line, false);
-                            }),
-                        );
+                        ps.breakable_of(delims, |ps| {
+                            format_list_like_thing(ps, aas, end_line, false);
+                        });
                         if let Some(end_line) = end_line {
                             // If we're rendering a single-line chain, force a reset so
                             // that comments end up at the current indentation level
@@ -2853,12 +2608,9 @@ pub fn format_method_add_block(ps: &mut ParserState, mab: MethodAddBlock) {
     let mut chain = (mab.1).into_call_chain();
     chain.push(CallChainElement::Block(mab.2));
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_call_chain(ps, chain, None);
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_call_chain(ps, chain, None);
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -2908,16 +2660,13 @@ pub fn format_brace_block(ps: &mut ParserState, brace_block: BraceBlock) {
 
     let brace_block_render_method = get_brace_block_render_method(ps, start_line, end_line, &body);
 
-    ps.inline_breakable_of(
-        BreakableDelims::for_brace_block(),
-        Box::new(|ps| {
-            if let Some(bv) = bv {
-                format_blockvar(ps, bv);
-            }
+    ps.inline_breakable_of(BreakableDelims::for_brace_block(), |ps| {
+        if let Some(bv) = bv {
+            format_blockvar(ps, bv);
+        }
 
-            render_block_contents(ps, brace_block_render_method, body, end_line);
-        }),
-    );
+        render_block_contents(ps, brace_block_render_method, body, end_line);
+    });
 }
 
 fn render_block_contents(
@@ -2939,7 +2688,7 @@ fn render_block_contents(
             ps.wind_dumping_comments_until_line(end_line);
             ps.shift_comments();
             // Force the closing brace on indentation back
-            ps.dedent(Box::new(|ps| ps.emit_soft_indent()));
+            ps.dedent(|ps| ps.emit_soft_indent());
             return;
         }
         BraceBlockRenderMethod::NoCommentsOrExpressions => {
@@ -2961,23 +2710,20 @@ fn render_block_contents(
         }
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            let mut peekable = body.into_iter().peekable();
-            while peekable.peek().is_some() {
-                format_expression(ps, peekable.next().unwrap());
-                ps.emit_soft_newline();
-                if peekable.peek().is_some() {
-                    ps.emit_soft_indent();
-                }
+    ps.with_start_of_line(false, |ps| {
+        let mut peekable = body.into_iter().peekable();
+        while peekable.peek().is_some() {
+            format_expression(ps, peekable.next().unwrap());
+            ps.emit_soft_newline();
+            if peekable.peek().is_some() {
+                ps.emit_soft_indent();
             }
-            ps.shift_comments();
-        }),
-    );
+        }
+        ps.shift_comments();
+    });
     // This is assuming that we're always inside of an `inline_breakable_of` block, which
     // doesn't handle the indentation for the closing delimeter for us.
-    ps.dedent(Box::new(|ps| ps.emit_soft_indent()));
+    ps.dedent(|ps| ps.emit_soft_indent());
 
     ps.wind_dumping_comments_until_line(end_line);
 }
@@ -3015,24 +2761,18 @@ pub fn format_do_block(ps: &mut ParserState, do_block: DoBlock) {
         format_blockvar(ps, bv)
     }
 
-    ps.new_block(Box::new(|ps| {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.emit_newline();
-                format_bodystmt(ps, body, end_line);
-            }),
-        );
-    }));
+    ps.new_block(|ps| {
+        ps.with_start_of_line(true, |ps| {
+            ps.emit_newline();
+            format_bodystmt(ps, body, end_line);
+        });
+    });
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.wind_dumping_comments_until_line(end_line);
-            ps.emit_end();
-            ps.shift_comments();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        ps.wind_dumping_comments_until_line(end_line);
+        ps.emit_end();
+        ps.shift_comments();
+    });
 }
 
 pub fn format_keyword(
@@ -3075,17 +2815,14 @@ pub fn format_keyword(
     };
     ps.on_line(start_end.0);
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_list_like_thing(
-                ps,
-                (yield_args.1).into_args_add_star_or_expression_list(),
-                Some(start_end.1),
-                true,
-            );
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_list_like_thing(
+            ps,
+            (yield_args.1).into_args_add_star_or_expression_list(),
+            Some(start_end.1),
+            true,
+        );
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -3101,12 +2838,9 @@ pub fn format_while(
 ) {
     format_conditional(ps, conditional, exprs, kw, None, Some(start_end));
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_end();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        ps.emit_end();
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -3139,15 +2873,12 @@ pub fn format_inline_mod(
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_expression(ps, *body);
+    ps.with_start_of_line(false, |ps| {
+        format_expression(ps, *body);
 
-            ps.emit_mod_keyword(format!(" {} ", name));
-            format_expression(ps, *conditional);
-        }),
-    );
+        ps.emit_mod_keyword(format!(" {} ", name));
+        format_expression(ps, *conditional);
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -3162,9 +2893,9 @@ pub fn format_multilinable_mod(
     body: Box<Expression>,
     name: String,
 ) {
-    let is_multiline = ps.will_render_as_multiline(Box::new(|next_ps| {
+    let is_multiline = ps.will_render_as_multiline(|next_ps| {
         format_inline_mod(next_ps, conditional.clone(), body.clone(), name.clone())
-    }));
+    });
 
     if is_multiline {
         let exps = match *body {
@@ -3176,12 +2907,9 @@ pub fn format_multilinable_mod(
         };
         format_conditional(ps, *conditional, exps, name, None, None);
 
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.emit_end();
-            }),
-        );
+        ps.with_start_of_line(true, |ps| {
+            ps.emit_end();
+        });
 
         if ps.at_start_of_line() {
             ps.emit_newline();
@@ -3202,32 +2930,23 @@ pub fn format_when_or_else(ps: &mut ParserState, tail: WhenOrElse) {
             ps.emit_indent();
             ps.emit_when_keyword();
 
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    ps.new_block(Box::new(|ps| {
-                        ps.inline_breakable_of(
-                            BreakableDelims::for_when(),
-                            Box::new(|ps| {
-                                ps.emit_collapsing_newline();
-                                format_list_like_thing(ps, conditionals, None, false);
-                            }),
-                        );
-                    }));
-                }),
-            );
+            ps.with_start_of_line(false, |ps| {
+                ps.new_block(|ps| {
+                    ps.inline_breakable_of(BreakableDelims::for_when(), |ps| {
+                        ps.emit_collapsing_newline();
+                        format_list_like_thing(ps, conditionals, None, false);
+                    });
+                });
+            });
 
-            ps.new_block(Box::new(|ps| {
-                ps.with_start_of_line(
-                    true,
-                    Box::new(|ps| {
-                        ps.emit_newline();
-                        for expr in body {
-                            format_expression(ps, expr);
-                        }
-                    }),
-                );
-            }));
+            ps.new_block(|ps| {
+                ps.with_start_of_line(true, |ps| {
+                    ps.emit_newline();
+                    for expr in body {
+                        format_expression(ps, expr);
+                    }
+                });
+            });
 
             if let Some(tail) = tail {
                 format_when_or_else(ps, *tail);
@@ -3237,20 +2956,17 @@ pub fn format_when_or_else(ps: &mut ParserState, tail: WhenOrElse) {
             ps.emit_indent();
             ps.emit_else();
 
-            ps.new_block(Box::new(|ps| {
-                ps.with_start_of_line(
-                    true,
-                    Box::new(|ps| {
-                        ps.on_line(e.2.start_line());
-                        ps.emit_newline();
-                        for expr in e.1 {
-                            format_expression(ps, expr);
-                        }
+            ps.new_block(|ps| {
+                ps.with_start_of_line(true, |ps| {
+                    ps.on_line(e.2.start_line());
+                    ps.emit_newline();
+                    for expr in e.1 {
+                        format_expression(ps, expr);
+                    }
 
-                        ps.wind_dumping_comments_until_line(e.2.end_line());
-                    }),
-                );
-            }));
+                    ps.wind_dumping_comments_until_line(e.2.end_line());
+                });
+            });
         }
     }
 }
@@ -3268,23 +2984,17 @@ pub fn format_case(ps: &mut ParserState, case: Case) {
     let tail = case.2;
 
     if let Some(e) = case_expr {
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                ps.emit_space();
-                format_expression(ps, *e)
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            ps.emit_space();
+            format_expression(ps, *e)
+        });
     }
 
     ps.emit_newline();
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            format_when_or_else(ps, WhenOrElse::When(tail));
-            ps.emit_end();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        format_when_or_else(ps, WhenOrElse::When(tail));
+        ps.emit_end();
+    });
 
     if ps.at_start_of_line() {
         ps.wind_dumping_comments_until_line(end_line);
@@ -3320,31 +3030,22 @@ pub fn format_sclass(ps: &mut ParserState, sc: SClass) {
     let body = sc.2;
     let end_line = sc.3.end_line();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.emit_keyword("class".into());
-            ps.emit_space();
-            ps.emit_ident("<<".to_string());
-            ps.emit_space();
-            format_expression(ps, *expr);
-            ps.emit_newline();
-            ps.new_block(Box::new(|ps| {
-                ps.with_start_of_line(
-                    true,
-                    Box::new(|ps| {
-                        format_bodystmt(ps, body, end_line);
-                    }),
-                );
-            }));
-        }),
-    );
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_end();
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_keyword("class".into());
+        ps.emit_space();
+        ps.emit_ident("<<".to_string());
+        ps.emit_space();
+        format_expression(ps, *expr);
+        ps.emit_newline();
+        ps.new_block(|ps| {
+            ps.with_start_of_line(true, |ps| {
+                format_bodystmt(ps, body, end_line);
+            });
+        });
+    });
+    ps.with_start_of_line(true, |ps| {
+        ps.emit_end();
+    });
 
     ps.on_line(end_line);
 
@@ -3364,52 +3065,40 @@ pub fn format_stabby_lambda(ps: &mut ParserState, sl: StabbyLambda) {
     let params = sl.1;
     let body = sl.2;
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.emit_keyword("->".to_string());
-            if params.is_present() {
-                ps.emit_space();
-            }
-            format_paren_or_params(ps, params);
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_keyword("->".to_string());
+        if params.is_present() {
+            ps.emit_space();
+        }
+        format_paren_or_params(ps, params);
 
-            // Curly blocks are always represented as ExpressionLists (stmt_add nodes)
-            // while do/end blocks are BodyStmt nodes
-            match body {
-                ExpressionListOrBodyStmt::ExpressionList(body) => {
-                    let brace_block_render_method =
-                        get_brace_block_render_method(ps, start_line, end_line, &body);
-                    ps.emit_space();
-                    ps.inline_breakable_of(
-                        BreakableDelims::for_brace_block(),
-                        Box::new(|ps| {
-                            render_block_contents(ps, brace_block_render_method, body, end_line);
-                        }),
-                    );
-                }
-                ExpressionListOrBodyStmt::BodyStmt(bs) => {
-                    ps.emit_space();
-                    ps.emit_do_keyword();
-                    ps.emit_newline();
-                    ps.new_block(Box::new(|ps| {
-                        ps.with_start_of_line(
-                            true,
-                            Box::new(|ps| {
-                                format_bodystmt(ps, bs, end_line);
-                            }),
-                        );
-                    }));
-                    ps.with_start_of_line(
-                        true,
-                        Box::new(|ps| {
-                            ps.wind_dumping_comments_until_line(end_line);
-                            ps.emit_end()
-                        }),
-                    );
-                }
+        // Curly blocks are always represented as ExpressionLists (stmt_add nodes)
+        // while do/end blocks are BodyStmt nodes
+        match body {
+            ExpressionListOrBodyStmt::ExpressionList(body) => {
+                let brace_block_render_method =
+                    get_brace_block_render_method(ps, start_line, end_line, &body);
+                ps.emit_space();
+                ps.inline_breakable_of(BreakableDelims::for_brace_block(), |ps| {
+                    render_block_contents(ps, brace_block_render_method, body, end_line);
+                });
             }
-        }),
-    );
+            ExpressionListOrBodyStmt::BodyStmt(bs) => {
+                ps.emit_space();
+                ps.emit_do_keyword();
+                ps.emit_newline();
+                ps.new_block(|ps| {
+                    ps.with_start_of_line(true, |ps| {
+                        format_bodystmt(ps, bs, end_line);
+                    });
+                });
+                ps.with_start_of_line(true, |ps| {
+                    ps.wind_dumping_comments_until_line(end_line);
+                    ps.emit_end()
+                });
+            }
+        }
+    });
 
     ps.wind_dumping_comments_until_line(end_line);
 
@@ -3451,49 +3140,40 @@ pub fn format_for(ps: &mut ParserState, forloop: For) {
     let collection = forloop.2;
     let body = forloop.3;
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.emit_keyword("for".to_string());
-            ps.emit_space();
-            match variables {
-                VarFieldOrVarFields::VarField(vf) => {
-                    format_var_field(ps, vf);
-                }
-                VarFieldOrVarFields::VarFields(vfs) => {
-                    let len = vfs.len();
-                    for (idx, expr) in vfs.into_iter().enumerate() {
-                        format_var_field(ps, expr);
-                        if idx != len - 1 {
-                            ps.emit_comma_space();
-                        }
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_keyword("for".to_string());
+        ps.emit_space();
+        match variables {
+            VarFieldOrVarFields::VarField(vf) => {
+                format_var_field(ps, vf);
+            }
+            VarFieldOrVarFields::VarFields(vfs) => {
+                let len = vfs.len();
+                for (idx, expr) in vfs.into_iter().enumerate() {
+                    format_var_field(ps, expr);
+                    if idx != len - 1 {
+                        ps.emit_comma_space();
                     }
                 }
             }
+        }
 
-            ps.emit_space();
-            ps.emit_keyword("in".to_string());
-            ps.emit_space();
-            format_expression(ps, *collection);
-            ps.emit_newline();
-            ps.new_block(Box::new(|ps| {
-                ps.with_start_of_line(
-                    true,
-                    Box::new(|ps| {
-                        for expr in body.into_iter() {
-                            format_expression(ps, expr);
-                        }
-                    }),
-                );
-            }));
-        }),
-    );
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_end();
-        }),
-    );
+        ps.emit_space();
+        ps.emit_keyword("in".to_string());
+        ps.emit_space();
+        format_expression(ps, *collection);
+        ps.emit_newline();
+        ps.new_block(|ps| {
+            ps.with_start_of_line(true, |ps| {
+                for expr in body.into_iter() {
+                    format_expression(ps, expr);
+                }
+            });
+        });
+    });
+    ps.with_start_of_line(true, |ps| {
+        ps.emit_end();
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -3505,25 +3185,19 @@ pub fn format_ifop(ps: &mut ParserState, ifop: IfOp) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.with_formatting_context(
-                FormattingContext::IfOp,
-                Box::new(|ps| {
-                    format_expression(ps, *ifop.1);
-                    ps.emit_space();
-                    ps.emit_keyword("?".to_string());
-                    ps.emit_space();
-                    format_expression(ps, *ifop.2);
-                    ps.emit_space();
-                    ps.emit_keyword(":".to_string());
-                    ps.emit_space();
-                    format_expression(ps, *ifop.3);
-                }),
-            );
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.with_formatting_context(FormattingContext::IfOp, |ps| {
+            format_expression(ps, *ifop.1);
+            ps.emit_space();
+            ps.emit_keyword("?".to_string());
+            ps.emit_space();
+            format_expression(ps, *ifop.2);
+            ps.emit_space();
+            ps.emit_keyword(":".to_string());
+            ps.emit_space();
+            format_expression(ps, *ifop.3);
+        });
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -3544,16 +3218,13 @@ pub fn format_opassign(ps: &mut ParserState, opassign: OpAssign) {
         ps.emit_indent();
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_assignable(ps, opassign.1);
-            ps.emit_space();
-            format_op(ps, opassign.2);
-            ps.emit_space();
-            format_expression(ps, *opassign.3);
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_assignable(ps, opassign.1);
+        ps.emit_space();
+        format_op(ps, opassign.2);
+        ps.emit_space();
+        format_expression(ps, *opassign.3);
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -3561,7 +3232,7 @@ pub fn format_opassign(ps: &mut ParserState, opassign: OpAssign) {
 }
 pub fn format_to_proc(ps: &mut ParserState, e: Box<Expression>) {
     ps.emit_ident("&".to_string());
-    ps.with_start_of_line(false, Box::new(|ps| format_expression(ps, *e)));
+    ps.with_start_of_line(false, |ps| format_expression(ps, *e));
 }
 
 pub fn format_anon_block_arg(ps: &mut ParserState) {
@@ -3602,47 +3273,44 @@ pub fn format_return(ps: &mut ParserState, ret: Return) {
     let args = normalize_args(args);
     ps.emit_keyword("return".to_string());
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            if !args.is_empty() {
-                match args {
-                    ArgsAddStarOrExpressionListOrArgsForward::ArgsAddStar(aas) => {
-                        format_bare_return_args(
-                            ps,
-                            ArgsAddStarOrExpressionListOrArgsForward::ArgsAddStar(aas),
-                        );
-                    }
-                    ArgsAddStarOrExpressionListOrArgsForward::ArgsForward(af) => {
-                        format_bare_return_args(
-                            ps,
-                            ArgsAddStarOrExpressionListOrArgsForward::ArgsForward(af),
-                        );
-                    }
-                    ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(mut el) => {
-                        if el.len() == 1 {
-                            let element = el.remove(0);
-                            match element {
-                                Expression::Array(Array(array_tag, contents, linecol)) => {
-                                    ps.emit_space();
-                                    format_array(ps, Array(array_tag, contents, linecol));
-                                }
-                                elem => {
-                                    ps.emit_space();
-                                    format_expression(ps, elem);
-                                }
+    ps.with_start_of_line(false, |ps| {
+        if !args.is_empty() {
+            match args {
+                ArgsAddStarOrExpressionListOrArgsForward::ArgsAddStar(aas) => {
+                    format_bare_return_args(
+                        ps,
+                        ArgsAddStarOrExpressionListOrArgsForward::ArgsAddStar(aas),
+                    );
+                }
+                ArgsAddStarOrExpressionListOrArgsForward::ArgsForward(af) => {
+                    format_bare_return_args(
+                        ps,
+                        ArgsAddStarOrExpressionListOrArgsForward::ArgsForward(af),
+                    );
+                }
+                ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(mut el) => {
+                    if el.len() == 1 {
+                        let element = el.remove(0);
+                        match element {
+                            Expression::Array(Array(array_tag, contents, linecol)) => {
+                                ps.emit_space();
+                                format_array(ps, Array(array_tag, contents, linecol));
                             }
-                        } else {
-                            format_bare_return_args(
-                                ps,
-                                ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(el),
-                            );
+                            elem => {
+                                ps.emit_space();
+                                format_expression(ps, elem);
+                            }
                         }
+                    } else {
+                        format_bare_return_args(
+                            ps,
+                            ArgsAddStarOrExpressionListOrArgsForward::ExpressionList(el),
+                        );
                     }
                 }
             }
-        }),
-    );
+        }
+    });
 
     if ps.at_start_of_line() {
         ps.emit_newline();
@@ -3653,18 +3321,12 @@ pub fn format_bare_return_args(
     ps: &mut ParserState,
     args: ArgsAddStarOrExpressionListOrArgsForward,
 ) {
-    ps.breakable_of(
-        BreakableDelims::for_return_kw(),
-        Box::new(|ps| {
-            ps.with_formatting_context(
-                FormattingContext::ArgsList,
-                Box::new(|ps| {
-                    format_list_like_thing(ps, args, None, false);
-                    ps.emit_collapsing_newline();
-                }),
-            );
-        }),
-    );
+    ps.breakable_of(BreakableDelims::for_return_kw(), |ps| {
+        ps.with_formatting_context(FormattingContext::ArgsList, |ps| {
+            format_list_like_thing(ps, args, None, false);
+            ps.emit_collapsing_newline();
+        });
+    });
 }
 
 pub fn format_expression(ps: &mut ParserState, expression: Expression) {

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4,7 +4,7 @@ use crate::{
     delimiters::BreakableDelims,
     format::{GEMFILE_METHODS, OPTIONALLY_PARENTHESIZED_METHODS, SpecialCase},
     heredoc_string::HeredocKind,
-    parser_state::{FormattingContext, HashType, ParserState, RenderFunc},
+    parser_state::{FormattingContext, HashType, ParserState},
     render_targets::MultilineHandling,
     types::SourceOffset,
     util::{const_to_string, loc_to_string, u8_to_string},
@@ -414,14 +414,11 @@ fn format_alias_global_variable_node(
 fn format_alias_method_node(ps: &mut ParserState, alias_method_node: prism::AliasMethodNode) {
     ps.emit_ident("alias ".to_string());
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_node(ps, alias_method_node.new_name());
-            ps.emit_space();
-            format_node(ps, alias_method_node.old_name());
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, alias_method_node.new_name());
+        ps.emit_space();
+        format_node(ps, alias_method_node.old_name());
+    });
 }
 
 fn format_alternation_pattern_node(
@@ -432,22 +429,16 @@ fn format_alternation_pattern_node(
 }
 
 fn format_and_node(ps: &mut ParserState, and_node: prism::AndNode) {
-    ps.inline_breakable_of(
-        BreakableDelims::for_binary_op(),
-        Box::new(|ps| {
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    format_infix_operator(
-                        ps,
-                        and_node.left(),
-                        loc_to_string(and_node.operator_loc()),
-                        and_node.right(),
-                    );
-                }),
+    ps.inline_breakable_of(BreakableDelims::for_binary_op(), |ps| {
+        ps.with_start_of_line(false, |ps| {
+            format_infix_operator(
+                ps,
+                and_node.left(),
+                loc_to_string(and_node.operator_loc()),
+                and_node.right(),
             );
-        }),
-    );
+        });
+    });
 }
 
 fn format_back_reference_read_node(
@@ -479,7 +470,7 @@ fn format_begin_node(ps: &mut ParserState, begin_node: prism::BeginNode) {
     } else {
         ps.emit_keyword("begin".to_string());
     }
-    ps.new_block(Box::new(|ps| {
+    ps.new_block(|ps| {
         // For implicit nodes, this newline was already emitted by the caller
         if !is_implicit_begin_node {
             ps.emit_newline();
@@ -487,31 +478,28 @@ fn format_begin_node(ps: &mut ParserState, begin_node: prism::BeginNode) {
         if let Some(statements_node) = begin_node.statements() {
             format_statements(ps, statements_node);
         }
-    }));
+    });
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            if let Some(rescue_node) = begin_node.rescue_clause() {
-                ps.emit_indent();
-                format_rescue_node(ps, rescue_node);
-            }
+    ps.with_start_of_line(true, |ps| {
+        if let Some(rescue_node) = begin_node.rescue_clause() {
+            ps.emit_indent();
+            format_rescue_node(ps, rescue_node);
+        }
 
-            if let Some(else_node) = begin_node.else_clause() {
-                ps.emit_indent();
-                format_else_node(ps, else_node);
-            }
+        if let Some(else_node) = begin_node.else_clause() {
+            ps.emit_indent();
+            format_else_node(ps, else_node);
+        }
 
-            if let Some(ensure_node) = begin_node.ensure_clause() {
-                ps.emit_indent();
-                format_ensure_node(ps, ensure_node);
-            }
+        if let Some(ensure_node) = begin_node.ensure_clause() {
+            ps.emit_indent();
+            format_ensure_node(ps, ensure_node);
+        }
 
-            if !is_implicit_begin_node {
-                ps.emit_end();
-            }
-        }),
-    );
+        if !is_implicit_begin_node {
+            ps.emit_end();
+        }
+    });
 
     if is_implicit_begin_node {
         ps.start_indent();
@@ -523,17 +511,11 @@ fn format_begin_node(ps: &mut ParserState, begin_node: prism::BeginNode) {
 fn format_break_node(ps: &mut ParserState, break_node: prism::BreakNode) {
     ps.emit_ident("break".to_string());
     if let Some(arguments_node) = break_node.arguments() {
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                ps.breakable_of(
-                    BreakableDelims::for_kw(),
-                    Box::new(|ps| {
-                        format_arguments_node(ps, arguments_node);
-                    }),
-                );
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            ps.breakable_of(BreakableDelims::for_kw(), |ps| {
+                format_arguments_node(ps, arguments_node);
+            });
+        });
     }
 }
 
@@ -552,31 +534,25 @@ fn format_case_node(ps: &mut ParserState, case_node: prism::CaseNode) {
     ps.emit_case_keyword();
 
     if let Some(predicate) = case_node.predicate() {
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                ps.emit_space();
-                format_node(ps, predicate);
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            ps.emit_space();
+            format_node(ps, predicate);
+        });
     }
 
     ps.emit_newline();
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            for condition in case_node.conditions().iter() {
-                format_when_node(ps, condition.as_when_node().unwrap());
-            }
+    ps.with_start_of_line(true, |ps| {
+        for condition in case_node.conditions().iter() {
+            format_when_node(ps, condition.as_when_node().unwrap());
+        }
 
-            if let Some(else_node) = case_node.else_clause() {
-                ps.emit_indent();
-                format_else_node(ps, else_node);
-            }
+        if let Some(else_node) = case_node.else_clause() {
+            ps.emit_indent();
+            format_else_node(ps, else_node);
+        }
 
-            ps.emit_end();
-        }),
-    );
+        ps.emit_end();
+    });
 }
 
 pub fn format_program(
@@ -584,12 +560,9 @@ pub fn format_program(
     program_node: prism::ProgramNode,
     data_loc: Option<prism::Location>,
 ) {
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            format_statements(ps, program_node.statements());
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        format_statements(ps, program_node.statements());
+    });
     ps.emit_newline();
     ps.on_line(10000000000);
     ps.shift_comments();
@@ -600,14 +573,11 @@ pub fn format_program(
 }
 
 fn format_statements(ps: &mut ParserState, statements_node: prism::StatementsNode) {
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            for node in statements_node.body().iter() {
-                format_node(ps, node);
-            }
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        for node in statements_node.body().iter() {
+            format_node(ps, node);
+        }
+    });
 }
 
 fn format_string_node(ps: &mut ParserState, string_node: prism::StringNode) {
@@ -634,36 +604,33 @@ fn format_string_node(ps: &mut ParserState, string_node: prism::StringNode) {
         return;
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            // Always use double quotes over single quotes/percent literals
-            if opener.is_some() {
-                ps.emit_double_quote();
-            }
+    ps.with_start_of_line(false, |ps| {
+        // Always use double quotes over single quotes/percent literals
+        if opener.is_some() {
+            ps.emit_double_quote();
+        }
 
-            // If opener is nil, we must be in some kind of interpolated string context, which
-            // means the contents must already be appropriately escaped -- hence we default to `true` here
-            let in_escaped_context =
-                is_heredoc || opener.clone().map(|s| s.starts_with("\"")).unwrap_or(true);
-            let string_content = if in_escaped_context {
-                loc_to_string(string_node.content_loc())
-            } else {
-                crate::string_escape::single_to_double_quoted(
-                    loc_to_string(string_node.content_loc()),
-                    opener.clone().unwrap().as_str(),
-                    closer.clone().unwrap().as_str(),
-                )
-            };
+        // If opener is nil, we must be in some kind of interpolated string context, which
+        // means the contents must already be appropriately escaped -- hence we default to `true` here
+        let in_escaped_context =
+            is_heredoc || opener.clone().map(|s| s.starts_with("\"")).unwrap_or(true);
+        let string_content = if in_escaped_context {
+            loc_to_string(string_node.content_loc())
+        } else {
+            crate::string_escape::single_to_double_quoted(
+                loc_to_string(string_node.content_loc()),
+                opener.clone().unwrap().as_str(),
+                closer.clone().unwrap().as_str(),
+            )
+        };
 
-            ps.emit_string_content(string_content);
-            ps.wind_dumping_comments_until_offset(string_node.content_loc().end_offset());
+        ps.emit_string_content(string_content);
+        ps.wind_dumping_comments_until_offset(string_node.content_loc().end_offset());
 
-            if opener.is_some() {
-                ps.emit_double_quote();
-            }
-        }),
-    );
+        if opener.is_some() {
+            ps.emit_double_quote();
+        }
+    });
 
     ps.wind_dumping_comments_until_offset(string_node.location().end_offset());
 }
@@ -711,42 +678,39 @@ fn format_interpolated_string_node(
         ps.emit_string_content(s.clone());
     }
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            let string_parts_count = interpolated_string_node.parts().iter().count();
-            for (i, part) in interpolated_string_node.parts().iter().enumerate() {
-                let start_offset = part.location().start_offset();
-                let end_offset = part.location().end_offset();
+    ps.with_start_of_line(false, |ps| {
+        let string_parts_count = interpolated_string_node.parts().iter().count();
+        for (i, part) in interpolated_string_node.parts().iter().enumerate() {
+            let start_offset = part.location().start_offset();
+            let end_offset = part.location().end_offset();
 
-                ps.at_offset(start_offset);
-                let indent_for_consecutive_strings = is_backslash_string_interpolation && i > 0;
+            ps.at_offset(start_offset);
+            let indent_for_consecutive_strings = is_backslash_string_interpolation && i > 0;
 
-                if indent_for_consecutive_strings {
-                    ps.start_indent();
-                    ps.emit_newline();
-                    ps.emit_indent();
-                }
-
-                format_node(ps, part);
-
-                // For non-backslash-concatenated multiline strings, `part` contains newlines and indentation,
-                // so we don't need to handle that ourselves.
-                if is_backslash_string_interpolation && i < string_parts_count - 1 {
-                    if let Some(s) = interpolated_string_node.closing_loc() {
-                        ps.emit_string_content(loc_to_string(s).trim().to_string());
-                    }
-                    ps.emit_space();
-                    ps.emit_slash();
-                }
-
-                ps.at_offset(end_offset);
-                if indent_for_consecutive_strings {
-                    ps.end_indent();
-                }
+            if indent_for_consecutive_strings {
+                ps.start_indent();
+                ps.emit_newline();
+                ps.emit_indent();
             }
-        }),
-    );
+
+            format_node(ps, part);
+
+            // For non-backslash-concatenated multiline strings, `part` contains newlines and indentation,
+            // so we don't need to handle that ourselves.
+            if is_backslash_string_interpolation && i < string_parts_count - 1 {
+                if let Some(s) = interpolated_string_node.closing_loc() {
+                    ps.emit_string_content(loc_to_string(s).trim().to_string());
+                }
+                ps.emit_space();
+                ps.emit_slash();
+            }
+
+            ps.at_offset(end_offset);
+            if indent_for_consecutive_strings {
+                ps.end_indent();
+            }
+        }
+    });
 
     if let Some(closing_loc) = interpolated_string_node.closing_loc() {
         ps.emit_string_content(loc_to_string(closing_loc).trim().to_string());
@@ -890,24 +854,18 @@ fn format_embedded_statements_node(
 ) {
     ps.emit_string_content("#{".to_string());
     if let Some(statements) = embedded_statements_node.statements() {
-        ps.with_formatting_context(
-            FormattingContext::StringEmbexpr,
-            Box::new(|ps| {
-                let has_multiple_statements = statements.body().iter().count() > 1;
-                ps.with_start_of_line(
-                    has_multiple_statements,
-                    Box::new(|ps| {
-                        if has_multiple_statements {
-                            ps.emit_newline();
-                            ps.new_block(Box::new(|ps| format_node(ps, statements.as_node())));
-                            ps.emit_indent();
-                        } else if let Some(statement) = statements.body().iter().next() {
-                            format_node(ps, statement);
-                        }
-                    }),
-                );
-            }),
-        );
+        ps.with_formatting_context(FormattingContext::StringEmbexpr, |ps| {
+            let has_multiple_statements = statements.body().iter().count() > 1;
+            ps.with_start_of_line(has_multiple_statements, |ps| {
+                if has_multiple_statements {
+                    ps.emit_newline();
+                    ps.new_block(|ps| format_node(ps, statements.as_node()));
+                    ps.emit_indent();
+                } else if let Some(statement) = statements.body().iter().next() {
+                    format_node(ps, statement);
+                }
+            });
+        });
     }
     ps.emit_string_content("}".to_string());
 }
@@ -925,12 +883,12 @@ fn format_ensure_node(ps: &mut ParserState, ensure_node: prism::EnsureNode) {
     ps.at_offset(ensure_node.location().start_offset());
 
     ps.emit_keyword("ensure".to_string());
-    ps.new_block(Box::new(|ps| {
+    ps.new_block(|ps| {
         ps.emit_newline();
         if let Some(statements) = ensure_node.statements() {
             format_statements(ps, statements);
         }
-    }));
+    });
 
     ps.at_offset(ensure_node.location().end_offset());
 }
@@ -954,44 +912,27 @@ fn format_flip_flop_node(_ps: &mut ParserState, _flip_flop_node: prism::FlipFlop
 fn format_class_node(ps: &mut ParserState, class_node: prism::ClassNode) {
     ps.emit_class_keyword();
     ps.emit_space();
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, class_node.constant_path())),
-    );
+    ps.with_start_of_line(false, |ps| format_node(ps, class_node.constant_path()));
 
     if let Some(superclass) = class_node.superclass() {
         ps.emit_ident(" < ".to_string());
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                format_node(ps, superclass);
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            format_node(ps, superclass);
+        });
     }
 
-    ps.new_block(Box::new(|ps| {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.with_formatting_context(
-                    FormattingContext::ClassOrModule,
-                    Box::new(|ps| {
-                        ps.emit_newline();
-                        if let Some(body) = class_node.body() {
-                            format_node(ps, body);
-                        }
-                    }),
-                );
-            }),
-        )
-    }));
+    ps.new_block(|ps| {
+        ps.with_start_of_line(true, |ps| {
+            ps.with_formatting_context(FormattingContext::ClassOrModule, |ps| {
+                ps.emit_newline();
+                if let Some(body) = class_node.body() {
+                    format_node(ps, body);
+                }
+            });
+        })
+    });
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_end();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| ps.emit_end());
 }
 
 fn format_class_variable_and_write_node(
@@ -1004,10 +945,9 @@ fn format_class_variable_and_write_node(
     ps.emit_op(loc_to_string(class_variable_and_write_node.operator_loc()));
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, class_variable_and_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, class_variable_and_write_node.value())
+    });
 }
 
 fn format_class_variable_operator_write_node(
@@ -1022,10 +962,9 @@ fn format_class_variable_operator_write_node(
     ));
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, class_variable_operator_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, class_variable_operator_write_node.value())
+    });
 }
 
 fn format_class_variable_or_write_node(
@@ -1038,10 +977,9 @@ fn format_class_variable_or_write_node(
     ps.emit_op(loc_to_string(class_variable_or_write_node.operator_loc()));
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, class_variable_or_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, class_variable_or_write_node.value())
+    });
 }
 
 fn format_class_variable_read_node(
@@ -1068,98 +1006,82 @@ fn format_class_variable_write_node(
     ps.emit_space();
     ps.emit_op("=".to_string());
     ps.emit_space();
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, class_variable_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, class_variable_write_node.value())
+    });
 }
 
 fn format_module_node(ps: &mut ParserState, module_node: prism::ModuleNode) {
     ps.emit_module_keyword();
     ps.emit_space();
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, module_node.constant_path())),
-    );
+    ps.with_start_of_line(false, |ps| format_node(ps, module_node.constant_path()));
 
-    ps.new_block(Box::new(|ps| {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.with_formatting_context(
-                    FormattingContext::ClassOrModule,
-                    Box::new(|ps| {
-                        ps.emit_newline();
-                        if let Some(body) = module_node.body() {
-                            format_node(ps, body);
-                        }
-                    }),
-                );
-            }),
-        )
-    }));
+    ps.new_block(|ps| {
+        ps.with_start_of_line(true, |ps| {
+            ps.with_formatting_context(FormattingContext::ClassOrModule, |ps| {
+                ps.emit_newline();
+                if let Some(body) = module_node.body() {
+                    format_node(ps, body);
+                }
+            });
+        })
+    });
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_end();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        ps.emit_end();
+    });
 }
 
 fn format_def_node(ps: &mut ParserState, def_node: prism::DefNode) {
     ps.emit_keyword("def".to_string());
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            if let Some(receiver) = def_node.receiver() {
-                format_node(ps, receiver);
-                ps.emit_dot();
-            }
+    ps.with_start_of_line(false, |ps| {
+        if let Some(receiver) = def_node.receiver() {
+            format_node(ps, receiver);
+            ps.emit_dot();
+        }
 
-            handle_string_at_offset(
-                ps,
-                const_to_string(def_node.name()),
-                def_node.name_loc().end_offset(),
-            );
-        }),
-    );
+        handle_string_at_offset(
+            ps,
+            const_to_string(def_node.name()),
+            def_node.name_loc().end_offset(),
+        );
+    });
 
     format_def_body(ps, def_node);
 }
 
 fn format_def_body(ps: &mut ParserState, def_node: prism::DefNode) {
-    ps.new_scope(Box::new(|ps| {
+    ps.new_scope(|ps| {
         if let Some(parameters_node) = def_node.parameters() {
             ps.breakable_of(
                 BreakableDelims::for_method_call(),
-                Box::new(|ps| {
+                |ps| {
                     ps.with_start_of_line(
                         false,
-                        Box::new(|ps| {
+                        |ps| {
                             format_parameters_node(ps, parameters_node);
                             // If the parameters have parens, wind to the closing paren, since it may
                             // be on its own line past the end of the params
                             if let Some(rparen_loc) = def_node.rparen_loc() {
                                 ps.at_offset(rparen_loc.end_offset());
                             }
-                        }),
+                        },
                     );
-                }),
+                },
             );
         }
 
         ps.with_formatting_context(
             FormattingContext::Def,
-            Box::new(|ps| {
+            |ps| {
                 if def_node.end_keyword_loc().is_some() {
-                    ps.new_block(Box::new(|ps| {
+                    ps.new_block(|ps| {
                         ps.emit_newline();
                         ps.with_start_of_line(
                             true,
-                            Box::new(|ps| {
+                            |ps| {
                                 if let Some(body) = def_node.body() {
                                     // Begin nodes are special because they could be "implicit" begins,
                                     // e.g. `def foo; rescue Foo; end`, which aren't indented the same way
@@ -1175,9 +1097,9 @@ fn format_def_body(ps: &mut ParserState, def_node: prism::DefNode) {
                                         format_node(ps, body);
                                     }
                                 }
-                            }),
+                            },
                         );
-                    }));
+                    });
                 } else {
                     ps.emit_space();
                     ps.emit_op("=".to_string());
@@ -1185,7 +1107,7 @@ fn format_def_body(ps: &mut ParserState, def_node: prism::DefNode) {
 
                     ps.with_start_of_line(
                         false,
-                        Box::new(|ps| {
+                        |ps| {
                             if let Some(body) = def_node.body() {
                                 let mut body_node_list = body.as_statements_node()
                                     .expect("Endless methods must have a body, and method definitions are always a Statements node")
@@ -1197,33 +1119,27 @@ fn format_def_body(ps: &mut ParserState, def_node: prism::DefNode) {
 
                                 format_node(ps, body_expression);
                             }
-                        }),
+                        },
                     )
                 }
-            }),
+            },
         );
-    }));
+    });
 
     if let Some(end_keyword_loc) = def_node.end_keyword_loc() {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.wind_dumping_comments_until_offset(end_keyword_loc.end_offset());
-                ps.emit_end();
-            }),
-        );
+        ps.with_start_of_line(true, |ps| {
+            ps.wind_dumping_comments_until_offset(end_keyword_loc.end_offset());
+            ps.emit_end();
+        });
     }
 }
 
 fn format_defined_node(ps: &mut ParserState, defined_node: prism::DefinedNode) {
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.emit_ident("defined?(".to_string());
-            format_node(ps, defined_node.value());
-            ps.emit_close_paren();
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_ident("defined?(".to_string());
+        format_node(ps, defined_node.value());
+        ps.emit_close_paren();
+    });
 }
 
 fn format_else_node(ps: &mut ParserState, else_node: prism::ElseNode) {
@@ -1237,32 +1153,29 @@ fn format_else_node(ps: &mut ParserState, else_node: prism::ElseNode) {
     if &keyword == "else" {
         ps.emit_conditional_keyword(keyword);
 
-        ps.new_block(Box::new(|ps| {
+        ps.new_block(|ps| {
             ps.emit_newline();
             if let Some(statements) = else_node.statements() {
                 format_node(ps, statements.as_node())
             }
-        }));
+        });
     } else {
         // In a ternary
         ps.emit_space();
         ps.emit_conditional_keyword(keyword);
         ps.emit_space();
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                format_node(
-                    ps,
-                    else_node
-                        .statements()
-                        .expect("Statements must be present in a ternary")
-                        .body()
-                        .iter()
-                        .next()
-                        .expect("Ternaries cannot have multiple statements"),
-                );
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            format_node(
+                ps,
+                else_node
+                    .statements()
+                    .expect("Statements must be present in a ternary")
+                    .body()
+                    .iter()
+                    .next()
+                    .expect("Ternaries cannot have multiple statements"),
+            );
+        });
     }
 
     ps.at_offset(else_node.location().end_offset());
@@ -1357,29 +1270,23 @@ fn format_parameters_node(ps: &mut ParserState, params: prism::ParametersNode) {
 }
 
 fn format_block_parameter_node(ps: &mut ParserState, block_arg: prism::BlockParameterNode) {
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.emit_soft_indent();
-            ps.emit_ident("&".to_string());
-            if let Some(ident) = block_arg.name() {
-                let ident_str = const_to_string(ident);
-                ps.bind_variable(ident_str.clone());
-                format_ident(ps, ident_str, block_arg.name_loc().unwrap().end_offset());
-            }
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_soft_indent();
+        ps.emit_ident("&".to_string());
+        if let Some(ident) = block_arg.name() {
+            let ident_str = const_to_string(ident);
+            ps.bind_variable(ident_str.clone());
+            format_ident(ps, ident_str, block_arg.name_loc().unwrap().end_offset());
+        }
+    });
 }
 
 fn format_block_argument_node(ps: &mut ParserState, block_argument_node: prism::BlockArgumentNode) {
     ps.emit_ident("&".to_string());
     if let Some(expression_node) = block_argument_node.expression() {
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                format_node(ps, expression_node);
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            format_node(ps, expression_node);
+        });
     }
 }
 
@@ -1506,27 +1413,20 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
             } else if is_aref_write {
                 let arg_count = arguments.arguments().iter().count();
 
-                ps.with_start_of_line(
-                    false,
-                    Box::new(|ps| {
-                        ps.breakable_of(
-                            BreakableDelims::for_array(),
-                            Box::new(|ps| {
-                                // All arguments except the last are index arguments
-                                for (i, arg) in
-                                    arguments.arguments().iter().take(arg_count - 1).enumerate()
-                                {
-                                    if i > 0 {
-                                        ps.emit_comma();
-                                        ps.emit_soft_newline();
-                                    }
-                                    ps.emit_soft_indent();
-                                    format_node(ps, arg);
-                                }
-                            }),
-                        );
-                    }),
-                );
+                ps.with_start_of_line(false, |ps| {
+                    ps.breakable_of(BreakableDelims::for_array(), |ps| {
+                        // All arguments except the last are index arguments
+                        for (i, arg) in arguments.arguments().iter().take(arg_count - 1).enumerate()
+                        {
+                            if i > 0 {
+                                ps.emit_comma();
+                                ps.emit_soft_newline();
+                            }
+                            ps.emit_soft_indent();
+                            format_node(ps, arg);
+                        }
+                    });
+                });
 
                 ps.emit_ident(" = ".to_string());
 
@@ -1534,7 +1434,7 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
                     arguments.arguments().iter().last().expect(
                         "The last argument is the value being assigned and must be present",
                     );
-                ps.with_start_of_line(false, Box::new(|ps| format_node(ps, last_arg)));
+                ps.with_start_of_line(false, |ps| format_node(ps, last_arg));
             } else if call_node.is_attribute_write() {
                 ps.emit_ident(" = ".to_string());
                 format_arguments_node(ps, arguments);
@@ -1553,38 +1453,32 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
                 } else {
                     BreakableDelims::for_kw()
                 };
-                ps.with_start_of_line(
-                    false,
-                    Box::new(|ps| {
-                        ps.breakable_of(
-                            delims,
-                            Box::new(|ps| {
-                                let has_arguments = !node_list_is_empty(&arguments.arguments());
-                                format_arguments_node(ps, arguments);
+                ps.with_start_of_line(false, |ps| {
+                    ps.breakable_of(delims, |ps| {
+                        let has_arguments = !node_list_is_empty(&arguments.arguments());
+                        format_arguments_node(ps, arguments);
 
-                                // Somewhat confusingly, the block argument node (&blk) is
-                                // separate from the rest of the arguments node. If it's present,
-                                // we want it to be a part of the comma-separated list
-                                if let Some(block_argument_node) = call_node
-                                    .block()
-                                    .and_then(|block_node| block_node.as_block_argument_node())
-                                {
-                                    if has_arguments {
-                                        ps.emit_comma();
-                                        ps.emit_soft_newline();
-                                        ps.emit_soft_indent();
-                                    }
-                                    format_block_argument_node(ps, block_argument_node);
-                                }
+                        // Somewhat confusingly, the block argument node (&blk) is
+                        // separate from the rest of the arguments node. If it's present,
+                        // we want it to be a part of the comma-separated list
+                        if let Some(block_argument_node) = call_node
+                            .block()
+                            .and_then(|block_node| block_node.as_block_argument_node())
+                        {
+                            if has_arguments {
+                                ps.emit_comma();
+                                ps.emit_soft_newline();
+                                ps.emit_soft_indent();
+                            }
+                            format_block_argument_node(ps, block_argument_node);
+                        }
 
-                                // Ensure that we render comments between the last argument and closing parens
-                                if let Some(closing_loc) = call_node.closing_loc() {
-                                    ps.wind_dumping_comments_until_offset(closing_loc.end_offset());
-                                }
-                            }),
-                        );
-                    }),
-                );
+                        // Ensure that we render comments between the last argument and closing parens
+                        if let Some(closing_loc) = call_node.closing_loc() {
+                            ps.wind_dumping_comments_until_offset(closing_loc.end_offset());
+                        }
+                    });
+                });
             };
         } else if is_aref {
             // For a[] or a[]= with no arguments, we still need to emit the brackets
@@ -1594,23 +1488,17 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
         if let Some(block) = call_node.block() {
             if block.as_block_argument_node().is_none() {
                 ps.emit_space();
-                ps.with_start_of_line(
-                    false,
-                    Box::new(|ps| {
-                        format_node(ps, block);
-                    }),
-                );
+                ps.with_start_of_line(false, |ps| {
+                    format_node(ps, block);
+                });
             // If there's an arguments node, we've handled this block arg with
             // the rest of the args (since it's included in the comma-separated
             // args list), otherwise the only argument is the &blk node, so we
             // have to handle that here separately
             } else if call_node.arguments().is_none() && block.as_block_argument_node().is_some() {
-                ps.breakable_of(
-                    BreakableDelims::for_method_call(),
-                    Box::new(|ps| {
-                        format_block_argument_node(ps, block.as_block_argument_node().unwrap());
-                    }),
-                );
+                ps.breakable_of(BreakableDelims::for_method_call(), |ps| {
+                    format_block_argument_node(ps, block.as_block_argument_node().unwrap());
+                });
             }
         }
     } else {
@@ -1620,17 +1508,14 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
             !is_aref && !is_aref_write && call_node.call_operator_loc().is_none();
 
         if is_infix_operator {
-            ps.inline_breakable_of(
-                BreakableDelims::for_binary_op(),
-                Box::new(|ps| {
-                    format_infix_operator(
-                        ps,
-                        call_node.receiver().unwrap(),
-                        method_name,
-                        call_node.arguments().unwrap().as_node(),
-                    );
-                }),
-            );
+            ps.inline_breakable_of(BreakableDelims::for_binary_op(), |ps| {
+                format_infix_operator(
+                    ps,
+                    call_node.receiver().unwrap(),
+                    method_name,
+                    call_node.arguments().unwrap().as_node(),
+                );
+            });
         } else {
             format_call_chain(ps, call_node);
         }
@@ -1644,129 +1529,115 @@ fn format_infix_operator(
     operator: String,
     right: prism::Node,
 ) {
-    ps.with_formatting_context(
-        FormattingContext::Binary,
-        Box::new(|ps| {
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    // Check if left and right are also binary operators so we recurse back and handle it here.
-                    // This is so that chained and/or operations get indented correctly as one big chain.
-                    // ```ruby
-                    // foo &&
-                    //   bar &&
-                    //   baz
-                    // ```
-                    if let Some(and_node) = left.as_and_node() {
-                        format_infix_operator(
-                            ps,
-                            and_node.left(),
-                            loc_to_string(and_node.operator_loc()),
-                            and_node.right(),
-                        );
-                    } else if let Some(or_node) = left.as_or_node() {
-                        format_infix_operator(
-                            ps,
-                            or_node.left(),
-                            loc_to_string(or_node.operator_loc()),
-                            or_node.right(),
-                        );
-                    } else {
-                        ps.dedent(Box::new(|ps| {
-                            format_node(ps, left);
-                        }));
-                    }
+    ps.with_formatting_context(FormattingContext::Binary, |ps| {
+        ps.with_start_of_line(false, |ps| {
+            // Check if left and right are also binary operators so we recurse back and handle it here.
+            // This is so that chained and/or operations get indented correctly as one big chain.
+            // ```ruby
+            // foo &&
+            //   bar &&
+            //   baz
+            // ```
+            if let Some(and_node) = left.as_and_node() {
+                format_infix_operator(
+                    ps,
+                    and_node.left(),
+                    loc_to_string(and_node.operator_loc()),
+                    and_node.right(),
+                );
+            } else if let Some(or_node) = left.as_or_node() {
+                format_infix_operator(
+                    ps,
+                    or_node.left(),
+                    loc_to_string(or_node.operator_loc()),
+                    or_node.right(),
+                );
+            } else {
+                ps.dedent(|ps| format_node(ps, left));
+            }
 
-                    let comparison_operators = [">", ">=", "===", "==", "<", "<=", "<=>", "!="];
-                    let is_comparison = comparison_operators.iter().any(|o| o == &operator);
+            let comparison_operators = [">", ">=", "===", "==", "<", "<=", "<=>", "!="];
+            let is_comparison = comparison_operators.iter().any(|o| o == &operator);
 
-                    ps.emit_space();
-                    ps.emit_ident(operator);
+            ps.emit_space();
+            ps.emit_ident(operator);
 
-                    if is_comparison {
-                        // For comparison operators, we always put the right-hand side
-                        // on the same line as the left-hand side.
-                        ps.emit_space();
-                    } else {
-                        ps.emit_soft_newline();
-                        ps.emit_soft_indent();
-                    }
-                    ps.reset_space_count();
+            if is_comparison {
+                // For comparison operators, we always put the right-hand side
+                // on the same line as the left-hand side.
+                ps.emit_space();
+            } else {
+                ps.emit_soft_newline();
+                ps.emit_soft_indent();
+            }
+            ps.reset_space_count();
 
-                    if let Some(and_node) = right.as_and_node() {
-                        format_infix_operator(
-                            ps,
-                            and_node.left(),
-                            loc_to_string(and_node.operator_loc()),
-                            and_node.right(),
-                        );
-                    } else if let Some(or_node) = right.as_or_node() {
-                        format_infix_operator(
-                            ps,
-                            or_node.left(),
-                            loc_to_string(or_node.operator_loc()),
-                            or_node.right(),
-                        );
-                    } else {
-                        format_node(ps, right);
-                    }
-                }),
-            );
-        }),
-    );
+            if let Some(and_node) = right.as_and_node() {
+                format_infix_operator(
+                    ps,
+                    and_node.left(),
+                    loc_to_string(and_node.operator_loc()),
+                    and_node.right(),
+                );
+            } else if let Some(or_node) = right.as_or_node() {
+                format_infix_operator(
+                    ps,
+                    or_node.left(),
+                    loc_to_string(or_node.operator_loc()),
+                    or_node.right(),
+                );
+            } else {
+                format_node(ps, right);
+            }
+        });
+    });
 }
 
 fn format_call_chain(ps: &mut ParserState, call_node: ruby_prism::CallNode<'_>) {
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            let mut call_chain_elements = collapse_nodes_to_call_chain(call_node.as_node());
-            ps.breakable_call_chain_of(
-                MultilineHandling::Prism(call_chain_elements_are_user_multilined(
-                    ps,
-                    call_chain_elements.iter().clone().collect(),
-                )),
-                Box::new(|ps| {
-                    // The first node can be *any* expression, whereas following receivers
-                    // must be additional calls -- you cannot insert literals into call chains
-                    let first_expression = call_chain_elements.remove(0);
-                    format_node(ps, first_expression);
-                    // Eagerly render heredocs if they're in the first expression.
-                    // We want the full heredoc to get rendered _before_ we emit the
-                    // BeginCallChainIndent token so that it gets correctly indented
-                    // (or in the case of it being the first expression, _not_ indented).
-                    ps.render_heredocs(true);
+    ps.with_start_of_line(false, |ps| {
+        let mut call_chain_elements = collapse_nodes_to_call_chain(call_node.as_node());
+        ps.breakable_call_chain_of(
+            MultilineHandling::Prism(call_chain_elements_are_user_multilined(
+                ps,
+                call_chain_elements.iter().clone().collect(),
+            )),
+            |ps| {
+                // The first node can be *any* expression, whereas following receivers
+                // must be additional calls -- you cannot insert literals into call chains
+                let first_expression = call_chain_elements.remove(0);
+                format_node(ps, first_expression);
+                // Eagerly render heredocs if they're in the first expression.
+                // We want the full heredoc to get rendered _before_ we emit the
+                // BeginCallChainIndent token so that it gets correctly indented
+                // (or in the case of it being the first expression, _not_ indented).
+                ps.render_heredocs(true);
 
-                    ps.start_indent_for_call_chain();
+                ps.start_indent_for_call_chain();
 
-                    ps.with_start_of_line(
-                        false,
-                        Box::new(|ps| {
-                            for element in call_chain_elements {
-                                let element = element.as_call_node().unwrap();
+                ps.with_start_of_line(false, |ps| {
+                    for element in call_chain_elements {
+                        let element = element.as_call_node().unwrap();
 
-                                // `call_operator_loc` is the `.`/`::`/`&.` etc.
-                                // it may be None in the case of arefs, e.g. foo[bar]
-                                let call_operator =
-                                    element.call_operator_loc().map(|loc| loc_to_string(loc));
-                                if let Some(call_operator) = call_operator {
-                                    if call_operator != *"::" {
-                                        ps.emit_collapsing_newline();
-                                        ps.emit_soft_indent();
-                                    }
-                                    ps.emit_ident(call_operator);
-                                }
-
-                                ps.at_offset(element.location().start_offset());
-                                format_call_node(ps, element, true);
+                        // `call_operator_loc` is the `.`/`::`/`&.` etc.
+                        // it may be None in the case of arefs, e.g. foo[bar]
+                        let call_operator =
+                            element.call_operator_loc().map(|loc| loc_to_string(loc));
+                        if let Some(call_operator) = call_operator {
+                            if call_operator != *"::" {
+                                ps.emit_collapsing_newline();
+                                ps.emit_soft_indent();
                             }
-                        }),
-                    );
-                    ps.end_indent_for_call_chain();
-                }),
-            );
-        }),
-    );
+                            ps.emit_ident(call_operator);
+                        }
+
+                        ps.at_offset(element.location().start_offset());
+                        format_call_node(ps, element, true);
+                    }
+                });
+                ps.end_indent_for_call_chain();
+            },
+        );
+    });
 }
 
 fn call_chain_elements_are_user_multilined(
@@ -1845,7 +1716,7 @@ fn format_call_operator_write_node(
 
 fn format_call_or_write_node(ps: &mut ParserState, call_or_write_node: prism::CallOrWriteNode) {
     if let Some(receiver) = call_or_write_node.receiver() {
-        ps.with_start_of_line(false, Box::new(|ps| format_node(ps, receiver)));
+        ps.with_start_of_line(false, |ps| format_node(ps, receiver));
     }
 
     if let Some(call_operator_loc) = call_or_write_node.call_operator_loc() {
@@ -1860,10 +1731,7 @@ fn format_call_or_write_node(ps: &mut ParserState, call_or_write_node: prism::Ca
     ps.emit_op(loc_to_string(call_or_write_node.operator_loc()));
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, call_or_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| format_node(ps, call_or_write_node.value()));
 }
 
 fn format_call_target_node(_ps: &mut ParserState, _call_target_node: prism::CallTargetNode) {
@@ -1893,40 +1761,34 @@ fn format_assoc_node(ps: &mut ParserState, assoc_node: prism::AssocNode) {
         assoc_node.operator_loc().is_none()
     };
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_node(ps, assoc_node.key());
-            if as_symbol {
-                ps.emit_ident(":".to_string());
-            } else {
-                ps.emit_space();
-                ps.emit_ident("=>".to_string());
-            }
-            // For assoc nodes, skip the space so it renders as `{ a:, b:, c: }`
-            if assoc_node.value().as_implicit_node().is_none() {
-                ps.emit_space();
-            }
-            format_node(ps, assoc_node.value());
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, assoc_node.key());
+        if as_symbol {
+            ps.emit_ident(":".to_string());
+        } else {
+            ps.emit_space();
+            ps.emit_ident("=>".to_string());
+        }
+        // For assoc nodes, skip the space so it renders as `{ a:, b:, c: }`
+        if assoc_node.value().as_implicit_node().is_none() {
+            ps.emit_space();
+        }
+        format_node(ps, assoc_node.value());
+    });
 }
 
 fn format_assoc_splat_node(ps: &mut ParserState, assoc_splat_node: prism::AssocSplatNode) {
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.emit_ident("**".to_string());
-            if let Some(value) = assoc_splat_node.value() {
-                format_node(ps, value);
-            }
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_ident("**".to_string());
+        if let Some(value) = assoc_splat_node.value() {
+            format_node(ps, value);
+        }
+    });
 }
 
 fn format_block_node(ps: &mut ParserState, block_node: prism::BlockNode) {
     if &loc_to_string(block_node.opening_loc()) == "do" {
-        ps.new_block(Box::new(|ps| {
+        ps.new_block(|ps| {
             ps.emit_do_keyword();
             if let Some(block_parameters) = block_node.parameters() {
                 format_node(ps, block_parameters);
@@ -1938,76 +1800,58 @@ fn format_block_node(ps: &mut ParserState, block_node: prism::BlockNode) {
             ps.emit_newline();
 
             if let Some(body) = block_node.body() {
-                ps.with_start_of_line(
-                    true,
-                    Box::new(|ps| {
-                        format_node(ps, body);
-                    }),
-                );
+                ps.with_start_of_line(true, |ps| {
+                    format_node(ps, body);
+                });
             }
-        }));
+        });
 
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.wind_dumping_comments_until_offset(block_node.location().end_offset());
-                ps.emit_end();
-                ps.shift_comments();
-            }),
-        );
+        ps.with_start_of_line(true, |ps| {
+            ps.wind_dumping_comments_until_offset(block_node.location().end_offset());
+            ps.emit_end();
+            ps.shift_comments();
+        });
     } else {
-        ps.inline_breakable_of(
-            BreakableDelims::for_brace_block(),
-            Box::new(|ps| {
-                if let Some(parameters) = block_node.parameters() {
-                    format_node(ps, parameters);
-                }
+        ps.inline_breakable_of(BreakableDelims::for_brace_block(), |ps| {
+            if let Some(parameters) = block_node.parameters() {
+                format_node(ps, parameters);
+            }
 
-                if let Some(body) = block_node.body() {
-                    let has_multiple_statements = body
-                        .as_statements_node()
-                        .map(|statements_node| statements_node.body().iter().count() > 1)
-                        .unwrap_or(false);
-                    if has_multiple_statements {
-                        ps.emit_soft_newline();
-                        ps.with_start_of_line(
-                            true,
-                            Box::new(|ps| {
-                                format_node(ps, body);
-                            }),
-                        );
-                    } else {
-                        ps.with_start_of_line(
-                            false,
-                            Box::new(|ps| {
-                                if let Some(node) =
-                                    body.as_statements_node().unwrap().body().iter().next()
-                                {
-                                    ps.emit_soft_newline();
-                                    ps.emit_soft_indent();
-                                    format_node(ps, node);
-                                    ps.emit_soft_newline();
-                                }
-                            }),
-                        );
-                    }
-                } else if ps.has_comment_in_offset_span(
-                    block_node.opening_loc().start_offset(),
-                    block_node.closing_loc().end_offset(),
-                ) {
-                    // Even if there's no `body` node -- that is, there are no statements in the block --
-                    // we still need to look for comments and multiline if they're present.
-                    // Note that this is a soft newline, which are special-cased in breakables to correctly handle
-                    // comments, so we use one here instead of a hard newline.
+            if let Some(body) = block_node.body() {
+                let has_multiple_statements = body
+                    .as_statements_node()
+                    .map(|statements_node| statements_node.body().iter().count() > 1)
+                    .unwrap_or(false);
+                if has_multiple_statements {
                     ps.emit_soft_newline();
+                    ps.with_start_of_line(true, |ps| format_node(ps, body));
+                } else {
+                    ps.with_start_of_line(false, |ps| {
+                        if let Some(node) = body.as_statements_node().unwrap().body().iter().next()
+                        {
+                            ps.emit_soft_newline();
+                            ps.emit_soft_indent();
+                            format_node(ps, node);
+                            ps.emit_soft_newline();
+                        }
+                    });
                 }
+            } else if ps.has_comment_in_offset_span(
+                block_node.opening_loc().start_offset(),
+                block_node.closing_loc().end_offset(),
+            ) {
+                // Even if there's no `body` node -- that is, there are no statements in the block --
+                // we still need to look for comments and multiline if they're present.
+                // Note that this is a soft newline, which are special-cased in breakables to correctly handle
+                // comments, so we use one here instead of a hard newline.
+                ps.emit_soft_newline();
+            }
 
-                // `inline_breakable_of` doesn't handle the indentation for the closing delimeter for us.
-                ps.dedent(Box::new(|ps| ps.emit_soft_indent()));
-                ps.wind_dumping_comments_until_offset(block_node.location().end_offset());
-                ps.shift_comments();
-            }),
-        );
+            // `inline_breakable_of` doesn't handle the indentation for the closing delimeter for us.
+            ps.dedent(|ps| ps.emit_soft_indent());
+            ps.wind_dumping_comments_until_offset(block_node.location().end_offset());
+            ps.shift_comments();
+        });
     }
 }
 
@@ -2022,30 +1866,24 @@ fn format_block_parameters_node(
         return;
     }
 
-    ps.breakable_of(
-        BreakableDelims::for_block_params(),
-        Box::new(|ps| {
-            let has_locals = !node_list_is_empty(&block_parameters_node.locals());
+    ps.breakable_of(BreakableDelims::for_block_params(), |ps| {
+        let has_locals = !node_list_is_empty(&block_parameters_node.locals());
 
-            if let Some(parameters) = block_parameters_node.parameters() {
-                format_parameters_node(ps, parameters);
-            }
-            if has_locals {
-                ps.emit_ident(";".to_string());
-                ps.with_start_of_line(
+        if let Some(parameters) = block_parameters_node.parameters() {
+            format_parameters_node(ps, parameters);
+        }
+        if has_locals {
+            ps.emit_ident(";".to_string());
+            ps.with_start_of_line(false, |ps| {
+                format_list_like_thing(
+                    ps,
+                    block_parameters_node.locals(),
+                    block_parameters_node.location().end_offset(),
                     false,
-                    Box::new(|ps| {
-                        format_list_like_thing(
-                            ps,
-                            block_parameters_node.locals(),
-                            block_parameters_node.location().end_offset(),
-                            false,
-                        );
-                    }),
                 );
-            }
-        }),
-    );
+            });
+        }
+    });
 }
 
 fn format_block_local_variable_node(
@@ -2065,53 +1903,37 @@ fn format_array_node(ps: &mut ParserState, array_node: prism::ArrayNode) {
             array_node.location().start_offset(),
             array_node.location().end_offset(),
         ) {
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    ps.breakable_of(
-                        BreakableDelims::for_array(),
-                        Box::new(|ps| {
-                            ps.wind_dumping_comments_until_offset(
-                                array_node.location().end_offset(),
-                            );
-                        }),
-                    )
-                }),
-            )
+            ps.with_start_of_line(false, |ps| {
+                ps.breakable_of(BreakableDelims::for_array(), |ps| {
+                    ps.wind_dumping_comments_until_offset(array_node.location().end_offset());
+                })
+            })
         } else {
             ps.emit_open_square_bracket();
             ps.emit_close_square_bracket();
         }
     } else {
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                if array_node.opening_loc().is_none() {
-                    // Array node is an implicit array, e.g. `a = 1, 2`
+        ps.with_start_of_line(false, |ps| {
+            if array_node.opening_loc().is_none() {
+                // Array node is an implicit array, e.g. `a = 1, 2`
+                format_list_like_thing(
+                    ps,
+                    array_node.elements(),
+                    array_node.location().end_offset(),
+                    true,
+                );
+            } else {
+                ps.breakable_of(BreakableDelims::for_array(), |ps| {
                     format_list_like_thing(
                         ps,
                         array_node.elements(),
                         array_node.location().end_offset(),
-                        true,
+                        false,
                     );
-                } else {
-                    ps.breakable_of(
-                        BreakableDelims::for_array(),
-                        Box::new(|ps| {
-                            format_list_like_thing(
-                                ps,
-                                array_node.elements(),
-                                array_node.location().end_offset(),
-                                false,
-                            );
-                            ps.wind_dumping_comments_until_offset(
-                                array_node.location().end_offset(),
-                            );
-                        }),
-                    );
-                }
-            }),
-        );
+                    ps.wind_dumping_comments_until_offset(array_node.location().end_offset());
+                });
+            }
+        });
     }
 }
 
@@ -2133,43 +1955,31 @@ fn format_parentheses_node(ps: &mut ParserState, parentheses_node: prism::Parent
     };
 
     if let Some(body) = parentheses_node.body() {
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                if let Some(statements_node) = body.as_statements_node() {
-                    if statements_node.body().iter().count() == 1 {
-                        ps.with_start_of_line(
-                            false,
-                            Box::new(|ps| {
-                                format_node(ps, statements_node.body().iter().next().unwrap())
-                            }),
-                        );
-                    } else {
-                        ps.emit_newline();
-                        ps.new_block(Box::new(|ps| {
-                            ps.with_start_of_line(
-                                true,
-                                Box::new(|ps| {
-                                    format_node(ps, body);
-                                }),
-                            );
-                        }));
-                    }
+        ps.with_start_of_line(false, |ps| {
+            if let Some(statements_node) = body.as_statements_node() {
+                if statements_node.body().iter().count() == 1 {
+                    ps.with_start_of_line(false, |ps| {
+                        format_node(ps, statements_node.body().iter().next().unwrap())
+                    });
                 } else {
-                    // I'm *pretty* sure this should always be a StatementsNode, but this is here
-                    // just to be defensive
                     ps.emit_newline();
-                    ps.new_block(Box::new(|ps| {
-                        ps.with_start_of_line(
-                            true,
-                            Box::new(|ps| {
-                                format_node(ps, body);
-                            }),
-                        );
-                    }));
+                    ps.new_block(|ps| {
+                        ps.with_start_of_line(true, |ps| {
+                            format_node(ps, body);
+                        });
+                    });
                 }
-            }),
-        );
+            } else {
+                // I'm *pretty* sure this should always be a StatementsNode, but this is here
+                // just to be defensive
+                ps.emit_newline();
+                ps.new_block(|ps| {
+                    ps.with_start_of_line(true, |ps| {
+                        format_node(ps, body);
+                    });
+                });
+            }
+        });
     }
 
     if is_multiline {
@@ -2198,39 +2008,30 @@ fn format_rest_parameter_node(
     rest_param: prism::RestParameterNode,
     special_case: SpecialCase,
 ) {
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            if special_case != SpecialCase::RestParamOutsideOfParamDef {
-                ps.emit_soft_indent();
+    ps.with_start_of_line(false, |ps| {
+        if special_case != SpecialCase::RestParamOutsideOfParamDef {
+            ps.emit_soft_indent();
+        }
+        ps.emit_ident("*".to_string());
+        ps.with_start_of_line(false, |ps| {
+            if let Some(name) = rest_param.name() {
+                let name_str = const_to_string(name);
+                ps.bind_variable(name_str.clone());
+                format_ident(ps, name_str, rest_param.name_loc().unwrap().end_offset());
             }
-            ps.emit_ident("*".to_string());
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    if let Some(name) = rest_param.name() {
-                        let name_str = const_to_string(name);
-                        ps.bind_variable(name_str.clone());
-                        format_ident(ps, name_str, rest_param.name_loc().unwrap().end_offset());
-                    }
-                }),
-            );
-        }),
-    );
+        });
+    });
 }
 
 fn format_arguments_node(ps: &mut ParserState, arguments_node: prism::ArgumentsNode) {
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_list_like_thing(
-                ps,
-                arguments_node.arguments(),
-                arguments_node.location().end_offset(),
-                false,
-            );
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_list_like_thing(
+            ps,
+            arguments_node.arguments(),
+            arguments_node.location().end_offset(),
+            false,
+        );
+    });
 }
 
 fn format_keyword_hash_node(ps: &mut ParserState, keyword_hash_node: prism::KeywordHashNode) {
@@ -2246,22 +2047,16 @@ fn format_keyword_hash_node(ps: &mut ParserState, keyword_hash_node: prism::Keyw
         HashType::HashRocket
     };
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.with_formatting_context(
-                FormattingContext::HashType(hash_type),
-                Box::new(|ps| {
-                    format_list_like_thing(
-                        ps,
-                        keyword_hash_node.elements(),
-                        keyword_hash_node.location().end_offset(),
-                        false,
-                    );
-                }),
+    ps.with_start_of_line(false, |ps| {
+        ps.with_formatting_context(FormattingContext::HashType(hash_type), |ps| {
+            format_list_like_thing(
+                ps,
+                keyword_hash_node.elements(),
+                keyword_hash_node.location().end_offset(),
+                false,
             );
-        }),
-    );
+        });
+    });
 }
 
 fn format_keyword_rest_parameter_node(
@@ -2307,10 +2102,9 @@ fn format_local_variable_and_write_node(
     ps.emit_op(loc_to_string(local_variable_and_write_node.operator_loc()));
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, local_variable_and_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, local_variable_and_write_node.value())
+    });
 }
 
 fn format_local_variable_operator_write_node(
@@ -2327,10 +2121,9 @@ fn format_local_variable_operator_write_node(
     ));
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, local_variable_operator_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, local_variable_operator_write_node.value())
+    });
 }
 
 fn format_local_variable_or_write_node(
@@ -2345,10 +2138,9 @@ fn format_local_variable_or_write_node(
     ps.emit_op(loc_to_string(local_variable_or_write_node.operator_loc()));
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, local_variable_or_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, local_variable_or_write_node.value())
+    });
 }
 
 fn format_local_variable_target_node(
@@ -2379,21 +2171,17 @@ fn format_local_variable_write_node(
 
     ps.emit_ident(" = ".to_string());
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, local_variable_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, local_variable_write_node.value())
+    });
 }
 
 fn format_splat_node(ps: &mut ParserState, splat_node: prism::SplatNode) {
     ps.emit_ident("*".to_string());
     if let Some(node) = splat_node.expression() {
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                format_node(ps, node);
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            format_node(ps, node);
+        });
     }
 }
 
@@ -2411,10 +2199,9 @@ fn format_instance_variable_write_node(
     ps.emit_space();
     ps.emit_op("=".to_string());
     ps.emit_space();
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, instance_variable_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, instance_variable_write_node.value())
+    });
 }
 
 fn format_integer_node(ps: &mut ParserState, integer_node: prism::IntegerNode) {
@@ -2437,32 +2224,24 @@ fn format_for_node(ps: &mut ParserState, for_node: prism::ForNode) {
     ps.emit_keyword("for".to_string());
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_node(ps, for_node.index());
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, for_node.index());
 
-            ps.emit_space();
-            ps.emit_keyword("in".to_string());
-            ps.emit_space();
+        ps.emit_space();
+        ps.emit_keyword("in".to_string());
+        ps.emit_space();
 
-            format_node(ps, for_node.collection());
-        }),
-    );
+        format_node(ps, for_node.collection());
+    });
 
-    ps.new_block(Box::new(|ps| {
+    ps.new_block(|ps| {
         ps.emit_newline();
         if let Some(statements_node) = for_node.statements() {
             format_statements(ps, statements_node);
         }
-    }));
+    });
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_end();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| ps.emit_end());
 }
 
 fn format_forwarding_arguments_node(
@@ -2502,22 +2281,16 @@ fn format_super_node(ps: &mut ParserState, super_node: prism::SuperNode) {
     ps.emit_ident("super".to_string());
     // Note that we always emit parens for SuperNodes,
     // since they're distinct from ForwardingSuperNode which never use parens
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.breakable_of(
-                BreakableDelims::for_method_call(),
-                Box::new(|ps| {
-                    if let Some(arguments) = super_node.arguments() {
-                        format_arguments_node(ps, arguments);
-                    }
-                }),
-            );
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.breakable_of(BreakableDelims::for_method_call(), |ps| {
+            if let Some(arguments) = super_node.arguments() {
+                format_arguments_node(ps, arguments);
+            }
+        });
+    });
     if let Some(block) = super_node.block() {
         ps.emit_space();
-        ps.with_start_of_line(false, Box::new(|ps| format_node(ps, block)));
+        ps.with_start_of_line(false, |ps| format_node(ps, block));
     }
 }
 
@@ -2564,49 +2337,40 @@ fn format_global_variable_write_node(
 }
 
 fn format_hash_node(ps: &mut ParserState, hash_node: prism::HashNode) {
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            if node_list_is_empty(&hash_node.elements()) {
-                let start_offset = hash_node.location().start_offset();
-                let end_offset = hash_node.location().end_offset();
-                let is_multiline = ps.get_line_number_for_offset(start_offset)
-                    != ps.get_line_number_for_offset(end_offset);
+    ps.with_start_of_line(false, |ps| {
+        if node_list_is_empty(&hash_node.elements()) {
+            let start_offset = hash_node.location().start_offset();
+            let end_offset = hash_node.location().end_offset();
+            let is_multiline = ps.get_line_number_for_offset(start_offset)
+                != ps.get_line_number_for_offset(end_offset);
 
-                let has_comments = ps.has_comment_in_offset_span(start_offset, end_offset);
+            let has_comments = ps.has_comment_in_offset_span(start_offset, end_offset);
 
-                if is_multiline && has_comments {
-                    // Since we already know this is multiline, we can just use
-                    // a breakable and know that it will always be the multiline form
-                    // instead of manually inserting all of the newlines/indents for
-                    // a multiline hash
-                    ps.breakable_of(
-                        BreakableDelims::for_hash(),
-                        Box::new(|ps| {
-                            ps.wind_dumping_comments_until_offset(end_offset);
-                        }),
-                    );
-                } else {
-                    ps.emit_ident("{}".to_string());
+            if is_multiline && has_comments {
+                // Since we already know this is multiline, we can just use
+                // a breakable and know that it will always be the multiline form
+                // instead of manually inserting all of the newlines/indents for
+                // a multiline hash
+                ps.breakable_of(BreakableDelims::for_hash(), |ps| {
                     ps.wind_dumping_comments_until_offset(end_offset);
-                }
+                });
             } else {
-                ps.breakable_of(
-                    BreakableDelims::for_hash(),
-                    Box::new(|ps| {
-                        ps.emit_soft_indent();
-                        format_list_like_thing(
-                            ps,
-                            hash_node.elements(),
-                            hash_node.closing_loc().end_offset(),
-                            false,
-                        );
-                        ps.wind_dumping_comments_until_offset(hash_node.closing_loc().end_offset());
-                    }),
-                );
+                ps.emit_ident("{}".to_string());
+                ps.wind_dumping_comments_until_offset(end_offset);
             }
-        }),
-    );
+        } else {
+            ps.breakable_of(BreakableDelims::for_hash(), |ps| {
+                ps.emit_soft_indent();
+                format_list_like_thing(
+                    ps,
+                    hash_node.elements(),
+                    hash_node.closing_loc().end_offset(),
+                    false,
+                );
+                ps.wind_dumping_comments_until_offset(hash_node.closing_loc().end_offset());
+            });
+        }
+    });
 }
 
 fn format_hash_pattern_node(_ps: &mut ParserState, _hash_pattern_node: prism::HashPatternNode) {
@@ -2623,13 +2387,13 @@ fn format_inline_conditional(
         // There can only be a single statement in modifier form.
         // Format it directly to skip the StatementsNode machinery
         if let Some(first_statement) = statements.body().iter().next() {
-            ps.with_start_of_line(false, Box::new(|ps| format_node(ps, first_statement)));
+            ps.with_start_of_line(false, |ps| format_node(ps, first_statement));
         }
         ps.emit_space();
     }
     ps.emit_conditional_keyword(keyword);
     ps.emit_space();
-    ps.with_start_of_line(false, Box::new(|ps| format_node(ps, predicate)));
+    ps.with_start_of_line(false, |ps| format_node(ps, predicate));
 }
 
 enum Conditional<'pr> {
@@ -2706,16 +2470,13 @@ fn format_conditional_node(
             .expect("Begin modifiers must have a single statement")
             .as_begin_node()
             .expect("Statement in a begin modifier must be a BeginNode");
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                format_begin_node(ps, begin_node);
-                ps.emit_space();
-                ps.emit_keyword(conditional_keyword.to_string());
-                ps.emit_space();
-                format_node(ps, conditional.predicate());
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            format_begin_node(ps, begin_node);
+            ps.emit_space();
+            ps.emit_keyword(conditional_keyword.to_string());
+            ps.emit_space();
+            format_node(ps, conditional.predicate());
+        });
         return;
     }
 
@@ -2742,14 +2503,14 @@ fn format_conditional_node(
                     true
                 } else {
                     // Check if it renders multiline due to length
-                    ps.will_render_as_multiline(Box::new(move |next_ps| {
+                    ps.will_render_as_multiline(|next_ps| {
                         format_inline_conditional(
                             next_ps,
                             predicate,
                             statements,
                             conditional_keyword.to_string(),
                         )
-                    }))
+                    })
                 }
             }
         };
@@ -2794,38 +2555,27 @@ fn format_conditional_block_form<'pr>(
     ps.emit_conditional_keyword(conditional_keyword.to_string());
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.new_block(Box::new(|ps| {
-                format_node(ps, predicate);
-            }));
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        ps.new_block(|ps| {
+            format_node(ps, predicate);
+        });
+    });
 
-    ps.new_block(Box::new(|ps| {
+    ps.new_block(|ps| {
         ps.emit_newline();
         if let Some(statements) = statements {
             format_node(ps, statements.as_node());
         }
-    }));
+    });
 
     if let Some(subsequent_or_else) = subsequent_or_else {
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                ps.emit_indent();
-                format_node(ps, subsequent_or_else);
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            ps.emit_indent();
+            format_node(ps, subsequent_or_else);
+        });
     }
     if requires_end_keyword {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.emit_end();
-            }),
-        );
+        ps.with_start_of_line(true, |ps| ps.emit_end());
     }
 }
 
@@ -2847,30 +2597,27 @@ fn format_if_node(ps: &mut ParserState, if_node: prism::IfNode) {
         );
     } else {
         // No keyword, so this is a ternary
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                format_node(ps, if_node.predicate());
-                ps.emit_ident(" ? ".to_string());
+        ps.with_start_of_line(false, |ps| {
+            format_node(ps, if_node.predicate());
+            ps.emit_ident(" ? ".to_string());
 
-                format_node(
-                    ps,
-                    if_node
-                        .statements()
-                        .expect("Ternaries must have a `statements` branch")
-                        .body()
-                        .iter()
-                        .next()
-                        .expect("There must be exactly one statement inside a ternary branch"),
-                );
-                format_node(
-                    ps,
-                    if_node
-                        .subsequent()
-                        .expect("Ternaries must have a subsequent branch"),
-                )
-            }),
-        );
+            format_node(
+                ps,
+                if_node
+                    .statements()
+                    .expect("Ternaries must have a `statements` branch")
+                    .body()
+                    .iter()
+                    .next()
+                    .expect("There must be exactly one statement inside a ternary branch"),
+            );
+            format_node(
+                ps,
+                if_node
+                    .subsequent()
+                    .expect("Ternaries must have a subsequent branch"),
+            )
+        });
     }
 }
 
@@ -2918,24 +2665,20 @@ fn format_index_operator_write_node(
 
 fn format_index_or_write_node(ps: &mut ParserState, index_or_write_node: prism::IndexOrWriteNode) {
     if let Some(receiver) = index_or_write_node.receiver() {
-        ps.with_start_of_line(false, Box::new(|ps| format_node(ps, receiver)));
+        ps.with_start_of_line(false, |ps| format_node(ps, receiver));
     }
 
     if let Some(arguments) = index_or_write_node.arguments() {
-        ps.breakable_of(
-            BreakableDelims::for_array(),
-            Box::new(|ps| format_arguments_node(ps, arguments)),
-        );
+        ps.breakable_of(BreakableDelims::for_array(), |ps| {
+            format_arguments_node(ps, arguments)
+        });
     }
 
     ps.emit_space();
     ps.emit_op(loc_to_string(index_or_write_node.operator_loc()));
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, index_or_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| format_node(ps, index_or_write_node.value()));
 }
 
 fn format_index_target_node(_ps: &mut ParserState, _index_target_node: prism::IndexTargetNode) {
@@ -2954,10 +2697,9 @@ fn format_instance_variable_and_write_node(
     ));
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, instance_variable_and_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, instance_variable_and_write_node.value())
+    });
 }
 
 fn format_instance_variable_operator_write_node(
@@ -2974,10 +2716,9 @@ fn format_instance_variable_operator_write_node(
     ));
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, instance_variable_operator_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, instance_variable_operator_write_node.value())
+    });
 }
 
 fn format_instance_variable_or_write_node(
@@ -2992,10 +2733,9 @@ fn format_instance_variable_or_write_node(
     ));
     ps.emit_space();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, instance_variable_or_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, instance_variable_or_write_node.value())
+    });
 }
 
 fn format_instance_variable_read_node(
@@ -3021,23 +2761,20 @@ fn format_constant_read_node(ps: &mut ParserState, constant_read_node: prism::Co
 }
 
 fn format_constant_path_node(ps: &mut ParserState, constant_path_node: prism::ConstantPathNode) {
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            if let Some(parent) = constant_path_node.parent() {
-                format_node(ps, parent);
-            }
-            // Emit :: regardless of if there's a parent
-            // since it could be a top reference
-            ps.emit_colon_colon();
+    ps.with_start_of_line(false, |ps| {
+        if let Some(parent) = constant_path_node.parent() {
+            format_node(ps, parent);
+        }
+        // Emit :: regardless of if there's a parent
+        // since it could be a top reference
+        ps.emit_colon_colon();
 
-            handle_string_at_offset(
-                ps,
-                const_to_string(constant_path_node.name().unwrap()),
-                constant_path_node.name_loc().start_offset(),
-            );
-        }),
-    );
+        handle_string_at_offset(
+            ps,
+            const_to_string(constant_path_node.name().unwrap()),
+            constant_path_node.name_loc().start_offset(),
+        );
+    });
 }
 
 fn format_constant_and_write_node(
@@ -3095,10 +2832,9 @@ fn format_constant_path_write_node(
 ) {
     format_constant_path_node(ps, constant_path_write_node.target());
     ps.emit_op(" = ".to_string());
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, constant_path_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, constant_path_write_node.value())
+    });
 }
 
 fn format_constant_target_node(
@@ -3111,10 +2847,7 @@ fn format_constant_target_node(
 fn format_constant_write_node(ps: &mut ParserState, constant_write_node: prism::ConstantWriteNode) {
     ps.emit_ident(const_to_string(constant_write_node.name()));
     ps.emit_op(" = ".to_string());
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, constant_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| format_node(ps, constant_write_node.value()));
 }
 
 fn format_lambda_node(_ps: &mut ParserState, _lambda_node: prism::LambdaNode) {
@@ -3175,30 +2908,27 @@ fn format_multi_targets(
     let has_rest = rest.is_some();
     let has_rights = rights.iter().count() > 0;
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
+    ps.with_start_of_line(false, |ps| {
+        if has_lefts {
+            let lefts_offset = lefts.iter().last().unwrap().location().end_offset();
+            format_list_like_thing(ps, lefts, lefts_offset, true);
+        }
+
+        if let Some(rest) = rest {
             if has_lefts {
-                let lefts_offset = lefts.iter().last().unwrap().location().end_offset();
-                format_list_like_thing(ps, lefts, lefts_offset, true);
+                ps.emit_comma_space();
             }
+            format_node(ps, rest);
+        }
 
-            if let Some(rest) = rest {
-                if has_lefts {
-                    ps.emit_comma_space();
-                }
-                format_node(ps, rest);
+        if has_rights {
+            if has_lefts || has_rest {
+                ps.emit_comma_space();
             }
-
-            if has_rights {
-                if has_lefts || has_rest {
-                    ps.emit_comma_space();
-                }
-                let rights_offset = rights.iter().last().unwrap().location().end_offset();
-                format_list_like_thing(ps, rights, rights_offset, true);
-            }
-        }),
-    );
+            let rights_offset = rights.iter().last().unwrap().location().end_offset();
+            format_list_like_thing(ps, rights, rights_offset, true);
+        }
+    });
 }
 
 fn format_multi_write_node(ps: &mut ParserState, multi_write_node: prism::MultiWriteNode) {
@@ -3211,26 +2941,17 @@ fn format_multi_write_node(ps: &mut ParserState, multi_write_node: prism::MultiW
 
     ps.emit_ident(" = ".to_string());
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| format_node(ps, multi_write_node.value())),
-    );
+    ps.with_start_of_line(false, |ps| format_node(ps, multi_write_node.value()));
 }
 
 fn format_next_node(ps: &mut ParserState, next_node: prism::NextNode) {
     ps.emit_ident("next".to_string());
     if let Some(arguments_node) = next_node.arguments() {
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                ps.breakable_of(
-                    BreakableDelims::for_kw(),
-                    Box::new(|ps| {
-                        format_arguments_node(ps, arguments_node);
-                    }),
-                );
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            ps.breakable_of(BreakableDelims::for_kw(), |ps| {
+                format_arguments_node(ps, arguments_node);
+            });
+        });
     }
 }
 
@@ -3265,12 +2986,9 @@ fn format_optional_keyword_parameter_node(
 ) {
     ps.emit_ident(const_to_string(optional_keyword_parameter_node.name()));
     ps.emit_op(": ".to_string());
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_node(ps, optional_keyword_parameter_node.value());
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, optional_keyword_parameter_node.value());
+    });
 }
 
 fn format_optional_parameter_node(
@@ -3283,22 +3001,16 @@ fn format_optional_parameter_node(
 }
 
 fn format_or_node(ps: &mut ParserState, or_node: prism::OrNode) {
-    ps.inline_breakable_of(
-        BreakableDelims::for_binary_op(),
-        Box::new(|ps| {
-            ps.with_start_of_line(
-                false,
-                Box::new(|ps| {
-                    format_infix_operator(
-                        ps,
-                        or_node.left(),
-                        loc_to_string(or_node.operator_loc()),
-                        or_node.right(),
-                    );
-                }),
+    ps.inline_breakable_of(BreakableDelims::for_binary_op(), |ps| {
+        ps.with_start_of_line(false, |ps| {
+            format_infix_operator(
+                ps,
+                or_node.left(),
+                loc_to_string(or_node.operator_loc()),
+                or_node.right(),
             );
-        }),
-    );
+        });
+    });
 }
 
 fn format_pinned_expression_node(
@@ -3321,24 +3033,18 @@ fn format_post_execution_node(ps: &mut ParserState, post_execution_node: prism::
     ps.emit_open_curly_bracket();
 
     // END { } blocks are always multi-lined
-    ps.new_block(Box::new(|ps| {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.emit_newline();
-                if let Some(statements) = post_execution_node.statements() {
-                    format_node(ps, statements.as_node());
-                }
-            }),
-        )
-    }));
+    ps.new_block(|ps| {
+        ps.with_start_of_line(true, |ps| {
+            ps.emit_newline();
+            if let Some(statements) = post_execution_node.statements() {
+                format_node(ps, statements.as_node());
+            }
+        })
+    });
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_close_curly_bracket();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        ps.emit_close_curly_bracket();
+    });
 }
 
 fn format_pre_execution_node(ps: &mut ParserState, pre_execution_node: prism::PreExecutionNode) {
@@ -3347,39 +3053,30 @@ fn format_pre_execution_node(ps: &mut ParserState, pre_execution_node: prism::Pr
     ps.emit_open_curly_bracket();
 
     // BEGIN { } blocks are always multi-lined
-    ps.new_block(Box::new(|ps| {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.emit_newline();
-                if let Some(statements) = pre_execution_node.statements() {
-                    format_node(ps, statements.as_node());
-                }
-            }),
-        )
-    }));
+    ps.new_block(|ps| {
+        ps.with_start_of_line(true, |ps| {
+            ps.emit_newline();
+            if let Some(statements) = pre_execution_node.statements() {
+                format_node(ps, statements.as_node());
+            }
+        })
+    });
 
-    ps.with_start_of_line(
-        true,
-        Box::new(|ps| {
-            ps.emit_close_curly_bracket();
-        }),
-    );
+    ps.with_start_of_line(true, |ps| {
+        ps.emit_close_curly_bracket();
+    });
 }
 
 fn format_range_node(ps: &mut ParserState, range_node: prism::RangeNode) {
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            if let Some(left) = range_node.left() {
-                format_node(ps, left);
-            }
-            ps.emit_op(loc_to_string(range_node.operator_loc()));
-            if let Some(right) = range_node.right() {
-                format_node(ps, right);
-            }
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        if let Some(left) = range_node.left() {
+            format_node(ps, left);
+        }
+        ps.emit_op(loc_to_string(range_node.operator_loc()));
+        if let Some(right) = range_node.right() {
+            format_node(ps, right);
+        }
+    });
 }
 
 fn format_rational_node(ps: &mut ParserState, rational_node: prism::RationalNode) {
@@ -3418,43 +3115,37 @@ fn format_rescue_node(ps: &mut ParserState, rescue_node: prism::RescueNode) {
     ps.emit_keyword("rescue".to_string());
     let exceptions = rescue_node.exceptions();
     if !node_list_is_empty(&exceptions) {
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                ps.emit_space();
-                format_list_like_thing(
-                    ps,
-                    exceptions,
-                    rescue_node
-                        .exceptions()
-                        .iter()
-                        .last()
-                        .unwrap()
-                        .location()
-                        .end_offset(),
-                    true,
-                );
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            ps.emit_space();
+            format_list_like_thing(
+                ps,
+                exceptions,
+                rescue_node
+                    .exceptions()
+                    .iter()
+                    .last()
+                    .unwrap()
+                    .location()
+                    .end_offset(),
+                true,
+            );
+        });
     }
 
     if let Some(reference) = rescue_node.reference() {
         ps.emit_op(" => ".to_string());
-        ps.with_start_of_line(
-            false,
-            Box::new(|ps| {
-                format_node(ps, reference);
-            }),
-        );
+        ps.with_start_of_line(false, |ps| {
+            format_node(ps, reference);
+        });
     }
 
-    ps.new_block(Box::new(|ps| {
+    ps.new_block(|ps| {
         ps.emit_newline();
         if let Some(statements) = rescue_node.statements() {
             format_statements(ps, statements);
         }
         ps.shift_comments();
-    }));
+    });
 
     if let Some(subsequent) = rescue_node.subsequent() {
         format_node(ps, subsequent.as_node());
@@ -3469,25 +3160,19 @@ fn format_retry_node(ps: &mut ParserState) {
 
 fn format_return_node(ps: &mut ParserState, return_node: prism::ReturnNode) {
     ps.emit_ident("return".to_string());
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            if let Some(arguments) = return_node.arguments() {
-                ps.emit_space();
-                ps.with_start_of_line(
-                    false,
-                    Box::new(|ps| {
-                        format_list_like_thing(
-                            ps,
-                            arguments.arguments(),
-                            arguments.location().end_offset(),
-                            true,
-                        );
-                    }),
+    ps.with_start_of_line(false, |ps| {
+        if let Some(arguments) = return_node.arguments() {
+            ps.emit_space();
+            ps.with_start_of_line(false, |ps| {
+                format_list_like_thing(
+                    ps,
+                    arguments.arguments(),
+                    arguments.location().end_offset(),
+                    true,
                 );
-            }
-        }),
-    );
+            });
+        }
+    });
 }
 
 fn format_shareable_constant_node(
@@ -3549,12 +3234,9 @@ fn format_undef_node(ps: &mut ParserState, undef_node: prism::UndefNode) {
         .end_offset();
 
     ps.emit_ident("undef ".to_string());
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            format_list_like_thing(ps, names, end_offset, true);
-        }),
-    );
+    ps.with_start_of_line(false, |ps| {
+        format_list_like_thing(ps, names, end_offset, true);
+    });
 }
 
 fn format_unless_node(ps: &mut ParserState, unless_node: prism::UnlessNode) {
@@ -3570,37 +3252,28 @@ fn format_when_node(ps: &mut ParserState, when_node: prism::WhenNode) {
     ps.emit_indent();
     ps.emit_when_keyword();
 
-    ps.with_start_of_line(
-        false,
-        Box::new(|ps| {
-            ps.new_block(Box::new(|ps| {
-                ps.inline_breakable_of(
-                    BreakableDelims::for_when(),
-                    Box::new(|ps| {
-                        ps.emit_collapsing_newline();
-                        format_list_like_thing(
-                            ps,
-                            when_node.conditions(),
-                            when_node.location().end_offset(),
-                            false,
-                        );
-                    }),
+    ps.with_start_of_line(false, |ps| {
+        ps.new_block(|ps| {
+            ps.inline_breakable_of(BreakableDelims::for_when(), |ps| {
+                ps.emit_collapsing_newline();
+                format_list_like_thing(
+                    ps,
+                    when_node.conditions(),
+                    when_node.location().end_offset(),
+                    false,
                 );
-            }));
-        }),
-    );
+            });
+        });
+    });
 
-    ps.new_block(Box::new(|ps| {
-        ps.with_start_of_line(
-            true,
-            Box::new(|ps| {
-                ps.emit_newline();
-                if let Some(statements) = when_node.statements() {
-                    format_node(ps, statements.as_node());
-                }
-            }),
-        );
-    }));
+    ps.new_block(|ps| {
+        ps.with_start_of_line(true, |ps| {
+            ps.emit_newline();
+            if let Some(statements) = when_node.statements() {
+                format_node(ps, statements.as_node());
+            }
+        });
+    });
 }
 
 fn format_while_node(ps: &mut ParserState, while_node: prism::WhileNode) {
@@ -3624,12 +3297,9 @@ fn format_yield_node(ps: &mut ParserState, yield_node: prism::YieldNode) {
             BreakableDelims::for_kw()
         };
 
-        ps.breakable_of(
-            delims,
-            Box::new(|ps| {
-                format_arguments_node(ps, arguments);
-            }),
-        );
+        ps.breakable_of(delims, |ps| {
+            format_arguments_node(ps, arguments);
+        });
     }
 }
 
@@ -3662,17 +3332,18 @@ fn format_list_like_thing(
 ) -> bool {
     let mut emitted_args = false;
     let args_count = node_list.iter().count();
-    let cls: RenderFunc = Box::new(|ps| {
-        for (idx, expr) in node_list.iter().enumerate() {
-            if single_line {
-                format_node(ps, expr);
-                if idx != args_count - 1 {
-                    ps.emit_comma_space();
-                }
-            } else {
-                ps.with_start_of_line(
-                    false,
-                    Box::new(|ps| {
+
+    ps.magic_handle_comments_for_multiline_arrays(
+        Some(ps.get_line_number_for_offset(end_offset)),
+        |ps| {
+            for (idx, expr) in node_list.iter().enumerate() {
+                if single_line {
+                    format_node(ps, expr);
+                    if idx != args_count - 1 {
+                        ps.emit_comma_space();
+                    }
+                } else {
+                    ps.with_start_of_line(false, |ps| {
                         if let Some(assoc_node) = expr.as_assoc_node() {
                             if idx > 0 {
                                 ps.emit_soft_indent();
@@ -3689,16 +3360,11 @@ fn format_list_like_thing(
                         } else {
                             ps.shift_comments();
                         }
-                    }),
-                );
-            };
-            emitted_args = true;
-        }
-    });
-
-    ps.magic_handle_comments_for_multiline_arrays(
-        Some(ps.get_line_number_for_offset(end_offset)),
-        cls,
+                    });
+                };
+                emitted_args = true;
+            }
+        },
     );
     emitted_args
 }

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -12,8 +12,6 @@ use log::debug;
 use std::io::{self, Cursor, Write};
 use std::str;
 
-pub type RenderFunc<'a> = Box<dyn FnOnce(&mut ParserState) + 'a>;
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FormattingContext {
     Main,
@@ -81,7 +79,10 @@ impl ParserState {
             .expect("it's never empty")
             .contains(&s.to_string())
     }
-    pub(crate) fn new_scope(&mut self, f: RenderFunc) {
+    pub(crate) fn new_scope<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut ParserState),
+    {
         self.scopes.push(vec![]);
         f(self);
         self.scopes.pop();
@@ -89,13 +90,15 @@ impl ParserState {
     pub(crate) fn bind_variable(&mut self, s: String) {
         self.scopes.last_mut().expect("it's never empty").push(s);
     }
-    pub(crate) fn push_heredoc_content<'a>(
+    pub(crate) fn push_heredoc_content<F>(
         &mut self,
         symbol: String,
         kind: HeredocKind,
         end_line: LineNumber,
-        formatting_func: Box<dyn FnOnce(&mut ParserState) + 'a>,
-    ) {
+        formatting_func: F,
+    ) where
+        F: FnOnce(&mut ParserState),
+    {
         let mut next_ps = ParserState::render_with_blank_state(self, formatting_func);
 
         for hs in next_ps.heredoc_strings.drain(0..) {
@@ -127,15 +130,17 @@ impl ParserState {
         self.push_concrete_token(ConcreteLineToken::HeredocClose { symbol });
     }
 
-    pub(crate) fn magic_handle_comments_for_multiline_arrays(
+    pub(crate) fn magic_handle_comments_for_multiline_arrays<F>(
         &mut self,
         end_line: Option<LineNumber>,
-        f: RenderFunc,
-    ) {
+        f: F,
+    ) where
+        F: FnOnce(&mut ParserState),
+    {
         let current_line_number = self.current_orig_line_number;
-        self.new_block(Box::new(|ps| {
+        self.new_block(|ps| {
             ps.shift_comments();
-        }));
+        });
         f(self);
         // Reset here -- this resets when we emit newlines, but this may be out of date
         // if the most recent array didn't emit a newline
@@ -168,7 +173,10 @@ impl ParserState {
         }
     }
 
-    pub(crate) fn will_render_as_multiline(&mut self, f: RenderFunc) -> bool {
+    pub(crate) fn will_render_as_multiline<F>(&mut self, f: F) -> bool
+    where
+        F: FnOnce(&mut ParserState),
+    {
         let mut next_ps = ParserState::new_with_depth_stack_from(self);
         // Ignore commments when determining line length
         next_ps.with_suppress_comments(true, f);
@@ -191,7 +199,10 @@ impl ParserState {
         self.spaces_after_last_newline = self.current_spaces();
     }
 
-    pub(crate) fn dedent(&mut self, f: RenderFunc) {
+    pub(crate) fn dedent<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut ParserState),
+    {
         let ds_length = self.depth_stack.len();
         self.depth_stack[ds_length - 1].decrement();
         f(self);
@@ -216,23 +227,29 @@ impl ParserState {
         self.depth_stack[ds_length - 1].decrement();
     }
 
-    pub(crate) fn with_start_of_line(&mut self, start_of_line: bool, f: RenderFunc) {
+    pub(crate) fn with_start_of_line<F>(&mut self, start_of_line: bool, f: F)
+    where
+        F: FnOnce(&mut ParserState),
+    {
         self.start_of_line.push(start_of_line);
         f(self);
         self.start_of_line.pop();
     }
 
-    pub(crate) fn breakable_of(&mut self, delims: BreakableDelims, f: RenderFunc) {
+    pub(crate) fn breakable_of<F>(&mut self, delims: BreakableDelims, f: F)
+    where
+        F: FnOnce(&mut ParserState),
+    {
         self.shift_comments();
         let mut be = BreakableEntry::new(delims, self.formatting_context.clone());
         be.push_line_number(self.current_orig_line_number);
         self.breakable_entry_stack.push(Box::new(be));
 
-        self.new_block(Box::new(|ps| {
+        self.new_block(|ps| {
             ps.emit_collapsing_newline();
             f(ps);
             ps.emit_collapsing_newline();
-        }));
+        });
 
         // The last newline is in the old block, so we need
         // to reset to ensure that any comments between now and the
@@ -255,15 +272,16 @@ impl ParserState {
 
     /// A version of `breakable_of` for list-like things that use whitespace delimiters.
     /// At the moment, this is only for conditions in a `when` clause
-    pub(crate) fn inline_breakable_of(&mut self, delims: BreakableDelims, f: RenderFunc) {
+    pub(crate) fn inline_breakable_of<F>(&mut self, delims: BreakableDelims, f: F)
+    where
+        F: FnOnce(&mut ParserState),
+    {
         self.shift_comments();
         let mut be = BreakableEntry::new(delims, self.formatting_context.clone());
         be.push_line_number(self.current_orig_line_number);
         self.breakable_entry_stack.push(Box::new(be));
 
-        self.new_block(Box::new(|ps| {
-            f(ps);
-        }));
+        self.new_block(|ps| f(ps));
 
         // The last newline is in the old block, so we need
         // to reset to ensure that any comments between now and the
@@ -280,11 +298,13 @@ impl ParserState {
         self.push_target(ConcreteLineTokenAndTargets::BreakableEntry(insert_be));
     }
 
-    pub(crate) fn breakable_call_chain_of(
+    pub(crate) fn breakable_call_chain_of<F>(
         &mut self,
         mulitiline_handling: MultilineHandling,
-        f: RenderFunc,
-    ) {
+        f: F,
+    ) where
+        F: FnOnce(&mut ParserState),
+    {
         self.shift_comments();
         let mut be =
             BreakableCallChainEntry::new(self.formatting_context.clone(), mulitiline_handling);
@@ -304,13 +324,19 @@ impl ParserState {
         ));
     }
 
-    pub(crate) fn with_suppress_comments(&mut self, suppress: bool, f: RenderFunc) {
+    pub(crate) fn with_suppress_comments<F>(&mut self, suppress: bool, f: F)
+    where
+        F: FnOnce(&mut ParserState),
+    {
         self.suppress_comments_stack.push(suppress);
         f(self);
         self.suppress_comments_stack.pop();
     }
 
-    pub(crate) fn with_absorbing_indent_block(&mut self, f: RenderFunc) {
+    pub(crate) fn with_absorbing_indent_block<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut ParserState),
+    {
         let was_absorbing = self.absorbing_indents != 0;
         self.absorbing_indents += 1;
         if was_absorbing {
@@ -321,14 +347,20 @@ impl ParserState {
         self.absorbing_indents -= 1;
     }
 
-    pub(crate) fn new_block(&mut self, f: RenderFunc) {
+    pub(crate) fn new_block<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut ParserState),
+    {
         let ds_length = self.depth_stack.len();
         self.depth_stack[ds_length - 1].increment();
         f(self);
         self.depth_stack[ds_length - 1].decrement();
     }
 
-    pub(crate) fn with_formatting_context(&mut self, fc: FormattingContext, f: RenderFunc) {
+    pub(crate) fn with_formatting_context<F>(&mut self, fc: FormattingContext, f: F)
+    where
+        F: FnOnce(&mut ParserState),
+    {
         self.formatting_context.push(fc);
         f(self);
         self.formatting_context.pop();
@@ -508,9 +540,7 @@ impl ParserState {
     }
 
     pub(crate) fn emit_soft_newline(&mut self) {
-        self.new_block(Box::new(|ps| {
-            ps.shift_comments();
-        }));
+        self.new_block(|ps| ps.shift_comments());
         let hd = self.gather_heredocs();
         self.push_abstract_token(AbstractLineToken::SoftNewline(hd));
         self.spaces_after_last_newline = self.current_spaces();


### PR DESCRIPTION
`Box`ing closures has a runtime overhead, since it prevents some compiler optimizations and heap-allocates all of these closures. It's also very verbose and causes the formatted output to be far less intuitive. Now that @froydnj removed the trait implementation that first introduced this in #565, we can :knife: the `Box` usage as well.

This PR is hefty but quite mechanical -- the meat of the change is in `librubyfmt/src/parser_state.rs`, and everything else is just mechanical changes to callsites where I removed `Box::new(` from everything. I'd recommend viewing with whitespace changes hidden.