### PR TITLE
remove unnecessary call to `to_owned`

### DIFF
--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -159,7 +159,6 @@ impl ParserState {
                     .as_ref()
                     .map(|comments| comments.has_comments())
                     .unwrap_or(false)
-                    .to_owned()
                 {
                     self.push_concrete_token(ConcreteLineToken::HardNewLine);
                 }


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
I'm not sure what this is/was trying to take ownership of, but we don't need it anymore.