### PR TITLE
[prism] Don't wrap attr_write calls in breakables

### DIFF
--- a/fixtures/small/assign_field_actual.rb
+++ b/fixtures/small/assign_field_actual.rb
@@ -1,3 +1,7 @@
 foo.bar = :c
 foo.bar.baz = :c
 foo.Bar = :c
+
+T.unsafe(foo).bar = "Some really long value where I have to type so much just to get it all the way to"
+  .call(120, characters)
+  .all_the_way_to_here

--- a/fixtures/small/assign_field_expected.rb
+++ b/fixtures/small/assign_field_expected.rb
@@ -1,3 +1,7 @@
 foo.bar = :c
 foo.bar.baz = :c
 foo.Bar = :c
+
+T.unsafe(foo).bar = "Some really long value where I have to type so much just to get it all the way to"
+  .call(120, characters)
+  .all_the_way_to_here

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2003,65 +2003,108 @@ fn as_binary_op<'a>(
 
 fn format_call_chain(ps: &mut ParserState, call_node: ruby_prism::CallNode<'_>) {
     ps.with_start_of_line(false, |ps| {
-        let mut call_chain_elements = collapse_nodes_to_call_chain(call_node.as_node());
+        let call_chain_elements = collapse_nodes_to_call_chain(call_node.as_node());
 
-        let is_attr_write = call_chain_elements.len() == 2
-            && call_chain_elements
-                .get(1)
-                .and_then(|n| n.as_call_node())
-                .map(|c| c.is_attribute_write())
-                .unwrap_or(false);
+        let is_attr_write = call_chain_elements
+            .last()
+            .and_then(|n| n.as_call_node())
+            .map(|c| c.is_attribute_write())
+            .unwrap_or(false);
 
-        let is_user_multilined = if is_attr_write {
-            // For attribute writes, never consider the outer chain as multilined.
-            // The values will handle their own breaking.
-            false
+        if is_attr_write {
+            format_call_chain_body(ps, call_chain_elements, true);
         } else {
-            call_chain_elements_are_user_multilined(
+            let is_user_multilined = call_chain_elements_are_user_multilined(
                 ps,
                 call_chain_elements.iter().clone().collect(),
-            )
-        };
+            );
 
-        ps.breakable_call_chain_of(MultilineHandling::Prism(is_user_multilined), |ps| {
-            // The first node can be *any* expression, whereas following receivers
-            // must be additional calls -- you cannot insert literals into call chains
-            let first_expression = call_chain_elements.remove(0);
-            format_node(ps, first_expression);
+            ps.breakable_call_chain_of(MultilineHandling::Prism(is_user_multilined), |ps| {
+                format_call_chain_body(ps, call_chain_elements, false);
+            });
+        }
+    });
+}
 
-            // Arefs like `Array[1, 2]` are represented as a call chain where
-            // the receiver is the constant name `Array` and the aref is a separate call node.
-            // However, we don't want to start the call chain indent until after the aref, since the
-            // aref is "part of" the first expression.
-            // We loop here to handle chained arefs like `matrix[0][1].foo`.
-            while let Some(next) = call_chain_elements.first() {
-                if let Some(call_node) = next.as_call_node()
-                    && call_node.call_operator_loc().is_none()
-                {
-                    call_chain_elements.remove(0);
-                    format_call_node(ps, call_node, true);
-                    continue;
-                }
-                break;
+fn format_call_chain_body(
+    ps: &mut ParserState,
+    mut call_chain_elements: Vec<prism::Node>,
+    is_attr_write: bool,
+) {
+    // The first node can be *any* expression, whereas following receivers
+    // must be additional calls -- you cannot insert literals into call chains
+    let first_expression = call_chain_elements.remove(0);
+    format_node(ps, first_expression);
+
+    // Arefs like `Array[1, 2]` are represented as a call chain where
+    // the receiver is the constant name `Array` and the aref is a separate call node.
+    // However, we don't want to start the call chain indent until after the aref, since the
+    // aref is "part of" the first expression.
+    // We loop here to handle chained arefs like `matrix[0][1].foo`.
+    while let Some(next) = call_chain_elements.first() {
+        if let Some(call_node) = next.as_call_node()
+            && call_node.call_operator_loc().is_none()
+        {
+            call_chain_elements.remove(0);
+            format_call_node(ps, call_node, true);
+            continue;
+        }
+        break;
+    }
+
+    // Eagerly render heredocs if they're in the first expression.
+    // We want the full heredoc to get rendered _before_ we emit the
+    // BeginCallChainIndent token so that it gets correctly indented
+    // (or in the case of it being the first expression, _not_ indented).
+    ps.render_heredocs(true);
+
+    // Attribute writes like `self.foo = bar` should have both sides
+    // rendered separately so they can break independently
+    if call_chain_elements.len() == 1
+        && let Some(attr_write) = call_chain_elements
+            .first()
+            .and_then(|n| n.as_call_node())
+            .filter(|c| c.is_attribute_write())
+    {
+        // Format `.attr_name = ` directly without call chain indent
+        let call_operator = attr_write.call_operator_loc().map(|loc| loc_to_string(loc));
+        if let Some(call_operator) = call_operator {
+            match call_operator.as_str() {
+                "." => ps.emit_dot(),
+                "&." => ps.emit_lonely_operator(),
+                "::" => ps.emit_colon_colon(),
+                _ => ps.emit_ident(call_operator),
             }
+        }
 
-            // Eagerly render heredocs if they're in the first expression.
-            // We want the full heredoc to get rendered _before_ we emit the
-            // BeginCallChainIndent token so that it gets correctly indented
-            // (or in the case of it being the first expression, _not_ indented).
-            ps.render_heredocs(true);
+        ps.at_offset(start_loc_for_call_node_in_chain(&attr_write));
+        ps.shift_comments();
 
-            // Attribute writes like `self.foo = bar` should have both sides
-            // rendered separately so they can break independently
-            if call_chain_elements.len() == 1
-                && let Some(attr_write) = call_chain_elements
-                    .first()
-                    .and_then(|n| n.as_call_node())
-                    .filter(|c| c.is_attribute_write())
-            {
-                // Format `.attr_name = ` directly without call chain indent
-                let call_operator = attr_write.call_operator_loc().map(|loc| loc_to_string(loc));
+        // Format just the attribute name and ` = `, then the value separately
+        format_call_node(ps, attr_write, true);
+    } else {
+        // attr_writes are not wrapped in a breakable, so they
+        // cannot emit abstract token types
+        if !is_attr_write {
+            ps.start_indent_for_call_chain();
+        }
+
+        ps.with_start_of_line(false, |ps| {
+            for element in call_chain_elements {
+                let element = element.as_call_node().unwrap();
+
+                // `call_operator_loc` is the `.`/`::`/`&.` etc.
+                // it may be None in the case of arefs, e.g. foo[bar]
+                let call_operator = element.call_operator_loc().map(|loc| loc_to_string(loc));
                 if let Some(call_operator) = call_operator {
+                    if call_operator != *"::" && !is_attr_write {
+                        ps.emit_collapsing_newline();
+                        ps.emit_soft_indent();
+                    }
+
+                    // Emit the proper token type so that call_count is computed correctly
+                    // in single_line_string_length (which is used to determine whether to
+                    // break the call chain or just the arguments)
                     match call_operator.as_str() {
                         "." => ps.emit_dot(),
                         "&." => ps.emit_lonely_operator(),
@@ -2070,49 +2113,16 @@ fn format_call_chain(ps: &mut ParserState, call_node: ruby_prism::CallNode<'_>) 
                     }
                 }
 
-                ps.at_offset(start_loc_for_call_node_in_chain(&attr_write));
+                ps.at_offset(start_loc_for_call_node_in_chain(&element));
                 ps.shift_comments();
 
-                // Format just the attribute name and ` = `, then the value separately
-                format_call_node(ps, attr_write, true);
-                return;
+                format_call_node(ps, element, true);
             }
-
-            ps.start_indent_for_call_chain();
-
-            ps.with_start_of_line(false, |ps| {
-                for element in call_chain_elements {
-                    let element = element.as_call_node().unwrap();
-
-                    // `call_operator_loc` is the `.`/`::`/`&.` etc.
-                    // it may be None in the case of arefs, e.g. foo[bar]
-                    let call_operator = element.call_operator_loc().map(|loc| loc_to_string(loc));
-                    if let Some(call_operator) = call_operator {
-                        if call_operator != *"::" {
-                            ps.emit_collapsing_newline();
-                            ps.emit_soft_indent();
-                        }
-
-                        // Emit the proper token type so that call_count is computed correctly
-                        // in single_line_string_length (which is used to determine whether to
-                        // break the call chain or just the arguments)
-                        match call_operator.as_str() {
-                            "." => ps.emit_dot(),
-                            "&." => ps.emit_lonely_operator(),
-                            "::" => ps.emit_colon_colon(),
-                            _ => ps.emit_ident(call_operator),
-                        }
-                    }
-
-                    ps.at_offset(start_loc_for_call_node_in_chain(&element));
-                    ps.shift_comments();
-
-                    format_call_node(ps, element, true);
-                }
-            });
-            ps.end_indent_for_call_chain();
         });
-    });
+        if !is_attr_write {
+            ps.end_indent_for_call_chain();
+        }
+    }
 }
 
 fn call_chain_elements_are_user_multilined(


### PR DESCRIPTION
Related to [this report](https://github.com/fables-tales/rubyfmt/issues/656#issuecomment-3676650405) in #656 (cc @froydnj )

This is essentially #650 redux -- that PR didn't quite accomplish what it set out to, since it left behind the breakable that surrounds the whole assign call. The problem with that is that regardless of the layout of the left and right hand sides, the whole breakable could still be over 120 characters and thus forced onto multiple lines. This is incorrect -- we need to do away with the parent breakable entirely.

The diff here is slightly confusing. The main change is to move the bulk of call chain formatting into a function and then call that function with or without `ps.breakable_call_chain_of` as needed. The only other change is that we also avoid emitting abstract tokens when we're emitting tokens for the attr_write, since it won't be wrapped in a breakable anymore. (This is the same as the way Ripper does it, which is that the left hand side will never break to multiple lines. Possibly a thing to change in the future, but for now it's consistent with existing behavior.)
