### PR TITLE
[prism] Correctly handle spacing between `end` and `def` tokens

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1058,7 +1058,7 @@ fn format_module_node(ps: &mut ParserState, module_node: prism::ModuleNode) {
 }
 
 fn format_def_node(ps: &mut ParserState, def_node: prism::DefNode) {
-    ps.emit_keyword("def");
+    ps.emit_def_keyword();
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
@@ -1571,6 +1571,11 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
                 ps.with_start_of_line(false, |ps| {
                     format_node(ps, block);
                 });
+                // Only emit this when we're not inside a call chain (`skip_receiver` is false),
+                // since call chains emit AfterCallChain after the entire chain is done.
+                if !skip_receiver {
+                    ps.emit_after_call_chain();
+                }
             // If there's an arguments node, we've handled this block arg with
             // the rest of the args (since it's included in the comma-separated
             // args list), otherwise the only argument is the &blk node, so we

--- a/librubyfmt/src/intermediary.rs
+++ b/librubyfmt/src/intermediary.rs
@@ -220,10 +220,17 @@ impl Intermediary {
     }
 
     pub fn insert_blankline_from_end(&mut self, index_from_end: usize) {
-        self.tokens.insert(
-            self.tokens.len() - index_from_end,
-            ConcreteLineToken::HardNewLine,
-        )
+        let insert_position = self.tokens.len() - index_from_end;
+        self.tokens
+            .insert(insert_position, ConcreteLineToken::HardNewLine);
+
+        // If the insertion was at or before it, we'll have moved the last
+        // hard newline up by one place
+        if insert_position <= self.index_of_last_hard_newline {
+            self.index_of_last_hard_newline += 1;
+        }
+
+        self.debug_assert_newlines();
     }
 
     pub fn insert_trailing_blankline(&mut self, _bl: BlanklineReason) {

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -8,20 +8,6 @@ use std::{
 
 use assert_cmd::Command;
 
-// TODO: These tests fail in debug but work in release builds
-// due to some newline shenanigans, we should investigate why
-#[cfg(debug_assertions)]
-const IGNORED_IN_DEBUG: &[&'static str] = &[
-    "test_prism_large_concurrent-ruby_non_concurrent_map_backend",
-    "test_prism_large_rspec_mocks_proxy",
-    "test_ripper_large_concurrent-ruby_non_concurrent_map_backend",
-    "test_ripper_large_concurrent_ruby_future",
-    "test_ripper_large_rspec_mocks_proxy",
-];
-
-#[cfg(not(debug_assertions))]
-const IGNORED_IN_DEBUG: &[&'static str] = &[];
-
 // These tests are disabled due to ripper issues
 const DISABLED_RIPPER_TESTS: &[&'static str] = &[
     // TODO: The Ripper implementation does not currently support args forwarding with additional
@@ -39,14 +25,12 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_comments_at_indentation_changes",
     "small_dyna_symbol_with_escapes",
     "small_empty_arg_paren",
-    "small_method_annotation",
     "small_paren_expr_calls",
     "small_pathological_heredocs",
     "small_percent_q",
     "small_string_dvar",
     "small_string_first_item_is_embed",
     "small_string_with_embexpr_dyna_symbol",
-    "small_visibility_modifier",
 ];
 
 fn main() -> io::Result<()> {
@@ -94,8 +78,7 @@ struct Fixture {
 impl Fixture {
     fn to_trial(&self, flavor: Flavor) -> Trial {
         let name = format!("test_{}_{}", flavor.to_str(), self.name);
-        let is_ignored = IGNORED_IN_DEBUG.contains(&name.as_str())
-            || flavor.disabled_list().contains(&self.name.as_str());
+        let is_ignored = flavor.disabled_list().contains(&self.name.as_str());
         let actual = self.actual.clone();
         let expected = self.expected.clone();
         Trial::test(name.clone(), move || {


### PR DESCRIPTION
Normally, we add an extra newline after `end` nodes, but we have special handling for "method annotations" (mostly for `sig` and friends) where we detect `end`s followed by a `def` and don't insert this newline. This was previously busted because we were skipping emitting `AfterCallChain` tokens for single-element block calls (that is, calls with blocks not part of a call chain), which this handling depends on.

While investigating this, I also fixed a long-standing bug! It's nothing user-facing, but we had a set of tests that perennially failed in `debug` due to some assertions failing. The assertions failed because when we insert newlines in the render queue, we were failing to update the `index_of_last_hard_newline` attribute, which then triggered some, er, [_descriptive_](https://github.com/fables-tales/rubyfmt/blob/d033a7b24fe413490ee213a167b2a9559f2b8a06/librubyfmt/src/intermediary.rs#L272) debug assertions. This is now fixed!