### PR TITLE
[prism] Fix line winding for comments after the end of call chains

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1536,6 +1536,10 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
                     None
                 };
 
+                let maybe_closing_line = call_node
+                    .closing_loc()
+                    .map(|closing_loc| ps.get_line_number_for_offset(closing_loc.start_offset()));
+
                 ps.with_start_of_line(false, |ps| {
                     ps.breakable_of(delims, |ps| {
                         let has_arguments = !arguments.arguments().is_empty();
@@ -1564,12 +1568,19 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
                             format_block_argument_node(ps, block_argument_node);
                         }
 
-                        // Ensure that we render comments between the last argument and closing parens
-                        if let Some(closing_loc) = call_node.closing_loc() {
-                            ps.wind_dumping_comments_until_offset(closing_loc.end_offset());
+                        // Ensure that we render comments between the last argument and
+                        // closing parens. We wind to one line before the closing paren
+                        // to pick up comments that are inside the args but not trailing
+                        // comments on the same line as the closing delim (like `) # comment`).
+                        if let Some(closing_line) = maybe_closing_line {
+                            ps.wind_dumping_comments_until_line(closing_line - 1);
                         }
                     });
                 });
+
+                if let Some(closing_line) = maybe_closing_line {
+                    ps.on_line(closing_line);
+                }
             };
         } else if is_aref {
             // For a[] or a[]= with no arguments, we still need to emit the brackets
@@ -1841,12 +1852,13 @@ fn format_call_chain(ps: &mut ParserState, call_node: ruby_prism::CallNode<'_>) 
                             }
                         }
 
-                        ps.at_offset(element.location().start_offset());
+                        ps.at_offset(start_loc_for_call_node_in_chain(&element));
+                        ps.shift_comments();
+
                         format_call_node(ps, element, true);
                     }
                 });
                 ps.end_indent_for_call_chain();
-                ps.shift_comments();
             },
         );
     });

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -21,7 +21,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_aref_in_call",
     "small_binary_operators",
     "small_brace_blocks_with_no_args",
-    "small_comments_at_indentation_changes",
     "small_dyna_symbol_with_escapes",
     "small_pathological_heredocs",
     "small_percent_q",


### PR DESCRIPTION
Previously, we were winding all the way to the end loc of call chains, but all of our line winding internals operate on _lines_ and not on _offsets_, so comments on the same line as the closing delimiter were being pulled in and rendered above the delim. This is not what we want. Instead, I've made it wind to the line _right above_ the closing delim inside the breakable, and then only winding to the closing delim line outside the breakable so it renders as expected.

(FWIW, I'm totally open to the idea that this is not our long-term desired behavior, because IMO moving the comment potentially many lines up is pretty confusing, but this is the existing behavior so I'll leave it as-is for parity.)

Long term, it may be ideal to mostly have winding operate on offsets instead of lines, which would give us even more fine-grained tracking for individual locs. But that would be a pretty gnarly change that I didn't want to go into at the moment.