### PR TITLE
[prism] Ensure we wind to the closing loc for all call nodes

### DIFF
--- a/fixtures/small/method_chains_actual.rb
+++ b/fixtures/small/method_chains_actual.rb
@@ -54,6 +54,12 @@ foo.items.map { p(_1) }.last
 
 hashes.sort_by { |hsh| hsh[:start_time] }.reverse
 
+hash.sort_by(
+    &:max
+  )
+  .keys
+
+
 params(
   route: String,
   config: T.nilable(Some::Really::Long::Type::Name),

--- a/fixtures/small/method_chains_expected.rb
+++ b/fixtures/small/method_chains_expected.rb
@@ -57,6 +57,12 @@ foo.items.map { p(_1) }.last
 
 hashes.sort_by { |hsh| hsh[:start_time] }.reverse
 
+hash
+  .sort_by(
+    &:max
+  )
+  .keys
+
 params(
   route: String,
   config: T.nilable(Some::Really::Long::Type::Name),

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1597,6 +1597,7 @@ fn use_parens_for_call_node(
 
 fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_receiver: bool) {
     let method_name = const_to_string(call_node.name());
+    let end_offset = call_node.location().end_offset();
     let is_dot_call = &method_name == "call" && call_node.message_loc().is_none(); // e.g. `a.()`
 
     // Only treat [] and []= as aref syntax when there's no explicit call operator.
@@ -1856,6 +1857,9 @@ fn format_call_node(ps: &mut ParserState, call_node: prism::CallNode, skip_recei
             ps.emit_after_call_chain();
         }
     }
+    // We've been manually handling line winding while rendering the chain,
+    // so we need to manually check that we wind to the closing loc
+    ps.wind_dumping_comments_until_offset(end_offset);
 }
 
 fn format_unary_operator(ps: &mut ParserState, call_node: prism::CallNode, method_name: String) {


### PR DESCRIPTION
Closes #666 ([obligatory Iron Maiden](https://youtu.be/WxnN05vOuSM?t=110))

Call chains have some finicky line winding properties since we mostly handle the calls manually instead of passing it through the `format_node` machinery. We should always be winding to the end of each call node to make sure we wind to the closing paren, so this adds that to `format_call_node` to catch any places we forget to wind forward during the chain.