### PR TITLE
[prism] Properly enforce hash rocket usage rules

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1848,7 +1848,7 @@ fn format_assoc_node(ps: &mut ParserState, assoc_node: prism::AssocNode) {
             ps.emit_ident(":".to_string());
         }
 
-        format_node(ps, dbg!(assoc_node.key()));
+        format_node(ps, assoc_node.key());
         if as_symbol {
             ps.emit_ident(":".to_string());
         } else {
@@ -2511,7 +2511,7 @@ fn format_hash_node(ps: &mut ParserState, hash_node: prism::HashNode) {
                 ps.wind_dumping_comments_until_offset(end_offset);
             }
         } else {
-            let all_symbol_keys = dbg!(&hash_node)
+            let all_symbol_keys = hash_node
                 .elements()
                 .iter()
                 .filter_map(|node| node.as_assoc_node())

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1820,8 +1820,14 @@ fn format_symbol_node(ps: &mut ParserState, symbol_node: prism::SymbolNode) {
         ps.emit_ident(loc_to_string(value_loc));
     }
     if let Some(closing_loc) = symbol_node.closing_loc() {
-        let closing_str = loc_to_string(closing_loc);
-        if closing_str != ":" {
+        let mut closing_str = loc_to_string(closing_loc);
+        // String symbols, such as the key in `{ "a": b }` will have
+        // a closing_str of `"\":"`, so we have to trim instead of
+        // dropping the entire closing item.
+        if closing_str.ends_with(":") {
+            closing_str.pop();
+        }
+        if !closing_str.is_empty() {
             ps.emit_ident(closing_str);
         }
     }
@@ -1836,7 +1842,13 @@ fn format_assoc_node(ps: &mut ParserState, assoc_node: prism::AssocNode) {
     };
 
     ps.with_start_of_line(false, |ps| {
-        format_node(ps, assoc_node.key());
+        // Check if we're rendering a symbol key as a rocket,
+        // in which case we need to add back the leading colon
+        if !as_symbol && assoc_node.operator_loc().is_none() {
+            ps.emit_ident(":".to_string());
+        }
+
+        format_node(ps, dbg!(assoc_node.key()));
         if as_symbol {
             ps.emit_ident(":".to_string());
         } else {
@@ -2499,15 +2511,29 @@ fn format_hash_node(ps: &mut ParserState, hash_node: prism::HashNode) {
                 ps.wind_dumping_comments_until_offset(end_offset);
             }
         } else {
-            ps.breakable_of(BreakableDelims::for_hash(), |ps| {
-                ps.emit_soft_indent();
-                format_list_like_thing(
-                    ps,
-                    hash_node.elements(),
-                    hash_node.closing_loc().end_offset(),
-                    false,
-                );
-                ps.wind_dumping_comments_until_offset(hash_node.closing_loc().end_offset());
+            let all_symbol_keys = dbg!(&hash_node)
+                .elements()
+                .iter()
+                .filter_map(|node| node.as_assoc_node())
+                // The operator loc is empty for symbol keys
+                .all(|assoc| assoc.operator_loc().is_none());
+            let hash_type = if all_symbol_keys {
+                HashType::SymbolKey
+            } else {
+                HashType::HashRocket
+            };
+
+            ps.with_formatting_context(FormattingContext::HashType(hash_type), |ps| {
+                ps.breakable_of(BreakableDelims::for_hash(), |ps| {
+                    ps.emit_soft_indent();
+                    format_list_like_thing(
+                        ps,
+                        hash_node.elements(),
+                        hash_node.closing_loc().end_offset(),
+                        false,
+                    );
+                    ps.wind_dumping_comments_until_offset(hash_node.closing_loc().end_offset());
+                });
             });
         }
     });

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -49,7 +49,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_dyna_symbol_with_escapes",
     "small_empty_arg_paren",
     "small_gemfile",
-    "small_hash_rocket_usage",
     "small_inline_rescue",
     "small_lambda",
     "small_method_annotation",


### PR DESCRIPTION
The intended outcome is that if all keys are symbols, we use symbols, but if even one uses a hash rocket, we render everything as hash rockets. The tricky bit here is that symbols often include their trailing colon (and if we're converting to a hash rocket, need to be given a leading colon), so this PR adds all the logic to trim or add colons where necessary when converting between key types.