### PR TITLE
[prism] Trim trailing whitespace from comments

### DIFF
--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -77,7 +77,7 @@ impl FileComments {
         for comment in comments {
             file_comments.push_comment(
                 line_index.get_line_number(comment.location().start_offset()) as u64,
-                u8_to_string(comment.text()),
+                u8_to_string(comment.text().trim_ascii_end()),
             );
             file_comments
                 .comment_start_offsets

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -35,8 +35,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "large_concurrent-ruby_atom",
     "large_concurrent-ruby_copy_on_notify_observer_set",
     "large_concurrent-ruby_ivar",
-    "large_concurrent-ruby_java_non_concurrent_priority_queue",
-    "large_concurrent-ruby_ruby_non_concurrent_priority_queue",
     "large_rspec_core_notifications",
     "large_rspec_mocks_proxy",
     "small_2.5_lambda_do_end",


### PR DESCRIPTION
Trimming whitespace from comments is something we [did in the Ripper implementation](https://github.com/fables-tales/rubyfmt/blob/70601cffe28e3b5ac07c4cbe436b16e6aff9c727/librubyfmt/src/file_comments.rs#L129), and two test cases actually depend on this behavior, so this adds it to the Prism implementation too