### PR TITLE
[prism] Mark more node types as non-"literal" types for call chain multiline handling

### DIFF
--- a/fixtures/small/call_chain_leading_nodes_actual.rb
+++ b/fixtures/small/call_chain_leading_nodes_actual.rb
@@ -1,0 +1,26 @@
+def example(this)
+  this
+    .should_break!
+end
+
+foo {
+  _1
+    .should_break!
+}
+
+bar {
+  it
+    .should_break!
+}
+
+$globals
+  .should_break_too!
+
+class Foo
+  def self.do_things
+    @this
+      .should_break
+    @@and_this
+      .should_also_break
+  end
+end

--- a/fixtures/small/call_chain_leading_nodes_expected.rb
+++ b/fixtures/small/call_chain_leading_nodes_expected.rb
@@ -1,0 +1,26 @@
+def example(this)
+  this
+    .should_break!
+end
+
+foo {
+  _1
+    .should_break!
+}
+
+bar {
+  it
+    .should_break!
+}
+
+$globals
+  .should_break_too!
+
+class Foo
+  def self.do_things
+    @this
+      .should_break
+    @@and_this
+      .should_also_break
+  end
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2130,6 +2130,12 @@ fn call_chain_elements_are_user_multilined(
             prism::Node::CallNode { .. }
                 | prism::Node::ConstantReadNode { .. }
                 | prism::Node::ConstantPathNode { .. }
+                | prism::Node::LocalVariableReadNode { .. }
+                | prism::Node::GlobalVariableReadNode { .. }
+                | prism::Node::InstanceVariableReadNode { .. }
+                | prism::Node::ClassVariableReadNode { .. }
+                | prism::Node::ItLocalVariableReadNode { .. }
+                | prism::Node::NumberedReferenceReadNode { .. }
                 | prism::Node::ParenthesesNode { .. }
         );
 
@@ -2383,9 +2389,9 @@ fn format_block_node(ps: &mut ParserState, block_node: prism::BlockNode) {
         ps.new_block(|ps| {
             ps.emit_do_keyword();
             if let Some(block_parameters) = block_node.parameters()
-                // `it` parameters nodes are implicit nodes with no content, but they have
-                // a loc that is the entire loc of the block. This will cause major line
-                // winding problems if we try to format with `format_node`, so we just skip it.
+                // These node types are implicit types -- they don't represent anything
+                // and have misleading locs that we don't want to use
+                && block_parameters.as_numbered_parameters_node().is_none()
                 && block_parameters.as_it_parameters_node().is_none()
             {
                 format_node(ps, block_parameters);
@@ -2410,7 +2416,12 @@ fn format_block_node(ps: &mut ParserState, block_node: prism::BlockNode) {
         });
     } else {
         ps.inline_breakable_of(BreakableDelims::for_brace_block(), |ps| {
-            if let Some(parameters) = block_node.parameters() {
+            if let Some(parameters) = block_node.parameters()
+                // These node types are implicit types -- they don't represent anything
+                // and have misleading locs that we don't want to use
+                && parameters.as_numbered_parameters_node().is_none()
+                && parameters.as_it_parameters_node().is_none()
+            {
                 format_node(ps, parameters);
             }
 


### PR DESCRIPTION
Closes #656 

For the first expression of call chains, we scrub any non-ident from the call chain so that certain kinds of multiline literals don't force the rest of the chain to multiline. We define "literals" in Ripper as [these node types](https://github.com/fables-tales/rubyfmt/blob/ce3148fbc75be0bba13bf4cab5be6e8763757871/librubyfmt/src/ripper_tree_types.rs#L166) intended to cover the range of identifiers, but in Prism there's ~many more "ident" nodes, [some of which are context-dependent](https://github.com/fables-tales/rubyfmt/issues/656#issuecomment-3676728317).

This PR adds more node types to the "non-literals" list in the multiline handler, as well as fix a small bug around implicit parameter nodes that came up while I was writing the test cases.