### PR TITLE
[prism] don't copy the call chain when determining multilining

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2039,10 +2039,8 @@ fn format_call_chain(ps: &mut ParserState, call_node: ruby_prism::CallNode<'_>) 
         if is_attr_write {
             format_call_chain_body(ps, call_chain_elements, true);
         } else {
-            let is_user_multilined = call_chain_elements_are_user_multilined(
-                ps,
-                call_chain_elements.iter().clone().collect(),
-            );
+            let is_user_multilined =
+                call_chain_elements_are_user_multilined(ps, &call_chain_elements);
 
             ps.breakable_call_chain_of(MultilineHandling::Prism(is_user_multilined), |ps| {
                 format_call_chain_body(ps, call_chain_elements, false);
@@ -2154,10 +2152,10 @@ fn format_call_chain_body(
 
 fn call_chain_elements_are_user_multilined(
     ps: &ParserState,
-    call_chain_elements: Vec<&prism::Node>,
+    call_chain_elements: &[prism::Node],
 ) -> bool {
     // Making a mutable copy since we may pop some items off later
-    let mut call_chain_elements = call_chain_elements.as_slice();
+    let mut call_chain_elements = call_chain_elements;
 
     if call_chain_elements.len() > 1 {
         // If the first item in the chain is a multiline expression (like a hash or array),


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Just like the subject says.