### PR TITLE
[prism] Elide parens for reserved test names

### DIFF
--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -619,7 +619,7 @@ pub fn args_has_single_def_expression(args: &ArgsAddStarOrExpressionListOrArgsFo
     false
 }
 
-static RSPEC_METHODS: LazyLock<HashSet<&'static str>> =
+pub static RSPEC_METHODS: LazyLock<HashSet<&'static str>> =
     LazyLock::new(|| vec!["it", "describe"].into_iter().collect());
 
 pub static GEMFILE_METHODS: LazyLock<HashSet<&'static str>> =

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4,12 +4,12 @@ use ruby_prism as prism;
 
 use crate::{
     delimiters::BreakableDelims,
-    format::{GEMFILE_METHODS, OPTIONALLY_PARENTHESIZED_METHODS, SpecialCase},
+    format::{GEMFILE_METHODS, OPTIONALLY_PARENTHESIZED_METHODS, RSPEC_METHODS, SpecialCase},
     heredoc_string::HeredocKind,
     parser_state::{FormattingContext, HashType, ParserState},
     render_targets::MultilineHandling,
     types::SourceOffset,
-    util::{const_to_string, loc_to_str, loc_to_string, u8_to_string},
+    util::{const_to_str, const_to_string, loc_to_str, loc_to_string, u8_to_string},
 };
 
 pub fn format_node(ps: &mut ParserState, node: prism::Node) {
@@ -1375,6 +1375,31 @@ fn use_parens_for_call_node(
 
     if !has_arguments {
         return false;
+    }
+
+    let has_brace_block = call_node
+        .block()
+        .and_then(|b| b.as_block_node())
+        .map(|block| &loc_to_string(block.opening_loc()) != "do")
+        .unwrap_or(false);
+
+    if has_brace_block {
+        // Brace blocks require parens, eliding is a syntax error
+        return true;
+    }
+
+    if RSPEC_METHODS.contains(method_name) && call_node.receiver().is_none() {
+        return false;
+    }
+
+    // Check for `RSpec.describe`
+    if let Some(receiver) = call_node.receiver()
+        && let Some(const_read) = receiver.as_constant_read_node()
+    {
+        let const_name = const_to_str(const_read.name());
+        if const_name == "RSpec" && method_name == "describe" {
+            return false;
+        }
     }
 
     if context == FormattingContext::ClassOrModule && !original_used_parens {

--- a/librubyfmt/src/util.rs
+++ b/librubyfmt/src/util.rs
@@ -12,6 +12,10 @@ pub fn const_to_string(constant_id: ConstantId) -> String {
     u8_to_string(constant_id.as_slice())
 }
 
+pub fn const_to_str(constant_id: ConstantId<'_>) -> &str {
+    u8_to_str(constant_id.as_slice())
+}
+
 pub fn loc_to_str(loc: Location<'_>) -> &str {
     u8_to_str(loc.as_slice())
 }

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -51,7 +51,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_pathological_heredocs",
     "small_percent_q",
     "small_return",
-    "small_rspec_its",
     "small_single_massign",
     "small_string_dvar",
     "small_string_first_item_is_embed",


### PR DESCRIPTION
`it` and `describe` (and `RSpec.describe`) have special-cases where they don't use parentheses. This adds that same logic to the Prism implementation.