### PR TITLE
[prism] Implement `ShareableConstantNode`

### DIFF
--- a/fixtures/small/shareable_constant_actual.rb
+++ b/fixtures/small/shareable_constant_actual.rb
@@ -1,0 +1,2 @@
+# shareable_constant_value: literal
+CONST = { a: 1,   b:   2 }

--- a/fixtures/small/shareable_constant_expected.rb
+++ b/fixtures/small/shareable_constant_expected.rb
@@ -1,0 +1,2 @@
+# shareable_constant_value: literal
+CONST = {a: 1, b: 2}

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4034,10 +4034,10 @@ fn format_return_node(ps: &mut ParserState, return_node: prism::ReturnNode) {
 }
 
 fn format_shareable_constant_node(
-    _ps: &mut ParserState,
-    _shareable_constant_node: prism::ShareableConstantNode,
+    ps: &mut ParserState,
+    shareable_constant_node: prism::ShareableConstantNode,
 ) {
-    todo!()
+    format_node(ps, shareable_constant_node.write());
 }
 
 fn format_singleton_class_node(


### PR DESCRIPTION
`ShareableConstantNode` is really just a regular node with a magic comment above it, so we can just pass it to `format_node` as usual 🤷‍♂️ 

(Also this'll be the last node type I'm doing for a bit -- I think every other node type left is related to pattern matching, which we hadn't yet implemented in Ripper either, so my primary focus is addressing any issues with Prism<>Ripper parity and then I'll work on pattern matching after that!)