### PR TITLE
[prism] Always render block local variables on a single line

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2033,7 +2033,7 @@ fn format_block_parameters_names(
     if has_locals {
         ps.emit_ident(";".to_string());
         ps.with_start_of_line(false, |ps| {
-            format_list_like_thing(ps, locals, end_offset, false);
+            format_list_like_thing(ps, locals, end_offset, true);
         });
     }
 }

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -39,7 +39,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_aref_rest_param",
     "small_binary_operators",
     "small_brace_blocks_with_no_args",
-    "small_break_all_the_things",
     "small_comments_at_indentation_changes",
     "small_dotcall",
     "small_dyna_symbol_with_escapes",


### PR DESCRIPTION
On the tin -- this is [what the Ripper implementation does](https://github.com/fables-tales/rubyfmt/blob/cb2b5d36c771004e799a07127a2eaabc2fe7d328/librubyfmt/src/format.rs#L157). Is this definitely correct choice? Eh, I don't know (generally any list-like thing _should_ be able to break to multiple lines), but it's a sufficiently rare syntax feature that I'd be surprised how often the multiline version even matters anyways, and getting it to format nicely would probably require some bikeshedding, so I'll just leave it as-is for now.