### PR TITLE
[prism] Enable one extra test

### DIFF
--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -37,7 +37,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "large_concurrent-ruby_copy_on_notify_observer_set",
     "large_concurrent-ruby_ivar",
     "large_concurrent-ruby_java_non_concurrent_priority_queue",
-    "large_concurrent-ruby_non_concurrent_map_backend",
     "large_concurrent-ruby_ruby_non_concurrent_priority_queue",
     "large_concurrent_ruby_future",
     "large_rspec_core_notifications",


### PR DESCRIPTION
This one test we had disabled in debug (it has a debug-related issue also present in the Ripper implementation that we disable for debug builds), but it passes in release, so we should go ahead and enable to prevent a regression.