### PR TITLE
[prism] Implement `MatchPredicateNode` and `MatchRequiredNode`

### DIFF
--- a/fixtures/small/prism/match_predicate_actual.rb
+++ b/fixtures/small/prism/match_predicate_actual.rb
@@ -1,0 +1,11 @@
+1 in x
+result in value
+
+foo   in   bar
+
+if 1 in x
+  puts x
+end
+
+[1, 2, 3].first in num
+some_method(arg) in result

--- a/fixtures/small/prism/match_predicate_expected.rb
+++ b/fixtures/small/prism/match_predicate_expected.rb
@@ -1,0 +1,11 @@
+1 in x
+result in value
+
+foo in bar
+
+if 1 in x
+  puts(x)
+end
+
+[1, 2, 3].first in num
+some_method(arg) in result

--- a/fixtures/small/prism/match_required_actual.rb
+++ b/fixtures/small/prism/match_required_actual.rb
@@ -1,0 +1,7 @@
+1 => x
+result => value
+
+foo   =>   bar
+
+[1, 2, 3].first => num
+some_method(arg) => result

--- a/fixtures/small/prism/match_required_expected.rb
+++ b/fixtures/small/prism/match_required_expected.rb
@@ -1,0 +1,7 @@
+1 => x
+result => value
+
+foo => bar
+
+[1, 2, 3].first => num
+some_method(arg) => result

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3975,10 +3975,7 @@ fn format_match_predicate_node(
     });
 }
 
-fn format_match_required_node(
-    ps: &mut ParserState,
-    match_required_node: prism::MatchRequiredNode,
-) {
+fn format_match_required_node(ps: &mut ParserState, match_required_node: prism::MatchRequiredNode) {
     ps.with_start_of_line(false, |ps| {
         format_node(ps, match_required_node.value());
         ps.emit_space();

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3963,17 +3963,29 @@ fn format_match_last_line_node(
 }
 
 fn format_match_predicate_node(
-    _ps: &mut ParserState,
-    _match_predicate_node: prism::MatchPredicateNode,
+    ps: &mut ParserState,
+    match_predicate_node: prism::MatchPredicateNode,
 ) {
-    todo!()
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, match_predicate_node.value());
+        ps.emit_space();
+        ps.emit_ident(loc_to_string(match_predicate_node.operator_loc()));
+        ps.emit_space();
+        format_node(ps, match_predicate_node.pattern());
+    });
 }
 
 fn format_match_required_node(
-    _ps: &mut ParserState,
-    _match_required_node: prism::MatchRequiredNode,
+    ps: &mut ParserState,
+    match_required_node: prism::MatchRequiredNode,
 ) {
-    todo!()
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, match_required_node.value());
+        ps.emit_space();
+        ps.emit_ident(loc_to_string(match_required_node.operator_loc()));
+        ps.emit_space();
+        format_node(ps, match_required_node.pattern());
+    });
 }
 
 fn format_match_write_node(ps: &mut ParserState, match_write_node: prism::MatchWriteNode) {


### PR DESCRIPTION
On the tin -- I'm planning on taking a first pass at some of the pattern matching nodes, and these are fairly straightforward