### PR TITLE
[prism] Implement inline rescue node

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3423,10 +3423,16 @@ fn format_regular_expression_node(
 }
 
 fn format_rescue_modifier_node(
-    _ps: &mut ParserState,
-    _rescue_modifier_node: prism::RescueModifierNode,
+    ps: &mut ParserState,
+    rescue_modifier_node: prism::RescueModifierNode,
 ) {
-    todo!()
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, rescue_modifier_node.expression());
+        ps.emit_space();
+        ps.emit_rescue();
+        ps.emit_space();
+        format_node(ps, rescue_modifier_node.rescue_expression());
+    });
 }
 
 fn format_rescue_node(ps: &mut ParserState, rescue_node: prism::RescueNode) {

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -44,7 +44,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_dotcall",
     "small_dyna_symbol_with_escapes",
     "small_empty_arg_paren",
-    "small_inline_rescue",
     "small_method_annotation",
     "small_multiline_method_chain_with_arguments",
     "small_paren_expr_calls",


### PR DESCRIPTION
On the tin.

(Note for the future -- inline rescues should _probably_ have a break-to-block-form like if/unless/while/etc. mod forms do, but I'm intentionally leaving that for another day. Ripper also doesn't implement a form that breaks, so this is just maintaining the status quo.)