### PR TITLE
[prism] Properly implement scoping rules

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1502,6 +1502,26 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
             // For a[] or a[]= with no arguments, we still need to emit the brackets
             ps.emit_open_square_bracket();
             ps.emit_close_square_bracket();
+        } else if !skip_receiver
+            || call_node
+                .receiver()
+                .map(|r| r.as_self_node().is_some())
+                .unwrap_or(false)
+        {
+            // Check if we need parens in two cases: we're the
+            // first/only item in a call chain (thus `!skip_receiver`)
+            // or we're in a chain but the receiver is `self`
+            let should_use_parens = use_parens_for_call_node(
+                ps,
+                &call_node,
+                &method_name,
+                ps.current_formatting_context(),
+            );
+
+            if should_use_parens {
+                ps.emit_open_paren();
+                ps.emit_close_paren();
+            }
         }
         if let Some(block) = call_node.block() {
             if block.as_block_argument_node().is_none() {
@@ -2306,7 +2326,6 @@ fn format_local_variable_read_node(
     local_variable_read_node: prism::LocalVariableReadNode,
 ) {
     let name = const_to_string(local_variable_read_node.name());
-    ps.bind_variable(name.clone());
     ps.emit_ident(name);
 }
 
@@ -3243,7 +3262,9 @@ fn format_optional_parameter_node(
     ps: &mut ParserState,
     optional_parameter_node: prism::OptionalParameterNode,
 ) {
-    ps.emit_ident(const_to_string(optional_parameter_node.name()));
+    let name = const_to_string(optional_parameter_node.name());
+    ps.bind_variable(name.clone());
+    ps.emit_ident(name);
     ps.emit_space();
     ps.emit_op(Cow::Borrowed("="));
     ps.emit_space();

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -41,7 +41,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_brace_blocks_with_no_args",
     "small_break_all_the_things",
     "small_comments_at_indentation_changes",
-    "small_const_call",
     "small_dotcall",
     "small_dyna_symbol_with_escapes",
     "small_empty_arg_paren",
@@ -55,13 +54,11 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_percent_q",
     "small_return",
     "small_rspec_its",
-    "small_scoping",
     "small_single_massign",
     "small_string_dvar",
     "small_string_first_item_is_embed",
     "small_string_literal_with_class_interp",
     "small_string_with_embexpr_dyna_symbol",
-    "small_variable_binding",
     "small_visibility_modifier",
 ];
 


### PR DESCRIPTION
We (mostly) correctly were adding idents to the current scope in Prism, but we were missing the implementation in the call node handling. This adds that implementation and fixes a few small prior oversights.