### PR TITLE
[prism] Unwrap infix arguments from `ArgumentsNode`

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1583,7 +1583,15 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
                         ps,
                         call_node.receiver().unwrap(),
                         method_name,
-                        call_node.arguments().unwrap().as_node(),
+                        // For infix operators, we still get an ArgumentsNode, but it will
+                        // always be an argument list of a single node.
+                        call_node
+                            .arguments()
+                            .unwrap()
+                            .arguments()
+                            .iter()
+                            .next()
+                            .unwrap(),
                     );
                 });
             } else {

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -32,9 +32,7 @@ const DISABLED_RIPPER_TESTS: &[&'static str] = &[
 
 // These tests will have their prism variants automatically ignored
 const DISABLED_PRISM_TESTS: &[&'static str] = &[
-    "large_concurrent-ruby_ivar",
     "large_rspec_core_notifications",
-    "large_rspec_mocks_proxy",
     "small_aref_in_call",
     "small_aref_rest_param",
     "small_binary_operators",
@@ -46,7 +44,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_empty_arg_paren",
     "small_inline_rescue",
     "small_method_annotation",
-    "small_multiline_method_chain_with_arguments",
     "small_paren_expr_calls",
     "small_pathological_heredocs",
     "small_percent_q",


### PR DESCRIPTION
Infix operators in Prism are just plain ol' `CallNode`s, and as such they wrap the right hand side of infix operators in an `ArgumentsNode` just like any other call. Because of that, we were trying to render them _as arguments_, which means rendering them as a list that could potentially break etc. This added an extra newline in many cases, which is incorrect.

To get around this, we just unwrap the single node from the `ArgumentsNode`. Infix operators can only ever have a single argument (unless there's some insane Ruby secret I don't know, in which case that's terrifying), so we can just read it from the `arguments()` of the `ArgumentsNode`.