### PR TITLE
[prism] Fix percent arrays

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2047,7 +2047,7 @@ fn format_word_array_elements(
                 }
 
                 if idx != args_count - 1 {
-                    ps.emit_collapsing_newline();
+                    ps.emit_soft_newline();
                 }
             }
         },

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -78,8 +78,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_string_with_embexpr_dyna_symbol",
     "small_variable_binding",
     "small_visibility_modifier",
-    "small_w_array",
-    "small_w_arrays",
 ];
 
 fn main() -> io::Result<()> {


### PR DESCRIPTION
me in #595: yeah weird that we only have this one weird test for this

_Narrator: there were definitely more tests for this_

---

Anyways, yes, I used collapsing new lines instead of soft newlines (so that items have spaces between them on single lines), and I just so happened to have missed the dedicated test for `%w[]` that catches this. Oop.