### PR TITLE
avoid parenthesizing longer call chains beginning with `self`

### DIFF
--- a/fixtures/small/variable_binding_actual.rb
+++ b/fixtures/small/variable_binding_actual.rb
@@ -17,7 +17,9 @@ end
 def cheese
   head = 1
   self.head
+  self.head()
   self.next.head
+  self.next.head()
 end
 
 bees

--- a/fixtures/small/variable_binding_actual.rb
+++ b/fixtures/small/variable_binding_actual.rb
@@ -17,6 +17,7 @@ end
 def cheese
   head = 1
   self.head
+  self.next.head
 end
 
 bees

--- a/fixtures/small/variable_binding_expected.rb
+++ b/fixtures/small/variable_binding_expected.rb
@@ -18,6 +18,7 @@ end
 def cheese
   head = 1
   self.head()
+  self.next.head
 end
 
 bees

--- a/fixtures/small/variable_binding_expected.rb
+++ b/fixtures/small/variable_binding_expected.rb
@@ -18,6 +18,8 @@ end
 def cheese
   head = 1
   self.head()
+  self.head()
+  self.next.head
   self.next.head
 end
 

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -662,7 +662,9 @@ pub fn use_parens_for_method_call(
             None => return original_used_parens,
             Some(CallChainElement::VarRef(VarRef(_, VarRefType::Kw(Kw(_, x, _))))) => {
                 if x == "self" {
-                    return true;
+                    // self.foo has a chain length of 2 -- `self` and `.`.
+                    // original_used_parens does not seem to be reliable in this case.
+                    return chain.len() == 2;
                 }
             }
             _ => {}


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
I think this "fixes" #657, or at least makes the behavior between ripper and prism identical.  This will require a reformatting of Stripe's code; I'll have to see what the diff looks like.