### PR TITLE
[prism] Fix block rendering for super nodes

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2297,12 +2297,24 @@ fn format_super_node(ps: &mut ParserState, super_node: prism::SuperNode) {
             if let Some(arguments) = super_node.arguments() {
                 format_arguments_node(ps, arguments);
             }
+            if let Some(block) = super_node.block()
+                && let Some(block_arg) = block.as_block_argument_node()
+            {
+                if super_node.arguments().is_some() {
+                    ps.emit_comma();
+                    ps.emit_soft_newline();
+                }
+                ps.with_start_of_line(false, |ps| format_block_argument_node(ps, block_arg));
+            }
         });
+
+        if let Some(block) = super_node.block()
+            && let Some(block_node) = block.as_block_node()
+        {
+            ps.emit_space();
+            ps.with_start_of_line(false, |ps| format_block_node(ps, block_node));
+        }
     });
-    if let Some(block) = super_node.block() {
-        ps.emit_space();
-        ps.with_start_of_line(false, |ps| format_node(ps, block));
-    }
 }
 
 fn format_global_variable_and_write_node(

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -13,7 +13,6 @@ use assert_cmd::Command;
 #[cfg(debug_assertions)]
 const IGNORED_IN_DEBUG: &[&'static str] = &[
     "test_prism_large_concurrent-ruby_non_concurrent_map_backend",
-    "test_prism_large_concurrent_ruby_future",
     "test_prism_large_rspec_mocks_proxy",
     "test_ripper_large_concurrent-ruby_non_concurrent_map_backend",
     "test_ripper_large_concurrent_ruby_future",
@@ -39,7 +38,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "large_concurrent-ruby_java_non_concurrent_priority_queue",
     "large_concurrent-ruby_non_concurrent_map_backend",
     "large_concurrent-ruby_ruby_non_concurrent_priority_queue",
-    "large_concurrent_ruby_future",
     "large_rspec_core_notifications",
     "large_rspec_mocks_proxy",
     "small_2.5_lambda_do_end",


### PR DESCRIPTION
`super` nodes have a `block` attribute, which when I originally implemented this I took to mean a do/end or brace block, but that also could be a block argument node (like `&blk`). This updates it to handle either variation.