### PR TITLE
[prism] Support singleton class nodes

### DIFF
--- a/fixtures/small/sclass_actual.rb
+++ b/fixtures/small/sclass_actual.rb
@@ -1,5 +1,9 @@
 class Foo
   class << self
+
+    def some_method
+      1
+    end
   end
 end
 

--- a/fixtures/small/sclass_expected.rb
+++ b/fixtures/small/sclass_expected.rb
@@ -1,5 +1,9 @@
 class Foo
   class << self
+
+    def some_method
+      1
+    end
   end
 end
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3324,10 +3324,27 @@ fn format_shareable_constant_node(
 }
 
 fn format_singleton_class_node(
-    _ps: &mut ParserState,
-    _singleton_class_node: prism::SingletonClassNode,
+    ps: &mut ParserState,
+    singleton_class_node: prism::SingletonClassNode,
 ) {
-    todo!()
+    ps.emit_class_keyword();
+    ps.emit_space();
+    ps.emit_ident("<<".to_string());
+    ps.emit_space();
+    ps.emit_ident("self".to_string());
+
+    ps.new_block(|ps| {
+        ps.with_start_of_line(true, |ps| {
+            ps.with_formatting_context(FormattingContext::ClassOrModule, |ps| {
+                ps.emit_newline();
+                if let Some(body) = singleton_class_node.body() {
+                    format_node(ps, body);
+                }
+            });
+        })
+    });
+
+    ps.with_start_of_line(true, |ps| ps.emit_end());
 }
 
 fn format_source_encoding_node(

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -60,7 +60,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_percent_q",
     "small_return",
     "small_rspec_its",
-    "small_sclass",
     "small_scoping",
     "small_single_massign",
     "small_stabby_lambda",


### PR DESCRIPTION
On the tin. I updated the fixtures to actually have some contents in them since this is really our only singleton class test and I wanted to at least check we got indentation etc. correct, but we could probably battle-test this some more in the future.
