### PR TITLE
[prism] Properly render character literals

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -617,10 +617,19 @@ fn format_string_node(ps: &mut ParserState, string_node: prism::StringNode) {
         let string_content = if in_escaped_context {
             loc_to_string(string_node.content_loc())
         } else {
+            // For character literals (`?a`), there can be an opening loc without
+            // a closing loc. In that case, fall back to a double quote, since
+            // we render character literals as double-quoted string literals
+            let end_delim = if let Some(ref closer) = closer {
+                closer.as_str()
+            } else {
+                "\""
+            };
+
             crate::string_escape::single_to_double_quoted(
                 loc_to_string(string_node.content_loc()),
                 opener.clone().unwrap().as_str(),
-                closer.clone().unwrap().as_str(),
+                end_delim,
             )
         };
 

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -52,7 +52,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_brace_blocks_with_no_args",
     "small_break_all_the_things",
     "small_breakables_over_line_length",
-    "small_character_literal",
     "small_comments_at_indentation_changes",
     "small_const_call",
     "small_dotcall",


### PR DESCRIPTION
Small fix -- character literals (`?a`) can have an opening loc without a closing loc. We previously unwrapped here, and instead we should fall back to double quotes, since we always render them double quoted (`?a` -> `"a"`).