### PR TITLE
[prism] Support embdoc (`=begin`/`=end`) comments

### DIFF
--- a/fixtures/small/prism/embdoc_actual.rb
+++ b/fixtures/small/prism/embdoc_actual.rb
@@ -1,0 +1,43 @@
+def haiku
+  # Violets -
+    how_precious
+    on_a_mountain_path
+
+=begin
+    Early autumn -
+    rice field, ocean,
+    one green.
+=end
+    by_basho!
+end
+
+=begin
+  The thief left it behind:
+  the moon
+  at my window.
+=end
+
+class Poet
+    def self.recite
+        poem {
+            recite!
+=begin
+    From the firefly
+    in my hands,
+    cold light
+=end
+            recite! while more_poetry?
+        }
+    end
+end
+
+def
+=begin
+=end
+a; end
+
+:\
+=begin
+not the symbol name
+=end
+symbol_name

--- a/fixtures/small/prism/embdoc_expected.rb
+++ b/fixtures/small/prism/embdoc_expected.rb
@@ -1,0 +1,42 @@
+def haiku
+  # Violets -
+  how_precious
+  on_a_mountain_path
+
+=begin
+    Early autumn -
+    rice field, ocean,
+    one green.
+=end
+  by_basho!
+end
+
+=begin
+  The thief left it behind:
+  the moon
+  at my window.
+=end
+
+class Poet
+  def self.recite
+    poem {
+      recite!
+=begin
+    From the firefly
+    in my hands,
+    cold light
+=end
+      recite! while more_poetry?
+    }
+  end
+end
+
+=begin
+=end
+def a
+end
+
+=begin
+not the symbol name
+=end
+:symbol_name

--- a/librubyfmt/src/comment_block.rs
+++ b/librubyfmt/src/comment_block.rs
@@ -40,7 +40,7 @@ impl CommentBlock {
         for comment in &mut self.comments {
             // Ignore empty strings -- these represent blank lines between
             // groups of comments
-            if !comment.is_empty() {
+            if !comment.is_empty() && !comment.starts_with("=begin") {
                 comment.insert_str(0, &indent);
             }
         }
@@ -51,8 +51,11 @@ impl CommentBlock {
         !self.comments.is_empty()
     }
 
-    pub fn len(&self) -> usize {
-        self.comments.len()
+    pub fn line_count(&self) -> usize {
+        self.comments
+            .iter()
+            .map(|comment| comment.lines().count())
+            .sum()
     }
 
     pub fn is_trailing(&self) -> bool {

--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -84,13 +84,24 @@ impl FileComments {
                 .insert(comment.location().start_offset());
         }
 
-        // Lookup lines that have any Ruby, which we broadly equate to
-        // a line that isn't empty and that doesn't start with a comment ("#")
+        // Lookup lines that have any Ruby
+        let mut inside_embdoc = false;
         u8_to_string(source)
             .lines()
             .enumerate()
             .filter(|(_lineno, line_contents)| {
                 let contents = line_contents.trim();
+                if contents.starts_with("=begin") {
+                    inside_embdoc = true;
+                    return false;
+                }
+                if contents.starts_with("=end") {
+                    inside_embdoc = false;
+                    return false;
+                }
+                if inside_embdoc {
+                    return false;
+                }
                 !(contents.starts_with("#") || contents.is_empty())
             })
             .for_each(|(lineno, _)| {
@@ -238,7 +249,8 @@ impl FileComments {
                     {
                         comment_block_with_spaces.push(String::new());
                     }
-                    last_line = Some(index);
+                    let line_count = comment_contents.lines().count() as u64;
+                    last_line = Some(index + line_count - 1);
                     comment_block_with_spaces.push(comment_contents);
                 }
 

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -509,7 +509,7 @@ impl ParserState {
                 && self.comments_to_insert.is_some()
             {
                 let mr = self.comments_to_insert.as_mut().expect("it's not nil");
-                if mr.len() == 0 {
+                if mr.line_count() == 0 {
                     break;
                 }
                 mr.add_line("".to_string());
@@ -798,11 +798,11 @@ impl ParserState {
             .last()
             .expect("comments stack is never empty")
         {
-            let len = comments.len();
+            let line_count = comments.line_count();
             let trailing_comment = comments.is_trailing();
             self.insert_comment_collection(comments);
             if !trailing_comment {
-                self.current_orig_line_number += len as u64;
+                self.current_orig_line_number += line_count as u64;
             }
         }
     }
@@ -901,12 +901,12 @@ impl ParserState {
                 self.on_line(1);
             }
             Some(comments) => {
-                let len = comments.len();
+                let line_count = comments.line_count();
                 let lts = comments.into_line_tokens();
                 for comment in lts.into_iter() {
                     self.push_concrete_token(comment);
                 }
-                self.current_orig_line_number = len as LineNumber;
+                self.current_orig_line_number = line_count as LineNumber;
             }
         }
     }


### PR DESCRIPTION
Related to #417 

The Ripper implementation just ignores embdocs, but Prism reports them the same as other comments, so it's not a huge lift to support them -- it's mostly a matter of updating the comment machinery to not assume that comments are always single-line and might be multiple lines long.