### PR TITLE
🧹 Bump several GH action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           toolchain: 1.91.1
           components: clippy
           override: true
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -78,7 +78,7 @@ jobs:
         toolchain: 1.91.1
         override: true
         target: aarch64-unknown-linux-gnu
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry
@@ -90,7 +90,7 @@ jobs:
         brew link bison --force
         echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
     - run: cargo test --release
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: rubyfmt-artifact-${{ matrix.os }}
         path: target/release/rubyfmt-main

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -58,7 +58,7 @@ jobs:
           brew install automake bison
           echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
       - run: ./script/make_release
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: rubyfmt-release-artifact-${{ matrix.os }}
           path: rubyfmt-*.tar.gz
@@ -75,7 +75,7 @@ jobs:
           RELEASE_DIR="out/release"
           mkdir -p ${RELEASE_DIR}
           ./script/make_source_release ${TAG}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: rubyfmt-source-release
           path: "out/release/source"
@@ -88,16 +88,16 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: rubyfmt-source-release
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: rubyfmt-release-artifact-ubuntu-22.04-arm
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: rubyfmt-release-artifact-ubuntu-22.04
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: rubyfmt-release-artifact-macos-latest
       - name: Upload Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           brew install automake bison
           echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
       - run: ./script/make_release
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: rubyfmt-release-artifact-${{ matrix.os }}
           path: rubyfmt-*.tar.gz
@@ -58,7 +58,7 @@ jobs:
           RELEASE_DIR="out/release"
           mkdir -p ${RELEASE_DIR}
           ./script/make_source_release ${TAG}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: rubyfmt-source-release
           path: "out/release/source"
@@ -68,16 +68,16 @@ jobs:
       - build
       - source-release
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: rubyfmt-source-release
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: rubyfmt-release-artifact-ubuntu-22.04
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: rubyfmt-release-artifact-macos-latest
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: rubyfmt-release-artifact-ubuntu-22.04-arm
       - name: Ship It 🚢


### PR DESCRIPTION
Several of the official GH action types have newer versions available. Our usages are pretty straightforward and shouldn't be majorly affected -- this is just to keep us up to date on dependencies.