### PR TITLE
only apply special `self` handling when the args list is empty

### DIFF
--- a/fixtures/small/variable_binding_actual.rb
+++ b/fixtures/small/variable_binding_actual.rb
@@ -18,8 +18,10 @@ def cheese
   head = 1
   self.head
   self.head()
+  self.head("oops arg")
   self.next.head
   self.next.head()
+  self.next.head("oops arg")
 end
 
 bees

--- a/fixtures/small/variable_binding_expected.rb
+++ b/fixtures/small/variable_binding_expected.rb
@@ -19,8 +19,10 @@ def cheese
   head = 1
   self.head()
   self.head()
+  self.head("oops arg")
   self.next.head
   self.next.head
+  self.next.head("oops arg")
 end
 
 bees

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -661,10 +661,9 @@ pub fn use_parens_for_method_call(
         match chain.first() {
             None => return original_used_parens,
             Some(CallChainElement::VarRef(VarRef(_, VarRefType::Kw(Kw(_, x, _))))) => {
-                if x == "self" {
-                    // self.foo has a chain length of 2 -- `self` and `.`.
-                    // original_used_parens does not seem to be reliable in this case.
-                    return chain.len() == 2;
+                // self.foo has a chain length of 2 -- `self` and `.`.
+                if x == "self" && chain.len() == 2 && args.is_empty() {
+                    return true;
                 }
             }
             _ => {}


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
This is a bugfix for #674 -- we would accidentally remove the parens from _all_ `self.method` calls, which is a big change, and probably not semantically correct?  We should limit the forced parenthesization to the special cases that we want and fallthrough for the rest.  (Which I think might change the formatting on some odd Ruby code?)