### PR TITLE
use `str` in prefence to allocating new strings

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -7,7 +7,7 @@ use crate::{
     parser_state::{FormattingContext, HashType, ParserState},
     render_targets::MultilineHandling,
     types::SourceOffset,
-    util::{const_to_string, loc_to_string, u8_to_string},
+    util::{const_to_string, loc_to_str, loc_to_string, u8_to_string},
 };
 
 pub fn format_node(ps: &mut ParserState, node: prism::Node) {
@@ -587,10 +587,10 @@ fn format_string_node(ps: &mut ParserState, string_node: prism::StringNode) {
     // (e.g. the inner contents of a heredoc)
     let opener = string_node
         .opening_loc()
-        .map(|s| loc_to_string(s).trim().to_string());
+        .map(|s| loc_to_str(s).trim().to_string());
     let closer = string_node
         .closing_loc()
-        .map(|s| loc_to_string(s).trim().to_string());
+        .map(|s| loc_to_str(s).trim().to_string());
     let is_heredoc = opener.clone().map(|s| s.starts_with("<")).unwrap_or(false);
 
     if is_heredoc {
@@ -650,7 +650,7 @@ fn format_interpolated_string_node(
 ) {
     let opener = interpolated_string_node
         .opening_loc()
-        .map(|s| loc_to_string(s).trim().to_string());
+        .map(|s| loc_to_str(s).trim().to_string());
     let is_heredoc = opener.as_ref().map(|s| s.starts_with("<")).unwrap_or(false);
 
     // Prism actually handles string concatenation when using "\", so it treats
@@ -708,7 +708,7 @@ fn format_interpolated_string_node(
             // so we don't need to handle that ourselves.
             if is_backslash_string_interpolation && i < string_parts_count - 1 {
                 if let Some(s) = interpolated_string_node.closing_loc() {
-                    ps.emit_string_content(loc_to_string(s).trim().to_string());
+                    ps.emit_string_content(loc_to_str(s).trim().to_string());
                 }
                 ps.emit_space();
                 ps.emit_slash();
@@ -722,7 +722,7 @@ fn format_interpolated_string_node(
     });
 
     if let Some(closing_loc) = interpolated_string_node.closing_loc() {
-        ps.emit_string_content(loc_to_string(closing_loc).trim().to_string());
+        ps.emit_string_content(loc_to_str(closing_loc).trim().to_string());
     }
 }
 
@@ -758,7 +758,7 @@ fn format_heredoc(ps: &mut ParserState, heredoc: HeredocNodeType, heredoc_symbol
     ps.emit_heredoc_start(heredoc_symbol, heredoc_kind);
 
     ps.push_heredoc_content(
-        loc_to_string(heredoc.closing_loc()).trim().to_string(),
+        loc_to_str(heredoc.closing_loc()).trim().to_string(),
         heredoc_kind,
         ps.get_line_number_for_offset(heredoc.closing_loc().start_offset()),
         Box::new(|n: &mut ParserState| {

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -591,7 +591,7 @@ fn format_string_node(ps: &mut ParserState, string_node: prism::StringNode) {
     let closer = string_node
         .closing_loc()
         .map(|s| loc_to_str(s).trim().to_string());
-    let is_heredoc = opener.clone().map(|s| s.starts_with("<")).unwrap_or(false);
+    let is_heredoc = opener.as_ref().map(|s| s.starts_with("<")).unwrap_or(false);
 
     if is_heredoc {
         format_heredoc(
@@ -613,7 +613,7 @@ fn format_string_node(ps: &mut ParserState, string_node: prism::StringNode) {
         // If opener is nil, we must be in some kind of interpolated string context, which
         // means the contents must already be appropriately escaped -- hence we default to `true` here
         let in_escaped_context =
-            is_heredoc || opener.clone().map(|s| s.starts_with("\"")).unwrap_or(true);
+            is_heredoc || opener.as_ref().map(|s| s.starts_with("\"")).unwrap_or(true);
         let string_content = if in_escaped_context {
             loc_to_string(string_node.content_loc())
         } else {
@@ -628,7 +628,7 @@ fn format_string_node(ps: &mut ParserState, string_node: prism::StringNode) {
 
             crate::string_escape::single_to_double_quoted(
                 loc_to_string(string_node.content_loc()),
-                opener.clone().unwrap().as_str(),
+                opener.as_ref().unwrap(),
                 end_delim,
             )
         };

--- a/librubyfmt/src/util.rs
+++ b/librubyfmt/src/util.rs
@@ -1,11 +1,19 @@
 use ruby_prism::{ConstantId, Location};
 
+pub fn u8_to_str(arr: &[u8]) -> &str {
+    std::str::from_utf8(arr).unwrap()
+}
+
 pub fn u8_to_string(arr: &[u8]) -> String {
-    std::str::from_utf8(arr).unwrap().to_string()
+    u8_to_str(arr).to_string()
 }
 
 pub fn const_to_string(constant_id: ConstantId) -> String {
     u8_to_string(constant_id.as_slice())
+}
+
+pub fn loc_to_str(loc: Location<'_>) -> &str {
+    u8_to_str(loc.as_slice())
 }
 
 pub fn loc_to_string(loc: Location) -> String {


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
This is probably not an exhaustive list of changes, but it should make things slightly faster.