### PR TITLE
[prism] Bump ruby-prism to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,12 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,12 +327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,16 +347,6 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
-dependencies = [
- "equivalent",
- "hashbrown",
 ]
 
 [[package]]
@@ -629,20 +607,20 @@ dependencies = [
 
 [[package]]
 name = "ruby-prism"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2486ac87dae4e4cbc31f5b7a5aa711a51d3c3fcd412d88745a34fa2f4721df8"
+checksum = "be11d8c2bb448a74d1b4804600cce66e8323696c11f8e0589bb07de57e8ab3f0"
 dependencies = [
  "ruby-prism-sys",
  "serde",
- "serde_yaml",
+ "serde_json",
 ]
 
 [[package]]
 name = "ruby-prism-sys"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2646504a4f369cad36018453a60b1b69b8068ae054db40fdb343e224b86d8061"
+checksum = "1540c758b97b61561d937cfcd2e1e03c840e8c63f8e8bba64ff924d5ee374396"
 dependencies = [
  "bindgen",
  "cc",
@@ -737,16 +715,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_json"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "indexmap",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -864,12 +841,6 @@ name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -14,7 +14,7 @@ fancy-regex = "0.14.0"
 ripper_deserialize = { path = "ripper_deserialize" }
 log = { version = "0.4.8", features = ["max_level_debug", "release_max_level_warn"] }
 simplelog = "0.12"
-ruby-prism="1.6.0"
+ruby-prism="1.7.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = { version = "0.3.0", features = ["disable_initial_exec_tls"], optional=true }

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -668,7 +668,7 @@ fn format_interpolated_string_node(
     // The logic for this is taken straight from Prism's Ripper translator:
     // https://github.com/ruby/prism/blob/609c80c91e146d9ac8f70deedfadca729e8a3e4f/lib/prism/translation/ripper.rb#L2183-L2189
     let is_backslash_string_interpolation = !is_heredoc
-        && interpolated_string_node.parts().iter().count() > 1
+        && interpolated_string_node.parts().len() > 1
         && interpolated_string_node.parts().iter().any(|node| {
             node.as_string_node()
                 .map(|node| node.opening_loc().is_some())
@@ -699,7 +699,7 @@ fn format_interpolated_string_node(
     }
 
     ps.with_start_of_line(false, |ps| {
-        let string_parts_count = interpolated_string_node.parts().iter().count();
+        let string_parts_count = interpolated_string_node.parts().len();
         for (i, part) in interpolated_string_node.parts().iter().enumerate() {
             let start_offset = part.location().start_offset();
             let end_offset = part.location().end_offset();
@@ -880,7 +880,7 @@ fn format_embedded_statements_node(
     ps.emit_string_content("#{".to_string());
     if let Some(statements) = embedded_statements_node.statements() {
         ps.with_formatting_context(FormattingContext::StringEmbexpr, |ps| {
-            let has_multiple_statements = statements.body().iter().count() > 1;
+            let has_multiple_statements = statements.body().len() > 1;
             ps.with_start_of_line(has_multiple_statements, |ps| {
                 if has_multiple_statements {
                     ps.emit_newline();
@@ -1446,7 +1446,7 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
         if let Some(arguments) = call_node.arguments() {
             // For callers where the only arg is a def node,
             // we assume that's a `public def` style modifier and don't use parens
-            if arguments.arguments().iter().count() == 1
+            if arguments.arguments().len() == 1
                 && arguments
                     .arguments()
                     .iter()
@@ -1466,7 +1466,7 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
                     .unwrap();
                 format_def_node(ps, def_node);
             } else if is_aref_write {
-                let arg_count = arguments.arguments().iter().count();
+                let arg_count = arguments.arguments().len();
 
                 ps.with_start_of_line(false, |ps| {
                     ps.breakable_of(BreakableDelims::for_array(), |ps| {
@@ -1744,7 +1744,7 @@ fn as_binary_op<'a>(
     let left = call_node.receiver()?;
 
     let arguments = call_node.arguments()?.arguments();
-    if arguments.iter().count() != 1 {
+    if arguments.len() != 1 {
         return None;
     }
 
@@ -2025,7 +2025,7 @@ fn format_block_node(ps: &mut ParserState, block_node: prism::BlockNode) {
             if let Some(body) = block_node.body() {
                 let has_multiple_statements = body
                     .as_statements_node()
-                    .map(|statements_node| statements_node.body().iter().count() > 1)
+                    .map(|statements_node| statements_node.body().len() > 1)
                     .unwrap_or(false);
                 if has_multiple_statements {
                     ps.emit_soft_newline();
@@ -2180,7 +2180,7 @@ fn format_word_array_elements(
     node_list: prism::NodeList,
     end_offset: SourceOffset,
 ) {
-    let args_count = node_list.iter().count();
+    let args_count = node_list.len();
 
     ps.magic_handle_comments_for_multiline_arrays(
         Some(ps.get_line_number_for_offset(end_offset)),
@@ -2214,7 +2214,7 @@ fn format_parentheses_node(ps: &mut ParserState, parentheses_node: prism::Parent
 
     let is_multiline = if let Some(body) = parentheses_node.body() {
         if let Some(statements_node) = body.as_statements_node() {
-            statements_node.body().iter().count() > 1
+            statements_node.body().len() > 1
         } else {
             true
         }
@@ -2225,7 +2225,7 @@ fn format_parentheses_node(ps: &mut ParserState, parentheses_node: prism::Parent
     if let Some(body) = parentheses_node.body() {
         ps.with_start_of_line(false, |ps| {
             if let Some(statements_node) = body.as_statements_node() {
-                if statements_node.body().iter().count() == 1 {
+                if statements_node.body().len() == 1 {
                     ps.with_start_of_line(false, |ps| {
                         format_node(ps, statements_node.body().iter().next().unwrap())
                     });
@@ -3204,7 +3204,7 @@ fn format_lambda_node(ps: &mut ParserState, lambda_node: prism::LambdaNode) {
                 if let Some(body) = lambda_node.body() {
                     let has_multiple_statements = body
                         .as_statements_node()
-                        .map(|statements_node| statements_node.body().iter().count() > 1)
+                        .map(|statements_node| statements_node.body().len() > 1)
                         .unwrap_or(false);
                     if has_multiple_statements {
                         ps.emit_soft_newline();
@@ -3288,9 +3288,9 @@ fn format_multi_targets(
     rest: Option<prism::Node>,
     rights: prism::NodeList,
 ) {
-    let has_lefts = lefts.iter().count() > 0;
+    let has_lefts = lefts.len() > 0;
     let has_rest = rest.is_some();
-    let has_rights = rights.iter().count() > 0;
+    let has_rights = rights.len() > 0;
 
     ps.with_start_of_line(false, |ps| {
         if has_lefts {
@@ -3566,7 +3566,7 @@ fn format_return_node(ps: &mut ParserState, return_node: prism::ReturnNode) {
     ps.with_start_of_line(false, |ps| {
         if let Some(arguments) = return_node.arguments() {
             let arguments_list = arguments.arguments();
-            if arguments_list.iter().count() == 1 {
+            if arguments_list.len() == 1 {
                 ps.emit_space();
                 format_node(ps, arguments_list.iter().last().unwrap());
             } else {
@@ -3722,7 +3722,7 @@ fn format_yield_node(ps: &mut ParserState, yield_node: prism::YieldNode) {
             || (yield_node
                 .arguments()
                 .map(|args| {
-                    args.arguments().iter().count() == 1
+                    args.arguments().len() == 1
                         && args
                             .arguments()
                             .iter()
@@ -3773,7 +3773,7 @@ fn format_list_like_thing(
     single_line: bool,
 ) -> bool {
     let mut emitted_args = false;
-    let args_count = node_list.iter().count();
+    let args_count = node_list.len();
 
     ps.magic_handle_comments_for_multiline_arrays(
         Some(ps.get_line_number_for_offset(end_offset)),

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3288,9 +3288,9 @@ fn format_multi_targets(
     rest: Option<prism::Node>,
     rights: prism::NodeList,
 ) {
-    let has_lefts = lefts.len() > 0;
+    let has_lefts = !lefts.is_empty();
     let has_rest = rest.is_some();
-    let has_rights = rights.len() > 0;
+    let has_rights = !rights.is_empty();
 
     ps.with_start_of_line(false, |ps| {
         if has_lefts {


### PR DESCRIPTION
On the tin -- the main thing I want in this version is @froydnj's change to add `.len()` to `NodeList` and `ConstantList` 🎉 

So this PR just bumps the version and updates a bunch of `.iter().count()` to `.len()`.