### PR TITLE
[prism] Fix rendering nested heredocs

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -787,6 +787,29 @@ fn format_heredoc(ps: &mut ParserState, heredoc: HeredocNodeType, heredoc_symbol
     ps.wind_dumping_comments_until_offset(heredoc.closing_loc().start_offset());
 }
 
+fn maybe_render_heredocs_in_string<'a>(
+    ps: &mut ParserState,
+    peekable: &mut std::iter::Peekable<impl Iterator<Item = &'a prism::Node<'a>>>,
+    is_heredoc: bool,
+) {
+    let should_render = is_heredoc
+        && match peekable.peek() {
+            Some(prism::Node::StringNode { .. }) => loc_to_string(
+                peekable
+                    .peek()
+                    .unwrap()
+                    .as_string_node()
+                    .unwrap()
+                    .content_loc(),
+            )
+            .starts_with('\n'),
+            _ => false,
+        };
+    if should_render {
+        ps.render_heredocs(true)
+    }
+}
+
 fn format_inner_string(ps: &mut ParserState, parts: Vec<prism::Node>, is_heredoc: bool) {
     let mut peekable = parts.iter().peekable();
     while let Some(part) = peekable.next() {
@@ -807,26 +830,11 @@ fn format_inner_string(ps: &mut ParserState, parts: Vec<prism::Node>, is_heredoc
             prism::Node::InterpolatedStringNode { .. } => {
                 ps.at_offset(part.location().start_offset());
                 format_interpolated_string_node(ps, part.as_interpolated_string_node().unwrap());
-
-                let on_line_skip = is_heredoc
-                    && match peekable.peek() {
-                        Some(prism::Node::StringNode { .. }) => loc_to_string(
-                            peekable
-                                .peek()
-                                .unwrap()
-                                .as_string_node()
-                                .unwrap()
-                                .content_loc(),
-                        )
-                        .starts_with('\n'),
-                        _ => false,
-                    };
-                if on_line_skip {
-                    ps.render_heredocs(true)
-                }
+                maybe_render_heredocs_in_string(ps, &mut peekable, is_heredoc);
             }
             prism::Node::EmbeddedStatementsNode { .. } => {
-                format_embedded_statements_node(ps, part.as_embedded_statements_node().unwrap())
+                format_embedded_statements_node(ps, part.as_embedded_statements_node().unwrap());
+                maybe_render_heredocs_in_string(ps, &mut peekable, is_heredoc);
             }
             prism::Node::EmbeddedVariableNode { .. } => {
                 format_embedded_variable_node(ps, part.as_embedded_variable_node().unwrap())

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -22,7 +22,6 @@ const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_aref_in_call",
     "small_brace_blocks_with_no_args",
     "small_dyna_symbol_with_escapes",
-    "small_pathological_heredocs",
     "small_percent_q",
     "small_string_dvar",
     "small_string_first_item_is_embed",


### PR DESCRIPTION
On the tin -- the code that handles rendering heredocs in interpolations was already run for `InterpolatedStringNode` but in our test also needs to run for `EmbeddedStatementsNode`s, since in our cursed fixture we have a heredoc with an interpolation (the former) but the interpolation itself also has a heredoc in it (the latter).