### PR TITLE
🧹 Remove dependency on deprecated `actions-rs` GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,7 @@ jobs:
           toolchain: stable
           components: rustfmt
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     runs-on: ubuntu-latest

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ fn rubyfmt_string(
             while !buffer.is_char_boundary(slice_size) && slice_size < blength {
                 slice_size += 1;
             }
-            slice = &buffer[..slice_size]
+            slice =     &buffer[..slice_size]
         }
 
         let matched = MAGIC_COMMENT_REGEX

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ fn rubyfmt_string(
             while !buffer.is_char_boundary(slice_size) && slice_size < blength {
                 slice_size += 1;
             }
-            slice =     &buffer[..slice_size]
+            slice = &buffer[..slice_size]
         }
 
         let matched = MAGIC_COMMENT_REGEX


### PR DESCRIPTION
On the tin -- the `actions-rs` repos were all [archived](https://github.com/actions-rs/cargo/) in 2023 and are no longer supported. Our only usage is this one caller for `cargo fmt`, so we can just run that directly.