### PR TITLE
Remove unnecessary `env` variables from GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,6 @@ on:
   pull_request:
     branches: [ trunk ]
 
-env:
-    BUNDLE_PATH: /tmp/.bundle
-    GEM_HOME: /tmp/.bundle
-    GEM_PATH: /tmp/.bundle
-    TERM: xterm256
-
 jobs:
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -5,12 +5,6 @@ on:
     branches: [trunk]
     tags-ignore: "*"
 
-env:
-  BUNDLE_PATH: /tmp/.bundle
-  GEM_HOME: /tmp/.bundle
-  GEM_PATH: /tmp/.bundle
-  TERM: xterm256
-
 jobs:
   bump-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,6 @@ on:
     tags:
       - "*"
 
-env:
-  BUNDLE_PATH: /tmp/.bundle
-  GEM_HOME: /tmp/.bundle
-  GEM_PATH: /tmp/.bundle
-  TERM: xterm256
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
I believe all of these are holdovers from the early days of `rubyfmt` when part of the test suite involved [running Ruby tests after formatting example repos](https://github.com/fables-tales/rubyfmt/commit/7b7a776439f18fd3379c00da0706afe1c3009c83). That's no longer used and these are just stragglers, so let's :knife: them.