### PR TITLE
[prism] Fix multilining for returns

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3487,15 +3487,22 @@ fn format_return_node(ps: &mut ParserState, return_node: prism::ReturnNode) {
     ps.emit_ident("return".to_string());
     ps.with_start_of_line(false, |ps| {
         if let Some(arguments) = return_node.arguments() {
-            ps.emit_space();
-            ps.with_start_of_line(false, |ps| {
-                format_list_like_thing(
-                    ps,
-                    arguments.arguments(),
-                    arguments.location().end_offset(),
-                    true,
-                );
-            });
+            let arguments_list = arguments.arguments();
+            if arguments_list.iter().count() == 1 {
+                ps.emit_space();
+                format_node(ps, arguments_list.iter().last().unwrap());
+            } else {
+                ps.breakable_of(BreakableDelims::for_return_kw(), |ps| {
+                    ps.with_start_of_line(false, |ps| {
+                        format_list_like_thing(
+                            ps,
+                            arguments_list,
+                            arguments.location().end_offset(),
+                            false,
+                        );
+                    });
+                });
+            }
         }
     });
 }

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -50,7 +50,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_paren_expr_calls",
     "small_pathological_heredocs",
     "small_percent_q",
-    "small_return",
     "small_single_massign",
     "small_string_dvar",
     "small_string_first_item_is_embed",


### PR DESCRIPTION
Returns are slightly special in that we explicitly format them as an array if they return multiple items (and those items are on multiple lines), so this PR adds support for that instead of trying to always shove them onto a single line.