### PR TITLE
Convert `ConcreteLineToken::Op` to use `Cow`

### DIFF
--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
@@ -48,7 +49,7 @@ fn format_def_body(
             }
             DefBodyStmt::EndlessBodyStmt(bodystmt) => {
                 ps.emit_space();
-                ps.emit_op("=".to_string());
+                ps.emit_op(Cow::Borrowed("="));
                 ps.emit_space();
 
                 ps.with_start_of_line(false, |ps| {
@@ -1661,7 +1662,7 @@ pub fn format_assign(ps: &mut ParserState, assign: Assign) {
         let right = assign.2;
 
         ps.emit_space();
-        ps.emit_op("=".to_string());
+        ps.emit_op(Cow::Borrowed("="));
         ps.emit_space();
 
         ps.with_formatting_context(FormattingContext::Assign, |ps| match right {

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use ruby_prism as prism;
 
 use crate::{
@@ -951,7 +953,7 @@ fn format_class_variable_and_write_node(
     ps.emit_ident(const_to_string(class_variable_and_write_node.name()));
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(class_variable_and_write_node.operator_loc()));
+    ps.emit_op(Cow::Borrowed("&&="));
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -966,9 +968,9 @@ fn format_class_variable_operator_write_node(
     ps.emit_ident(const_to_string(class_variable_operator_write_node.name()));
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(
+    ps.emit_op(Cow::Owned(loc_to_string(
         class_variable_operator_write_node.binary_operator_loc(),
-    ));
+    )));
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -983,7 +985,7 @@ fn format_class_variable_or_write_node(
     ps.emit_ident(const_to_string(class_variable_or_write_node.name()));
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(class_variable_or_write_node.operator_loc()));
+    ps.emit_op(Cow::Borrowed("||="));
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -1013,7 +1015,7 @@ fn format_class_variable_write_node(
 
     ps.emit_ident(const_to_string(class_variable_write_node.name()));
     ps.emit_space();
-    ps.emit_op("=".to_string());
+    ps.emit_op(Cow::Borrowed("="));
     ps.emit_space();
     ps.with_start_of_line(false, |ps| {
         format_node(ps, class_variable_write_node.value())
@@ -1111,7 +1113,7 @@ fn format_def_body(ps: &mut ParserState, def_node: prism::DefNode) {
                     });
                 } else {
                     ps.emit_space();
-                    ps.emit_op("=".to_string());
+                    ps.emit_op(Cow::Borrowed("="));
                     ps.emit_space();
 
                     ps.with_start_of_line(
@@ -1802,7 +1804,7 @@ fn format_call_or_write_node(ps: &mut ParserState, call_or_write_node: prism::Ca
     }
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(call_or_write_node.operator_loc()));
+    ps.emit_op(Cow::Borrowed("||="));
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| format_node(ps, call_or_write_node.value()));
@@ -2227,7 +2229,7 @@ fn format_local_variable_and_write_node(
     ps.emit_ident(variable_name);
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(local_variable_and_write_node.operator_loc()));
+    ps.emit_op(Cow::Borrowed("&&="));
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -2244,9 +2246,9 @@ fn format_local_variable_operator_write_node(
     ps.emit_ident(variable_name);
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(
+    ps.emit_op(Cow::Owned(loc_to_string(
         local_variable_operator_write_node.binary_operator_loc(),
-    ));
+    )));
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -2263,7 +2265,7 @@ fn format_local_variable_or_write_node(
     ps.emit_ident(variable_name);
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(local_variable_or_write_node.operator_loc()));
+    ps.emit_op(Cow::Borrowed("||="));
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -2325,7 +2327,7 @@ fn format_instance_variable_write_node(
 
     ps.emit_ident(const_to_string(instance_variable_write_node.name()));
     ps.emit_space();
-    ps.emit_op("=".to_string());
+    ps.emit_op(Cow::Borrowed("="));
     ps.emit_space();
     ps.with_start_of_line(false, |ps| {
         format_node(ps, instance_variable_write_node.value())
@@ -2815,7 +2817,7 @@ fn format_index_or_write_node(ps: &mut ParserState, index_or_write_node: prism::
     }
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(index_or_write_node.operator_loc()));
+    ps.emit_op(Cow::Borrowed("||="));
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| format_node(ps, index_or_write_node.value()));
@@ -2832,9 +2834,7 @@ fn format_instance_variable_and_write_node(
     ps.emit_ident(const_to_string(instance_variable_and_write_node.name()));
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(
-        instance_variable_and_write_node.operator_loc(),
-    ));
+    ps.emit_op(Cow::Borrowed("&&="));
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -2851,9 +2851,9 @@ fn format_instance_variable_operator_write_node(
     ));
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(
+    ps.emit_op(Cow::Owned(loc_to_string(
         instance_variable_operator_write_node.binary_operator_loc(),
-    ));
+    )));
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -2868,9 +2868,7 @@ fn format_instance_variable_or_write_node(
     ps.emit_ident(const_to_string(instance_variable_or_write_node.name()));
 
     ps.emit_space();
-    ps.emit_op(loc_to_string(
-        instance_variable_or_write_node.operator_loc(),
-    ));
+    ps.emit_op(Cow::Borrowed("||="));
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -2971,7 +2969,9 @@ fn format_constant_path_write_node(
     constant_path_write_node: prism::ConstantPathWriteNode,
 ) {
     format_constant_path_node(ps, constant_path_write_node.target());
-    ps.emit_op(" = ".to_string());
+    ps.emit_space();
+    ps.emit_op(Cow::Borrowed("="));
+    ps.emit_space();
     ps.with_start_of_line(false, |ps| {
         format_node(ps, constant_path_write_node.value())
     });
@@ -2986,7 +2986,9 @@ fn format_constant_target_node(
 
 fn format_constant_write_node(ps: &mut ParserState, constant_write_node: prism::ConstantWriteNode) {
     ps.emit_ident(const_to_string(constant_write_node.name()));
-    ps.emit_op(" = ".to_string());
+    ps.emit_space();
+    ps.emit_op(Cow::Borrowed("="));
+    ps.emit_space();
     ps.with_start_of_line(false, |ps| format_node(ps, constant_write_node.value()));
 }
 
@@ -3126,7 +3128,8 @@ fn format_optional_keyword_parameter_node(
     optional_keyword_parameter_node: prism::OptionalKeywordParameterNode,
 ) {
     ps.emit_ident(const_to_string(optional_keyword_parameter_node.name()));
-    ps.emit_op(": ".to_string());
+    ps.emit_op(Cow::Borrowed(":"));
+    ps.emit_space();
     ps.with_start_of_line(false, |ps| {
         format_node(ps, optional_keyword_parameter_node.value());
     });
@@ -3137,7 +3140,9 @@ fn format_optional_parameter_node(
     optional_parameter_node: prism::OptionalParameterNode,
 ) {
     ps.emit_ident(const_to_string(optional_parameter_node.name()));
-    ps.emit_op(" = ".to_string());
+    ps.emit_space();
+    ps.emit_op(Cow::Borrowed("="));
+    ps.emit_space();
     format_node(ps, optional_parameter_node.value());
 }
 
@@ -3213,7 +3218,7 @@ fn format_range_node(ps: &mut ParserState, range_node: prism::RangeNode) {
         if let Some(left) = range_node.left() {
             format_node(ps, left);
         }
-        ps.emit_op(loc_to_string(range_node.operator_loc()));
+        ps.emit_op(Cow::Owned(loc_to_string(range_node.operator_loc())));
         if let Some(right) = range_node.right() {
             format_node(ps, right);
         }
@@ -3274,7 +3279,9 @@ fn format_rescue_node(ps: &mut ParserState, rescue_node: prism::RescueNode) {
     }
 
     if let Some(reference) = rescue_node.reference() {
-        ps.emit_op(" => ".to_string());
+        ps.emit_space();
+        ps.emit_op(Cow::Borrowed("=>"));
+        ps.emit_space();
         ps.with_start_of_line(false, |ps| {
             format_node(ps, reference);
         });

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -48,7 +48,7 @@ pub enum ConcreteLineToken {
     CloseCurlyBracket,
     OpenParen,
     CloseParen,
-    Op { op: String },
+    Op { op: Cow<'static, str> },
     DoubleQuote,
     LTStringContent { content: String },
     SingleSlash,
@@ -91,7 +91,7 @@ impl ConcreteLineToken {
             Self::CloseCurlyBracket => Cow::Borrowed("}"),
             Self::OpenParen => Cow::Borrowed("("),
             Self::CloseParen => Cow::Borrowed(")"),
-            Self::Op { op } => Cow::Owned(op),
+            Self::Op { op } => op,
             Self::DoubleQuote => Cow::Borrowed("\""),
             Self::LTStringContent { content } => Cow::Owned(content),
             Self::SingleSlash => Cow::Borrowed("\\"),
@@ -123,8 +123,8 @@ impl ConcreteLineToken {
             Keyword { keyword: contents }
             | ModKeyword { contents }
             | ConditionalKeyword { contents } => contents.len(),
-            Op { op: contents }
-            | DirectPart { part: contents }
+            Op { op: contents } => contents.len(),
+            DirectPart { part: contents }
             | LTStringContent { content: contents }
             | Comment { contents }
             | HeredocClose { symbol: contents } => contents.len(),

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -9,6 +9,7 @@ use crate::render_targets::{
 };
 use crate::types::{ColNumber, LineNumber, SourceOffset};
 use log::debug;
+use std::borrow::Cow;
 use std::io::{self, Cursor, Write};
 use std::str;
 
@@ -434,7 +435,7 @@ impl ParserState {
             .merge(comments.apply_spaces(self.spaces_after_last_newline));
     }
 
-    pub(crate) fn emit_op(&mut self, op: String) {
+    pub(crate) fn emit_op(&mut self, op: Cow<'static, str>) {
         self.push_concrete_token(ConcreteLineToken::Op { op });
     }
 


### PR DESCRIPTION
On the tin. Some op tokens are copied from their respective nodes, so I opted to have this take a `Cow` itself instead of trying to wrangle lifetimes for the time being, allowing most nodes to pass a `&str` and the few operator writes to continue using `String`.