### PR TITLE
[prism] Fix comment rendering for multiline brace blocks

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2202,8 +2202,20 @@ fn format_block_node(ps: &mut ParserState, block_node: prism::BlockNode) {
                     .map(|statements_node| statements_node.body().len() > 1)
                     .unwrap_or(false);
                 if has_multiple_statements {
-                    ps.emit_soft_newline();
-                    ps.with_start_of_line(true, |ps| format_node(ps, body));
+                    ps.emit_newline();
+                    ps.emit_indent();
+                    ps.with_start_of_line(false, |ps| {
+                        let statements = body.as_statements_node().unwrap().body();
+                        let mut peekable = statements.iter().peekable();
+                        while peekable.peek().is_some() {
+                            format_node(ps, peekable.next().unwrap());
+                            ps.emit_soft_newline();
+                            if peekable.peek().is_some() {
+                                ps.emit_soft_indent();
+                            }
+                        }
+                        ps.shift_comments();
+                    });
                 } else {
                     ps.with_start_of_line(false, |ps| {
                         if let Some(node) = body.as_statements_node().unwrap().body().iter().next()

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -18,10 +18,7 @@ const DISABLED_RIPPER_TESTS: &[&'static str] = &[
 ];
 
 // These tests will have their prism variants automatically ignored
-const DISABLED_PRISM_TESTS: &[&'static str] = &[
-    "small_brace_blocks_with_no_args",
-    "small_dyna_symbol_with_escapes",
-];
+const DISABLED_PRISM_TESTS: &[&'static str] = &["small_dyna_symbol_with_escapes"];
 
 fn main() -> io::Result<()> {
     let args = Arguments::from_args();


### PR DESCRIPTION
Brace blocks are weird for a number of reasons, not the least of which is that they have a lot of strange newline usages to be able to render expressions either on a single line `.map { foo }` or on multiple lines like a do/end block. To properly render comments in the multiline form, we generally need to use soft newlines, which are special cased inside the comment rendering machinery to insert at the right index. Previously I had them using hard newlines (automatically inserted in `format_node`, but this instead updates it to manually insert the appropriate soft newlines/indents so that comments render in the right spots.