### PR TITLE
[prism] Fix backslash string interpolation detection

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -663,11 +663,20 @@ fn format_interpolated_string_node(
     // as an interpolated node with the contents `"foobar"` (in two `parts` of "foo" and "bar").
     // To detect this, we can look for any `InterpolatedStringNode` that has multiple `parts`
     // and isn't a heredoc.
+    //
+    // Note that Prism itself essentially scrubs any traces of heredocs, and so we have to detect it ourselves.
+    // The logic for this is taken straight from Prism's Ripper translator:
+    // https://github.com/ruby/prism/blob/609c80c91e146d9ac8f70deedfadca729e8a3e4f/lib/prism/translation/ripper.rb#L2183-L2189
     let is_backslash_string_interpolation = !is_heredoc
-        && interpolated_string_node.parts().iter().all(|node| {
+        && interpolated_string_node.parts().iter().count() > 1
+        && interpolated_string_node.parts().iter().any(|node| {
             node.as_string_node()
-                .map(|s| s.opening_loc().is_some())
+                .map(|node| node.opening_loc().is_some())
                 .unwrap_or(false)
+                || node
+                    .as_interpolated_string_node()
+                    .map(|node| node.opening_loc().is_some())
+                    .unwrap_or(false)
         });
 
     ps.at_offset(interpolated_string_node.location().start_offset());

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -54,7 +54,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_single_massign",
     "small_string_dvar",
     "small_string_first_item_is_embed",
-    "small_string_literal_with_class_interp",
     "small_string_with_embexpr_dyna_symbol",
     "small_visibility_modifier",
 ];


### PR DESCRIPTION
**BLUF**: This actually implements backslash string interpolation for real(-ish).

---

While Ripper had a really handy `string_concat` node type, Prism seems to basically scrub any traces of backslash string concatenation. It reports them just as an `InterpolatedStringNode` with several parts -- no loc for the `\` or anything.

To that end, it seems we have to detect these instances ourself. To corroborate that decision, Prism's own Ripper translator does [this exact same form of detection](https://github.com/ruby/prism/blob/609c80c91e146d9ac8f70deedfadca729e8a3e4f/lib/prism/translation/ripper.rb#L2183-L2189) in order to handle `on_string_concat` calls, so we're at least in good company here. (I would _rather_ this be actually supported in Prism, but I haven't done any investigation on how hard that is and don't intend to until this logic turns out to be incorrect or someone yells at me about it. If you, dear reader, feel like making that change, you will have my eternal gratitude.)