### PR TITLE
[prism] Fix implicit rest node spacing

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3274,10 +3274,14 @@ fn format_multi_targets(
         }
 
         if let Some(rest) = rest {
-            if has_lefts {
-                ps.emit_comma_space();
+            if rest.as_implicit_rest_node().is_some() {
+                ps.emit_comma();
+            } else {
+                if has_lefts {
+                    ps.emit_comma_space();
+                }
+                format_node(ps, rest);
             }
-            format_node(ps, rest);
         }
 
         if has_rights {

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -43,7 +43,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_paren_expr_calls",
     "small_pathological_heredocs",
     "small_percent_q",
-    "small_single_massign",
     "small_string_dvar",
     "small_string_first_item_is_embed",
     "small_string_with_embexpr_dyna_symbol",


### PR DESCRIPTION
This is another case where implicit nodes have needed some special cases (see also #609).

In cases like `a, = []`, there's an `ImplicitRestNode` which doesn't _really_ correspond to anything specifically, it just represents an elided rest param. In our case, we were emitting a comma and space assuming we would also emit a name, but there isn't one in this case, so we just emit a comma and continue on.