### PR TITLE
make `single_to_double_quoted` take `&str`

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -639,7 +639,7 @@ fn format_string_node(ps: &mut ParserState, string_node: prism::StringNode) {
             };
 
             crate::string_escape::single_to_double_quoted(
-                loc_to_string(string_node.content_loc()),
+                loc_to_str(string_node.content_loc()),
                 opener.as_ref().unwrap(),
                 end_delim,
             )
@@ -735,7 +735,7 @@ fn format_interpolated_string_node(
             }
 
             if needs_escape && let Some(string_node) = part.as_string_node() {
-                let content = loc_to_string(string_node.content_loc());
+                let content = loc_to_str(string_node.content_loc());
                 let escaped = crate::string_escape::single_to_double_quoted(
                     content,
                     opener.as_ref().unwrap(),
@@ -2207,7 +2207,7 @@ fn format_symbol_node(ps: &mut ParserState, symbol_node: prism::SymbolNode) {
         ps.emit_double_quote();
 
         if let Some(value_loc) = symbol_node.value_loc() {
-            let content = loc_to_string(value_loc);
+            let content = loc_to_str(value_loc);
             let escaped = crate::string_escape::single_to_double_quoted(
                 content,
                 opener

--- a/librubyfmt/src/string_escape.rs
+++ b/librubyfmt/src/string_escape.rs
@@ -1,6 +1,6 @@
 use fancy_regex::Regex;
 
-pub fn single_to_double_quoted(content: String, start_delim: &str, end_delim: &str) -> String {
+pub fn single_to_double_quoted(content: &str, start_delim: &str, end_delim: &str) -> String {
     if start_delim == "'" || start_delim.starts_with("%q") {
         escape_string(
             content,
@@ -24,7 +24,7 @@ pub fn single_to_double_quoted(content: String, start_delim: &str, end_delim: &s
         .unwrap();
 
         regexp
-            .replace_all(&content, |captures: &fancy_regex::Captures| {
+            .replace_all(content, |captures: &fancy_regex::Captures| {
                 // first capture is the entire match
                 let val = captures.get(0).unwrap();
                 let val_str = val.as_str().to_string();
@@ -44,9 +44,9 @@ pub fn single_to_double_quoted(content: String, start_delim: &str, end_delim: &s
     }
 }
 
-fn escape_string(content: String, opening_delim: char, closing_delim: char) -> String {
+fn escape_string(content: &str, opening_delim: char, closing_delim: char) -> String {
     if opening_delim == '"' {
-        return content;
+        return content.to_string();
     }
 
     let chars = content.chars().collect::<Vec<char>>();


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
On the tin.  This is maybe a little more efficient?