### PR TITLE
[prism] Fix block spacing with lonely operators in call chains

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1707,6 +1707,7 @@ fn format_call_chain(ps: &mut ParserState, call_node: ruby_prism::CallNode<'_>) 
                     }
                 });
                 ps.end_indent_for_call_chain();
+                ps.shift_comments();
             },
         );
     });
@@ -1727,6 +1728,7 @@ fn call_chain_elements_are_user_multilined(
             prism::Node::CallNode { .. }
                 | prism::Node::ConstantReadNode { .. }
                 | prism::Node::ConstantPathNode { .. }
+                | prism::Node::ParenthesesNode { .. }
         );
 
         // _However_, don't ignore this if there are comments in the call chain though; this check may
@@ -3108,7 +3110,8 @@ fn format_numbered_parameters_node(
     _ps: &mut ParserState,
     _numbered_parameters_node: prism::NumberedParametersNode,
 ) {
-    todo!()
+    // No-op. This node represents the implicit set of numbered parameters,
+    // and the actual parameter references are rendered separately.
 }
 
 fn format_numbered_reference_read_node(

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -151,7 +151,7 @@ impl ConcreteLineToken {
     fn is_conditional_spaced_token(&self) -> bool {
         match self {
             Self::ConditionalKeyword { contents } => !(*contents == "else" || *contents == "elsif"),
-            Self::Dot => false,
+            Self::Dot | Self::LonelyOperator => false,
             Self::DirectPart { part } => part != "&.",
             _ => true,
         }

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -53,7 +53,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_inline_rescue",
     "small_lambda",
     "small_method_annotation",
-    "small_method_chains",
     "small_multi_rescue",
     "small_multiline_method_chain_with_arguments",
     "small_paren_expr_calls",


### PR DESCRIPTION
This gets `test_prism_small_method_chains` passing by fixing several small issue. The main one was a small issue with lonely operators after blocks in call chains. We have special handling for the dot operators in calls, but for whatever reason the machinery was only checking for `Dot` and `DirectPart { "&." }` instead of the `LonelyOperator` token (which is equivalent to the latter). This adds the appropriate check and also makes a small adjustment to ensure we render comments correctly, as well as making sure that call chains that start with parentheses node multiline correctly.