### PR TITLE
[prism] Keep existing behavior around yield with keyword hash args

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3366,8 +3366,23 @@ fn format_x_string_node(ps: &mut ParserState, x_string_node: prism::XStringNode)
 fn format_yield_node(ps: &mut ParserState, yield_node: prism::YieldNode) {
     ps.emit_ident("yield".to_string());
     if let Some(arguments) = yield_node.arguments() {
-        let use_parens =
-            ps.current_formatting_context_requires_parens() || yield_node.lparen_loc().is_some();
+        let use_parens = ps.current_formatting_context_requires_parens()
+            || yield_node.lparen_loc().is_some()
+            // For single assoc values (`yield a: b`) we keep parens
+            || (yield_node
+                .arguments()
+                .map(|args| {
+                    args.arguments().iter().count() == 1
+                        && args
+                            .arguments()
+                            .iter()
+                            .last()
+                            .unwrap()
+                            .as_keyword_hash_node()
+                            .is_some()
+                })
+                .unwrap_or(false));
+
         let delims = if use_parens {
             BreakableDelims::for_method_call()
         } else {

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -84,7 +84,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_visibility_modifier",
     "small_w_array",
     "small_w_arrays",
-    "small_yield_hash_args",
 ];
 
 fn main() -> io::Result<()> {


### PR DESCRIPTION
Honestly, I don't remember the context of _why_ we did it this way, but in the Ripper implementation we [made a special-case](https://github.com/fables-tales/rubyfmt/commit/9e5d8cbf43a1b3adefc5c9cba2f8e5da41ca83da) for `yield` calls with arguments that are a single keyword node, e.g. `yield a: b`. I don't offhand remember what this was intended to prevent, but it was clearly intentional we put it there and I don't want to get Chesterton's fenced on some obscure yield behavior, so this adds that check in the Prism implementation too.