### PR TITLE
don't allocate a `String` in `scope_has_variable`

### DIFF
--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -77,7 +77,8 @@ impl ParserState {
         self.scopes
             .last()
             .expect("it's never empty")
-            .contains(&s.to_string())
+            .iter()
+            .any(|e| e == s)
     }
     pub(crate) fn new_scope<F>(&mut self, f: F)
     where


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->

We can more verbosely compare for string equality by not using `contains()` (I think this is actually the code that's recommended in the documentation for `contains`!).