### PR TITLE
[prism] Handle %Q string nodes

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -660,7 +660,14 @@ fn format_interpolated_string_node(
     let opener = interpolated_string_node
         .opening_loc()
         .map(|s| loc_to_str(s).trim().to_string());
+    let closer = interpolated_string_node
+        .closing_loc()
+        .map(|s| loc_to_str(s).trim().to_string());
     let is_heredoc = opener.as_ref().map(|s| s.starts_with("<")).unwrap_or(false);
+    let needs_escape = opener
+        .as_ref()
+        .map(|s| !s.starts_with("\"") && !is_heredoc)
+        .unwrap_or(false);
 
     // Prism actually handles string concatenation when using "\", so it treats
     // ```ruby
@@ -702,7 +709,11 @@ fn format_interpolated_string_node(
     }
 
     if let Some(s) = &opener {
-        ps.emit_string_content(s.clone());
+        if needs_escape {
+            ps.emit_double_quote();
+        } else {
+            ps.emit_string_content(s.clone());
+        }
     }
 
     ps.with_start_of_line(false, |ps| {
@@ -720,13 +731,27 @@ fn format_interpolated_string_node(
                 ps.emit_indent();
             }
 
-            format_node(ps, part);
+            if needs_escape && let Some(string_node) = part.as_string_node() {
+                let content = loc_to_string(string_node.content_loc());
+                let escaped = crate::string_escape::single_to_double_quoted(
+                    content,
+                    opener.as_ref().unwrap(),
+                    closer.as_deref().unwrap_or("\""),
+                );
+                ps.emit_string_content(escaped);
+            } else {
+                format_node(ps, part);
+            }
 
             // For non-backslash-concatenated multiline strings, `part` contains newlines and indentation,
             // so we don't need to handle that ourselves.
             if is_backslash_string_interpolation && i < string_parts_count - 1 {
-                if let Some(s) = interpolated_string_node.closing_loc() {
-                    ps.emit_string_content(loc_to_str(s).trim().to_string());
+                if let Some(s) = &closer {
+                    if needs_escape {
+                        ps.emit_double_quote();
+                    } else {
+                        ps.emit_string_content(s.clone());
+                    }
                 }
                 ps.emit_space();
                 ps.emit_slash();
@@ -739,8 +764,12 @@ fn format_interpolated_string_node(
         }
     });
 
-    if let Some(closing_loc) = interpolated_string_node.closing_loc() {
-        ps.emit_string_content(loc_to_str(closing_loc).trim().to_string());
+    if let Some(closer) = &closer {
+        if needs_escape {
+            ps.emit_double_quote();
+        } else {
+            ps.emit_string_content(closer.clone());
+        }
     }
 }
 

--- a/librubyfmt/src/string_escape.rs
+++ b/librubyfmt/src/string_escape.rs
@@ -17,7 +17,7 @@ pub fn single_to_double_quoted(content: String, start_delim: &str, end_delim: &s
         };
 
         let regexp = Regex::new(&format!(
-            r#"(?<!\\)(\\\\)*(\"|\\\\{}|\\\\{})"#,
+            r#"(?<!\\)(\\\\)*(\"|\\{}|\\{})"#,
             fancy_regex::escape(start_delim),
             fancy_regex::escape(end_delim)
         ))

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -21,7 +21,6 @@ const DISABLED_RIPPER_TESTS: &[&'static str] = &[
 const DISABLED_PRISM_TESTS: &[&'static str] = &[
     "small_brace_blocks_with_no_args",
     "small_dyna_symbol_with_escapes",
-    "small_percent_q",
     "small_string_dvar",
     "small_string_first_item_is_embed",
     "small_string_with_embexpr_dyna_symbol",


### PR DESCRIPTION
On the tin -- this updates the string escaping bits to transform `%Q` into double-quoted strings.