### PR TITLE
Avoid cloning `FormattingContext` on every breakable

### DIFF
--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -242,7 +242,7 @@ impl ParserState {
         F: FnOnce(&mut ParserState),
     {
         self.shift_comments();
-        let mut be = BreakableEntry::new(delims, self.formatting_context.clone());
+        let mut be = BreakableEntry::new(delims, &self.formatting_context);
         be.push_line_number(self.current_orig_line_number);
         self.breakable_entry_stack.push(Box::new(be));
 
@@ -278,7 +278,7 @@ impl ParserState {
         F: FnOnce(&mut ParserState),
     {
         self.shift_comments();
-        let mut be = BreakableEntry::new(delims, self.formatting_context.clone());
+        let mut be = BreakableEntry::new(delims, &self.formatting_context);
         be.push_line_number(self.current_orig_line_number);
         self.breakable_entry_stack.push(Box::new(be));
 

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -94,7 +94,7 @@ pub struct BreakableEntry {
     tokens: Vec<AbstractLineToken>,
     line_numbers: HashSet<LineNumber>,
     delims: BreakableDelims,
-    context: Vec<FormattingContext>,
+    in_string_embexpr: bool,
 }
 
 impl AbstractTokenTarget for BreakableEntry {
@@ -176,19 +176,21 @@ impl AbstractTokenTarget for BreakableEntry {
 }
 
 impl BreakableEntry {
-    pub fn new(delims: BreakableDelims, context: Vec<FormattingContext>) -> Self {
+    pub fn new(delims: BreakableDelims, formatting_context: &[FormattingContext]) -> Self {
+        let in_string_embexpr = formatting_context
+            .iter()
+            .any(|fc| fc == &FormattingContext::StringEmbexpr);
+
         BreakableEntry {
             tokens: Vec::new(),
             line_numbers: HashSet::new(),
             delims,
-            context,
+            in_string_embexpr,
         }
     }
 
     pub fn in_string_embexpr(&self) -> bool {
-        self.context
-            .iter()
-            .any(|fc| fc == &FormattingContext::StringEmbexpr)
+        self.in_string_embexpr
     }
 
     fn contains_hard_newline(&self) -> bool {


### PR DESCRIPTION
We clone the `Vec<FormattingContext>` on every single breakable, but we never modify it and just do a pretty simple check with it later -- all we need to know is whether there's a specific context type in that vec, which we can precompute at the breakable's initialization and avoid a clone.