### PR TITLE
[prism] correctly render `AssocSplat` nodes in lists

### DIFF
--- a/fixtures/small/assoc_double_splat_actual.rb
+++ b/fixtures/small/assoc_double_splat_actual.rb
@@ -1,1 +1,6 @@
 foo(bar: :baz, **qux)
+
+expected_header_hash = {
+  **defaults,
+  "In-Reply-To" => "thee, thou"
+}

--- a/fixtures/small/assoc_double_splat_expected.rb
+++ b/fixtures/small/assoc_double_splat_expected.rb
@@ -1,1 +1,6 @@
 foo(bar: :baz, **qux)
+
+expected_header_hash = {
+  **defaults,
+  "In-Reply-To" => "thee, thou"
+}

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4271,6 +4271,11 @@ fn format_list_like_thing(
                                 ps.emit_soft_indent();
                             }
                             format_assoc_node(ps, assoc_node)
+                        } else if let Some(splat_node) = expr.as_assoc_splat_node() {
+                            if idx > 0 {
+                                ps.emit_soft_indent();
+                            }
+                            format_assoc_splat_node(ps, splat_node)
                         } else {
                             ps.emit_soft_indent();
                             format_node(ps, expr);


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
This came up while trying to format Stripe's codebase; we have special handling for the first assoc node in a list, but we needed to extend that special handling to assoc splat nodes as well.  Without this, we'd get a double indent on the `**defaults` expression in the modified testcase.