### PR TITLE
[prism] Fix multiline call chain detection

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1890,16 +1890,18 @@ fn call_chain_elements_are_user_multilined(
         }
     }
 
-    let start_line = ps.get_line_number_for_offset(
-        call_chain_elements
-            .first()
-            .unwrap()
-            .location()
-            .start_offset(),
-    );
-    !call_chain_elements[1..].iter().all(|cce| {
+    let start_line = {
+        let start_node = call_chain_elements.first().unwrap();
+        if let Some(call_node) = start_node.as_call_node() {
+            ps.get_line_number_for_offset(start_loc_for_call_node_in_chain(&call_node))
+        } else {
+            ps.get_line_number_for_offset(start_node.location().start_offset())
+        }
+    };
+
+    call_chain_elements[1..].iter().any(|cce| {
         start_line
-            == cce
+            != cce
                 .as_call_node()
                 .unwrap()
                 .call_operator_loc()

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -19,7 +19,6 @@ const DISABLED_RIPPER_TESTS: &[&'static str] = &[
 // These tests will have their prism variants automatically ignored
 const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_aref_in_call",
-    "small_binary_operators",
     "small_brace_blocks_with_no_args",
     "small_comments_at_indentation_changes",
     "small_dyna_symbol_with_escapes",


### PR DESCRIPTION
One particular thing about the way we multiline call chains is that we only consider the call nodes after the first expression in cases where the first expression is a multiline hash/array/paren/etc. literal. This is so that things like

```ruby
[
  "foo",
  "bar",
  "bees"
].freeze
```

leave `freeze` connected to the array.

There was a small issue related to this, which is that we were using the first node's `node.location().start_location()` as the start line to compare against, but `CallNode` includes as its receiver the array node (in this example), which is the wrong start location to use. I've updated this to use that CallNode's message loc (with a safe fallback to the dot loc for dot calls).