### PR TITLE
[prism] Implement remaining pattern matching nodes

### DIFF
--- a/fixtures/small/prism/case_match_array_actual.rb
+++ b/fixtures/small/prism/case_match_array_actual.rb
@@ -1,0 +1,31 @@
+# Array pattern matching
+case    arr
+in     [a, b, c]
+   puts a + b + c
+in  [first, *rest]
+   puts first
+in   []
+  puts "empty"
+end
+
+# Array pattern without brackets (should add brackets)
+case   tuple
+in   a, b, c
+   puts a
+in  first, *rest
+  puts first
+end
+
+# Multiline array pattern
+case   big_array
+in   [
+       first,
+       second,
+       *rest
+     ]
+   puts first
+in  [a,
+     b,
+     c]
+  puts a + b + c
+end

--- a/fixtures/small/prism/case_match_array_expected.rb
+++ b/fixtures/small/prism/case_match_array_expected.rb
@@ -1,0 +1,33 @@
+# Array pattern matching
+case arr
+in [a, b, c]
+  puts(a + b + c)
+in [first, *rest]
+  puts(first)
+in []
+  puts("empty")
+end
+
+# Array pattern without brackets (should add brackets)
+case tuple
+in [a, b, c]
+  puts(a)
+in [first, *rest]
+  puts(first)
+end
+
+# Multiline array pattern
+case big_array
+in [
+    first,
+    second,
+    *rest
+  ]
+  puts(first)
+in [
+    a,
+    b,
+    c
+  ]
+  puts(a + b + c)
+end

--- a/fixtures/small/prism/case_match_basic_actual.rb
+++ b/fixtures/small/prism/case_match_basic_actual.rb
@@ -1,0 +1,17 @@
+# Basic case/in pattern matching
+case  value
+in   1
+    puts "one"
+in    2
+     puts "two"
+else
+   puts "other"
+end
+
+# Pattern matching without else
+case  status
+in   :ok
+   puts "success"
+in    :error
+    puts "failure"
+end

--- a/fixtures/small/prism/case_match_basic_expected.rb
+++ b/fixtures/small/prism/case_match_basic_expected.rb
@@ -1,0 +1,17 @@
+# Basic case/in pattern matching
+case value
+in 1
+  puts("one")
+in 2
+  puts("two")
+else
+  puts("other")
+end
+
+# Pattern matching without else
+case status
+in :ok
+  puts("success")
+in :error
+  puts("failure")
+end

--- a/fixtures/small/prism/case_match_comments_actual.rb
+++ b/fixtures/small/prism/case_match_comments_actual.rb
@@ -1,0 +1,38 @@
+# Comments in case/in pattern matching
+case   value
+in   [a, b]
+   # comment inside body
+   puts a
+in   {name: n}
+  # another body comment
+  puts n
+else
+  # comment in else body
+  puts "no match"
+end
+
+# Comments in multiline patterns
+case   data
+in   [
+       first,
+       second
+     ]
+   # body after multiline array pattern
+   puts first
+in   {
+       name: n,
+       age: a
+     }
+  # body after multiline hash pattern
+  puts n
+end
+
+# Comments with alternation patterns
+case   x
+in   1 | 2 | 3
+  # matched small numbers
+  puts "small"
+in   10 | 20
+  # matched larger numbers
+  puts "medium"
+end

--- a/fixtures/small/prism/case_match_comments_expected.rb
+++ b/fixtures/small/prism/case_match_comments_expected.rb
@@ -1,0 +1,38 @@
+# Comments in case/in pattern matching
+case value
+in [a, b]
+  # comment inside body
+  puts(a)
+in {name: n}
+  # another body comment
+  puts(n)
+else
+  # comment in else body
+  puts("no match")
+end
+
+# Comments in multiline patterns
+case data
+in [
+    first,
+    second
+  ]
+  # body after multiline array pattern
+  puts(first)
+in {
+    name: n,
+    age: a
+  }
+  # body after multiline hash pattern
+  puts(n)
+end
+
+# Comments with alternation patterns
+case x
+in 1 | 2 | 3
+  # matched small numbers
+  puts("small")
+in 10 | 20
+  # matched larger numbers
+  puts("medium")
+end

--- a/fixtures/small/prism/case_match_hash_actual.rb
+++ b/fixtures/small/prism/case_match_hash_actual.rb
@@ -1,0 +1,52 @@
+# Hash pattern matching
+case   hash
+in    {name: n, age: a}
+   puts "#{n} is #{a}"
+in   {name:}
+  puts name
+end
+
+# Multiline hash pattern
+case   big_hash
+in   {
+       name: n,
+       age: a,
+       email: e
+     }
+   puts n
+in  {foo:,
+     bar:,
+     baz:}
+  puts foo
+end
+
+# Hash pattern without braces (should add braces)
+case   data
+in   name: n, age: a
+   puts n
+in  foo:, bar:
+  puts foo
+end
+
+# Hash pattern with parens (constant check)
+case   obj
+in   Point(x:, y:)
+   puts x + y
+in  Rectangle(width: w, height: h)
+  puts w * h
+end
+
+# Multiline hash pattern with parens
+case   obj
+in   Point(
+       x:,
+       y:,
+       z:
+     )
+   puts x + y + z
+in  Rectangle(
+      width: w,
+      height: h
+    )
+  puts w * h
+end

--- a/fixtures/small/prism/case_match_hash_expected.rb
+++ b/fixtures/small/prism/case_match_hash_expected.rb
@@ -1,0 +1,54 @@
+# Hash pattern matching
+case hash
+in {name: n, age: a}
+  puts("#{n} is #{a}")
+in {name:}
+  puts(name)
+end
+
+# Multiline hash pattern
+case big_hash
+in {
+    name: n,
+    age: a,
+    email: e
+  }
+  puts(n)
+in {
+    foo:,
+    bar:,
+    baz:
+  }
+  puts(foo)
+end
+
+# Hash pattern without braces (should add braces)
+case data
+in {name: n, age: a}
+  puts(n)
+in {foo:, bar:}
+  puts(foo)
+end
+
+# Hash pattern with parens (constant check)
+case obj
+in Point(x:, y:)
+  puts(x + y)
+in Rectangle(width: w, height: h)
+  puts(w * h)
+end
+
+# Multiline hash pattern with parens
+case obj
+in Point(
+    x:,
+    y:,
+    z:
+  )
+  puts(x + y + z)
+in Rectangle(
+    width: w,
+    height: h
+  )
+  puts(w * h)
+end

--- a/fixtures/small/prism/case_match_misc_actual.rb
+++ b/fixtures/small/prism/case_match_misc_actual.rb
@@ -1,0 +1,55 @@
+# Alternation pattern
+case  x
+in    1 | 2 | 3
+   puts "small"
+in   10 | 20
+  puts "medium"
+end
+
+# Capture pattern
+case   obj
+in    String => s
+   puts s.upcase
+in   Integer => i
+  puts i * 2
+end
+
+# Pinned variables
+x = 5
+case  value
+in   ^x
+   puts "equals x"
+in ^(x + 1)
+  puts "equals x + 1"
+end
+
+# Nested patterns
+case   data
+in  {users: [{name: n, age: a}, *rest]}
+   puts "first user: #{n}"
+in   [1, [2, 3], {key: v}]
+  puts v
+end
+
+# Find pattern with brackets
+case   arr
+in   [*before, 42, *after]
+   puts "found 42"
+end
+
+# Find pattern without brackets (should add brackets)
+case   arr
+in   *before, 42, *after
+   puts "found 42"
+end
+
+# Complex nested multiline
+case  response
+in   {
+       status: 200,
+       body: {
+         users: [first, *rest]
+       }
+     }
+   puts first
+end

--- a/fixtures/small/prism/case_match_misc_expected.rb
+++ b/fixtures/small/prism/case_match_misc_expected.rb
@@ -1,0 +1,55 @@
+# Alternation pattern
+case x
+in 1 | 2 | 3
+  puts("small")
+in 10 | 20
+  puts("medium")
+end
+
+# Capture pattern
+case obj
+in String => s
+  puts(s.upcase)
+in Integer => i
+  puts(i * 2)
+end
+
+# Pinned variables
+x = 5
+case value
+in ^x
+  puts("equals x")
+in ^(x + 1)
+  puts("equals x + 1")
+end
+
+# Nested patterns
+case data
+in {users: [{name: n, age: a}, *rest]}
+  puts("first user: #{n}")
+in [1, [2, 3], {key: v}]
+  puts(v)
+end
+
+# Find pattern with brackets
+case arr
+in [*before, 42, *after]
+  puts("found 42")
+end
+
+# Find pattern without brackets (should add brackets)
+case arr
+in [*before, 42, *after]
+  puts("found 42")
+end
+
+# Complex nested multiline
+case response
+in {
+    status: 200,
+    body: {
+        users: [first, *rest]
+      }
+  }
+  puts(first)
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -428,10 +428,16 @@ fn format_alias_method_node(ps: &mut ParserState, alias_method_node: prism::Alia
 }
 
 fn format_alternation_pattern_node(
-    _ps: &mut ParserState,
-    _alternation_pattern_node: prism::AlternationPatternNode,
+    ps: &mut ParserState,
+    alternation_pattern_node: prism::AlternationPatternNode,
 ) {
-    todo!()
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, alternation_pattern_node.left());
+        ps.emit_space();
+        ps.emit_ident("|".to_string());
+        ps.emit_space();
+        format_node(ps, alternation_pattern_node.right());
+    });
 }
 
 fn format_and_node(ps: &mut ParserState, and_node: prism::AndNode) {
@@ -529,14 +535,41 @@ fn format_break_node(ps: &mut ParserState, break_node: prism::BreakNode) {
 }
 
 fn format_capture_pattern_node(
-    _ps: &mut ParserState,
-    _capture_pattern_node: prism::CapturePatternNode,
+    ps: &mut ParserState,
+    capture_pattern_node: prism::CapturePatternNode,
 ) {
-    todo!()
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, capture_pattern_node.value());
+        ps.emit_space();
+        ps.emit_ident("=>".to_string());
+        ps.emit_space();
+        format_node(ps, capture_pattern_node.target().as_node());
+    });
 }
 
-fn format_case_match_node(_ps: &mut ParserState, _case_match_node: prism::CaseMatchNode) {
-    todo!()
+fn format_case_match_node(ps: &mut ParserState, case_match_node: prism::CaseMatchNode) {
+    ps.emit_case_keyword();
+
+    if let Some(predicate) = case_match_node.predicate() {
+        ps.with_start_of_line(false, |ps| {
+            ps.emit_space();
+            format_node(ps, predicate);
+        });
+    }
+
+    ps.emit_newline();
+    ps.with_start_of_line(true, |ps| {
+        for condition in case_match_node.conditions().iter() {
+            ps.with_start_of_line(false, |ps| format_node(ps, condition));
+        }
+
+        if let Some(else_node) = case_match_node.else_clause() {
+            ps.emit_indent();
+            format_else_node(ps, else_node);
+        }
+
+        ps.emit_end();
+    });
 }
 
 fn format_case_node(ps: &mut ParserState, case_node: prism::CaseNode) {
@@ -1107,8 +1140,39 @@ fn format_false_node(ps: &mut ParserState, false_node: prism::FalseNode) {
     );
 }
 
-fn format_find_pattern_node(_ps: &mut ParserState, _find_pattern_node: prism::FindPatternNode) {
-    todo!()
+fn format_find_pattern_node(ps: &mut ParserState, find_pattern_node: prism::FindPatternNode) {
+    if let Some(constant) = find_pattern_node.constant() {
+        ps.with_start_of_line(false, |ps| {
+            format_node(ps, constant);
+        });
+    }
+
+    ps.with_start_of_line(false, |ps| {
+        ps.new_block(|ps| {
+            ps.breakable_of(BreakableDelims::for_array(), |ps| {
+                ps.emit_soft_indent();
+                ps.with_start_of_line(false, |ps| {
+                    format_node(ps, find_pattern_node.left().as_node());
+                });
+
+                let requireds = find_pattern_node.requireds();
+                let requireds_end_offset = requireds.iter().last().unwrap().location().end_offset();
+                if !requireds.is_empty() {
+                    ps.emit_comma();
+                    ps.emit_soft_newline();
+                    ps.emit_soft_indent();
+                }
+                format_list_like_thing(ps, requireds, requireds_end_offset, false);
+
+                ps.emit_comma();
+                ps.emit_soft_newline();
+                ps.emit_soft_indent();
+                ps.with_start_of_line(false, |ps| {
+                    format_node(ps, find_pattern_node.right());
+                });
+            });
+        });
+    });
 }
 
 fn format_flip_flop_node(ps: &mut ParserState, flip_flop_node: prism::FlipFlopNode) {
@@ -2781,8 +2845,53 @@ fn format_word_array_interpolated_parts(
     }
 }
 
-fn format_array_pattern_node(_ps: &mut ParserState, _array_pattern_node: prism::ArrayPatternNode) {
-    todo!()
+fn format_array_pattern_node(ps: &mut ParserState, array_pattern_node: prism::ArrayPatternNode) {
+    if let Some(constant) = array_pattern_node.constant() {
+        ps.with_start_of_line(false, |ps| {
+            format_node(ps, constant);
+        });
+    }
+
+    let requireds = array_pattern_node.requireds();
+    let rest = array_pattern_node.rest();
+    let posts = array_pattern_node.posts();
+
+    ps.with_start_of_line(false, |ps| {
+        ps.new_block(|ps| {
+            ps.breakable_of(BreakableDelims::for_array(), |ps| {
+                for (i, element) in requireds.iter().enumerate() {
+                    if i > 0 {
+                        ps.emit_comma();
+                        ps.emit_soft_newline();
+                    }
+                    ps.emit_soft_indent();
+                    ps.with_start_of_line(false, |ps| format_node(ps, element));
+                }
+
+                let has_rest = if let Some(rest_node) = rest {
+                    if !requireds.is_empty() {
+                        ps.emit_comma();
+                        ps.emit_soft_newline();
+                    }
+                    ps.emit_soft_indent();
+                    ps.with_start_of_line(false, |ps| format_node(ps, rest_node));
+                    true
+                } else {
+                    false
+                };
+
+                let has_prior = !requireds.is_empty() || has_rest;
+                for (i, element) in posts.iter().enumerate() {
+                    if i > 0 || has_prior {
+                        ps.emit_comma();
+                        ps.emit_soft_newline();
+                    }
+                    ps.emit_soft_indent();
+                    ps.with_start_of_line(false, |ps| format_node(ps, element));
+                }
+            });
+        });
+    });
 }
 
 fn format_parentheses_node(ps: &mut ParserState, parentheses_node: prism::ParenthesesNode) {
@@ -3295,8 +3404,50 @@ fn format_hash_node(ps: &mut ParserState, hash_node: prism::HashNode) {
     });
 }
 
-fn format_hash_pattern_node(_ps: &mut ParserState, _hash_pattern_node: prism::HashPatternNode) {
-    todo!()
+fn format_hash_pattern_node(ps: &mut ParserState, hash_pattern_node: prism::HashPatternNode) {
+    if let Some(constant) = hash_pattern_node.constant() {
+        ps.with_start_of_line(false, |ps| {
+            format_node(ps, constant);
+        });
+    }
+
+    let opener = hash_pattern_node
+        .opening_loc()
+        .map(|loc| loc_to_string(loc));
+    let use_parens = hash_pattern_node.constant().is_some()
+        || opener.as_ref().map(|s| s.starts_with("(")).unwrap_or(false);
+
+    let elements = hash_pattern_node.elements();
+
+    let delims = if use_parens {
+        BreakableDelims::for_method_call()
+    } else {
+        BreakableDelims::for_hash()
+    };
+
+    ps.with_start_of_line(false, |ps| {
+        ps.new_block(|ps| {
+            ps.breakable_of(delims, |ps| {
+                for (i, element) in elements.iter().enumerate() {
+                    if i > 0 {
+                        ps.emit_comma();
+                        ps.emit_soft_newline();
+                    }
+                    ps.emit_soft_indent();
+                    ps.with_start_of_line(false, |ps| format_node(ps, element));
+                }
+
+                if let Some(rest_node) = hash_pattern_node.rest() {
+                    if !elements.is_empty() {
+                        ps.emit_comma();
+                        ps.emit_soft_newline();
+                    }
+                    ps.emit_soft_indent();
+                    ps.with_start_of_line(false, |ps| format_node(ps, rest_node));
+                }
+            });
+        });
+    });
 }
 
 fn format_inline_conditional(
@@ -3569,8 +3720,22 @@ fn format_implicit_rest_node() {
     // Since other machinery actually handles all of this, we don't really need to do anything if we end up here.
 }
 
-fn format_in_node(_ps: &mut ParserState, _in_node: prism::InNode) {
-    todo!()
+fn format_in_node(ps: &mut ParserState, in_node: prism::InNode) {
+    ps.emit_in_keyword();
+
+    ps.with_start_of_line(false, |ps| {
+        ps.emit_space();
+        format_node(ps, in_node.pattern());
+    });
+
+    ps.new_block(|ps| {
+        ps.with_start_of_line(true, |ps| {
+            ps.emit_newline();
+            if let Some(statements) = in_node.statements() {
+                format_node(ps, statements.as_node());
+            }
+        });
+    });
 }
 
 fn format_index_and_write_node(
@@ -4122,17 +4287,25 @@ fn format_or_node(ps: &mut ParserState, or_node: prism::OrNode) {
 }
 
 fn format_pinned_expression_node(
-    _ps: &mut ParserState,
-    _pinned_expression_node: prism::PinnedExpressionNode,
+    ps: &mut ParserState,
+    pinned_expression_node: prism::PinnedExpressionNode,
 ) {
-    todo!()
+    ps.emit_ident("^".to_string());
+    ps.emit_open_paren();
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, pinned_expression_node.expression());
+    });
+    ps.emit_close_paren();
 }
 
 fn format_pinned_variable_node(
-    _ps: &mut ParserState,
-    _pinned_variable_node: prism::PinnedVariableNode,
+    ps: &mut ParserState,
+    pinned_variable_node: prism::PinnedVariableNode,
 ) {
-    todo!()
+    ps.emit_ident("^".to_string());
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, pinned_variable_node.variable());
+    });
 }
 
 fn format_post_execution_node(ps: &mut ParserState, post_execution_node: prism::PostExecutionNode) {

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -621,6 +621,10 @@ impl ParserState {
         self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "when" });
     }
 
+    pub(crate) fn emit_in_keyword(&mut self) {
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "in" });
+    }
+
     pub(crate) fn emit_do_keyword(&mut self) {
         self.push_concrete_token(ConcreteLineToken::DoKeyword);
     }


### PR DESCRIPTION
On the tin -- this means we'll have implemented every node that Prism emits, so no more `todo!()`!

I'm open to bikeshedding on the specifics, but in general I modeled these nodes after existing nodes elsewhere, so array patterns are formatted like arrays, hash patterns like hashes, etc. For multiline arrays/hashes, they emit one indentation level up, which is the same as what we do for conditionals. Everything else I think more or less straightforward. There's quite a lot of fixtures, so that's probably a great place to start.