### PR TITLE
Move method name constants into `format_prism`

### DIFF
--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1,8 +1,7 @@
 use std::borrow::Cow;
-use std::collections::HashSet;
-use std::sync::LazyLock;
 
 use crate::delimiters::BreakableDelims;
+use crate::format_prism::{GEMFILE_METHODS, OPTIONALLY_PARENTHESIZED_METHODS, RSPEC_METHODS};
 use crate::heredoc_string::HeredocKind;
 use crate::parser_state::{FormattingContext, ParserState};
 use crate::render_targets::MultilineHandling;
@@ -618,19 +617,6 @@ pub fn args_has_single_def_expression(args: &ArgsAddStarOrExpressionListOrArgsFo
 
     false
 }
-
-pub static RSPEC_METHODS: LazyLock<HashSet<&'static str>> =
-    LazyLock::new(|| vec!["it", "describe"].into_iter().collect());
-
-pub static GEMFILE_METHODS: LazyLock<HashSet<&'static str>> =
-    LazyLock::new(|| vec!["gem", "source", "ruby", "group"].into_iter().collect());
-
-pub static OPTIONALLY_PARENTHESIZED_METHODS: LazyLock<HashSet<&'static str>> =
-    LazyLock::new(|| {
-        vec!["super", "require", "require_relative"]
-            .into_iter()
-            .collect::<HashSet<_>>()
-    });
 
 pub fn use_parens_for_method_call(
     ps: &ParserState,

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1,10 +1,9 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashSet, sync::LazyLock};
 
 use ruby_prism as prism;
 
 use crate::{
     delimiters::BreakableDelims,
-    format::{GEMFILE_METHODS, OPTIONALLY_PARENTHESIZED_METHODS, RSPEC_METHODS},
     heredoc_string::HeredocKind,
     parser_state::{FormattingContext, HashType, ParserState},
     render_targets::MultilineHandling,
@@ -1500,6 +1499,19 @@ fn format_block_argument_node(ps: &mut ParserState, block_argument_node: prism::
         });
     }
 }
+
+pub static RSPEC_METHODS: LazyLock<HashSet<&'static str>> =
+    LazyLock::new(|| vec!["it", "describe"].into_iter().collect());
+
+pub static GEMFILE_METHODS: LazyLock<HashSet<&'static str>> =
+    LazyLock::new(|| vec!["gem", "source", "ruby", "group"].into_iter().collect());
+
+pub static OPTIONALLY_PARENTHESIZED_METHODS: LazyLock<HashSet<&'static str>> =
+    LazyLock::new(|| {
+        vec!["super", "require", "require_relative"]
+            .into_iter()
+            .collect::<HashSet<_>>()
+    });
 
 fn use_parens_for_call_node(
     ps: &ParserState,


### PR DESCRIPTION
On the tin -- this is a bit of early cleanup, but seeing as `format_prism` is the eventual canonical implementation, we'll eventually want these constants here instead of in the Ripper file to make things easier to delete later.
