### PR TITLE
Never strip parens from method call arguments

### DIFF
--- a/fixtures/small/paren_expr_calls_actual.rb
+++ b/fixtures/small/paren_expr_calls_actual.rb
@@ -14,3 +14,5 @@ other_cool_method (a + b).round(4)
   )
   &.rules)
   .freeze
+
+beekeep (the_bees unless not_the_bees!)

--- a/fixtures/small/paren_expr_calls_expected.rb
+++ b/fixtures/small/paren_expr_calls_expected.rb
@@ -1,4 +1,4 @@
-a(1)
+a((1))
 other_cool_method((a + b).round(4))
 
 # rubocop:disable PrisonGuard/PrivateModule
@@ -16,3 +16,5 @@ other_cool_method((a + b).round(4))
   )
   &.rules)
   .freeze
+
+beekeep((the_bees unless not_the_bees!))

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1725,22 +1725,6 @@ fn format_call_node(
                     BreakableDelims::for_kw()
                 };
 
-                // Check if we can unwrap a single parenthesized argument when we're adding
-                // method call parens. This handles cases like `a (1)` -> `a(1)` where the
-                // parens around `1` were just for argument grouping, not expression grouping.
-                let maybe_unwrapped_single_arg = if should_use_parens
-                    && arguments.arguments().len() == 1
-                    && call_node
-                        .block()
-                        .and_then(|b| b.as_block_argument_node())
-                        .is_none()
-                {
-                    let first_arg = arguments.arguments().iter().next().unwrap();
-                    unwrap_single_arg_paren(&first_arg)
-                } else {
-                    None
-                };
-
                 let maybe_closing_line = call_node
                     .closing_loc()
                     .map(|closing_loc| ps.get_line_number_for_offset(closing_loc.start_offset()));
@@ -1749,14 +1733,7 @@ fn format_call_node(
                     ps.breakable_of(delims, |ps| {
                         let has_arguments = !arguments.arguments().is_empty();
 
-                        if let Some(unwrapped_arg) = maybe_unwrapped_single_arg {
-                            ps.emit_collapsing_newline();
-                            ps.emit_soft_indent();
-                            format_node(ps, unwrapped_arg);
-                            ps.shift_comments();
-                        } else {
-                            format_arguments_node(ps, arguments);
-                        }
+                        format_arguments_node(ps, arguments);
 
                         // Somewhat confusingly, the block argument node (&blk) is
                         // separate from the rest of the arguments node. If it's present,
@@ -4409,21 +4386,6 @@ fn is_empty_parentheses_node(node: &prism::Node) -> bool {
     } else {
         false
     }
-}
-
-/// Returns Some(inner_node) if this is a ParenthesesNode containing a single expression that
-/// can be unwrapped when used as a method argument
-fn unwrap_single_arg_paren<'a>(node: &prism::Node<'a>) -> Option<prism::Node<'a>> {
-    let paren_node = node.as_parentheses_node()?;
-    let body = paren_node.body()?;
-    let statements = body.as_statements_node()?;
-
-    // Only unwrap if there's exactly one statement
-    if statements.body().len() != 1 {
-        return None;
-    }
-
-    statements.body().iter().next()
 }
 
 fn format_list_like_thing(

--- a/librubyfmt/src/ripper_tree_types.rs
+++ b/librubyfmt/src/ripper_tree_types.rs
@@ -1441,7 +1441,7 @@ pub struct ArgsAddBlock(
 
 #[derive(RipperDeserialize, Debug, Clone)]
 pub enum AABParen {
-    Paren((paren_tag, Box<Expression>)),
+    Paren((paren_tag, Box<Expression>, StartEnd)),
     #[allow(unused)]
     EmptyParen((paren_tag, bool)),
     Expression(Box<Expression>),
@@ -1462,7 +1462,11 @@ impl ArgsAddBlockInner {
                     .into_iter()
                     .filter(|aabp| !matches!(aabp, AABParen::EmptyParen(..)))
                     .map(|aabp| match aabp {
-                        AABParen::Paren(p) => *p.1,
+                        AABParen::Paren(p) => Expression::Paren(ParenExpr(
+                            paren_expr_tag,
+                            ParenExpressionOrExpressions::Expression(Box::new(*p.1)),
+                            p.2,
+                        )),
                         AABParen::Expression(e) => *e,
                         AABParen::EmptyParen(..) => {
                             unreachable!("We should have already filtered these out")


### PR DESCRIPTION
Closes #673

I was doing some spelunking to determine why we remove parens from nodes like `a (1)` in the Ripper implementation. I assumed that this had been an intentional choice and that we'd have some dedicated handling for it in the rendering code, but we don't! The only place that actually strips it is one place that converts from an `AABParen::Paren` to an `Expression` by returning the paren's inner expression value, and given that this was in the comparatively early days of `rubyfmt` and not applied uniformly (e.g. `a((1))` won't strip parens) and isn't safe in every context (e.g. `a (foo unless bar)` becomes `a(foo unless bar)`, which is invalid syntax), I'm led to believe this was just an oversight and not an explicit design choice.

To that end, this PR does what I think is the more correct behavior, which is that it never modifies parens for arguments in any case. This is (1) true to what the user's AST was previously and (2) means we never have to be concerned about when it is or isn't safe to strip them. This applies to both the Ripper and Prism implementations.

(For the Stripe folks, note that this shouldn't cause any changes to codebases that have already been formatted AFAICT, since any places where it's safe to strip parens would already have had them formatted away, so this should be a no-op.)