### PR TITLE
[prism] don't allocate a separate string when formatting end data

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -580,7 +580,7 @@ pub fn format_program(
     ps.shift_comments();
 
     if let Some(data) = data_loc {
-        ps.emit_data(&loc_to_string(data));
+        ps.emit_data(loc_to_str(data));
     }
 }
 


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Just like the subject says.