### PR TITLE
[prism] Properly indent keyword rest params

### DIFF
--- a/fixtures/small/keyword_rest_actual.rb
+++ b/fixtures/small/keyword_rest_actual.rb
@@ -1,0 +1,15 @@
+foo do |a, **more|
+end
+
+foo do |**more|
+end
+
+foo do |
+  a, **more
+  |
+end
+
+foo do |
+    **more
+  |
+end

--- a/fixtures/small/keyword_rest_expected.rb
+++ b/fixtures/small/keyword_rest_expected.rb
@@ -1,0 +1,16 @@
+foo do |a, **more|
+end
+
+foo do |**more|
+end
+
+foo do |
+    a,
+    **more
+  |
+end
+
+foo do |
+    **more
+  |
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2830,6 +2830,7 @@ fn format_keyword_rest_parameter_node(
     ps: &mut ParserState,
     keyword_rest_parameter_node: prism::KeywordRestParameterNode,
 ) {
+    ps.emit_soft_indent();
     ps.emit_ident("**".to_string());
     if let Some(constant_id) = keyword_rest_parameter_node.name() {
         let name = const_to_string(constant_id);


### PR DESCRIPTION
I was looking at #560 to see if it persisted in the Prism implementation (it doesn't!) and noticed that we had a separate problem in that example, which is that we weren't indenting the kwrest param. I just missed out on [this line](https://github.com/fables-tales/rubyfmt/blob/b189d6cc5442746d85ffa713cf8ff0de7db8ba39/librubyfmt/src/format.rs#L196) from the Ripper implementation, so I'm adding the indent here and adding some fixtures.