### PR TITLE
[ripper] Correctly break breakables with multiline double-quote strings

### DIFF
--- a/fixtures/small/gemfile_expected.rb
+++ b/fixtures/small/gemfile_expected.rb
@@ -17,8 +17,10 @@ scope(
   :with_ticket_types,
   -> {
     group("shops.id")
-      .joins("LEFT JOIN foos ON foos.bar_id
-= bars.id")
+      .joins(
+        "LEFT JOIN foos ON foos.bar_id
+= bars.id"
+      )
       .select("foos.*, COUNT(bars.id) count")
   }
 )

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -446,6 +446,9 @@ impl ParserState {
     pub(crate) fn emit_string_content(&mut self, s: String) {
         let newline_count = s.matches('\n').count() as u64;
         self.current_orig_line_number += newline_count;
+        for be in self.breakable_entry_stack.iter_mut().rev() {
+            be.push_line_number(self.current_orig_line_number);
+        }
 
         self.push_concrete_token(ConcreteLineToken::LTStringContent { content: s });
     }

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -44,7 +44,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_dotcall",
     "small_dyna_symbol_with_escapes",
     "small_empty_arg_paren",
-    "small_gemfile",
     "small_inline_rescue",
     "small_method_annotation",
     "small_multiline_method_chain_with_arguments",


### PR DESCRIPTION
While looking at Prism failures, I noticed that this Ripper output actually seemed wrong. Generally, the rule for breakables is that if the contents of the breakable are on multiple lines, then the breakable is also multiline. The Prism implementation did this correctly for strings, but the Ripper implementation didn't.

For double-quoted strings with newline characters, we adjust the `current_line_number` in the parser state, but incorrectly failed to update that for the breakable stack. In most cases, callers that do this will use heredocs (and the heredoc machinery correctly handles this case), but on the rare usage of a multiline double-quoted string, it didn't.

In short:

```ruby
# before
method("string on
multiple lines")

# after
method(
  "string on
multiple lines"
)
```