### PR TITLE
[prism] Wrap ternaries in correct formatting context

### DIFF
--- a/fixtures/small/ternary_raise_actual.rb
+++ b/fixtures/small/ternary_raise_actual.rb
@@ -1,0 +1,1 @@
+bees? ? raise("Not the bees!") : safe

--- a/fixtures/small/ternary_raise_expected.rb
+++ b/fixtures/small/ternary_raise_expected.rb
@@ -1,0 +1,1 @@
+bees? ? raise("Not the bees!") : safe

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3401,26 +3401,28 @@ fn format_if_node(ps: &mut ParserState, if_node: prism::IfNode) {
         );
     } else {
         // No keyword, so this is a ternary
-        ps.with_start_of_line(false, |ps| {
-            format_node(ps, if_node.predicate());
-            ps.emit_ident(" ? ".to_string());
+        ps.with_formatting_context(FormattingContext::IfOp, |ps| {
+            ps.with_start_of_line(false, |ps| {
+                format_node(ps, if_node.predicate());
+                ps.emit_ident(" ? ".to_string());
 
-            format_node(
-                ps,
-                if_node
-                    .statements()
-                    .expect("Ternaries must have a `statements` branch")
-                    .body()
-                    .iter()
-                    .next()
-                    .expect("There must be exactly one statement inside a ternary branch"),
-            );
-            format_node(
-                ps,
-                if_node
-                    .subsequent()
-                    .expect("Ternaries must have a subsequent branch"),
-            )
+                format_node(
+                    ps,
+                    if_node
+                        .statements()
+                        .expect("Ternaries must have a `statements` branch")
+                        .body()
+                        .iter()
+                        .next()
+                        .expect("There must be exactly one statement inside a ternary branch"),
+                );
+                format_node(
+                    ps,
+                    if_node
+                        .subsequent()
+                        .expect("Ternaries must have a subsequent branch"),
+                )
+            });
         });
     }
 }


### PR DESCRIPTION
Closes #668 

Method calls inside of ternaries require parens, so for method calls where we usually omit them (e.g. for `raise`, `return`, etc.), we [look to the formatting context](https://github.com/fables-tales/rubyfmt/blob/9fcc600beea6a1be4238f3ef23a3947a8f1ea91c/librubyfmt/src/parser_state.rs#L666-L669) to see if we're in a context that requires them. However, we weren't setting the right context for ternaries, so this wasn't firing. This adds the context wrapper for ternaries to fix this.