### PR TITLE
:broom: Clean up unused fields from `LineMetadata`

### DIFF
--- a/librubyfmt/src/intermediary.rs
+++ b/librubyfmt/src/intermediary.rs
@@ -118,12 +118,6 @@ impl Intermediary {
             ConcreteLineToken::ModuleKeyword | ConcreteLineToken::ClassKeyword => {
                 self.handle_class_or_module();
             }
-            ConcreteLineToken::DoKeyword => {
-                self.handle_do_keyword();
-            }
-            ConcreteLineToken::ConditionalKeyword { contents: _ } => self.handle_conditional(),
-            ConcreteLineToken::End => self.handle_end(),
-            ConcreteLineToken::DefKeyword => self.handle_def(),
             ConcreteLineToken::Indent { depth } => {
                 self.current_line_metadata.observe_indent_level(*depth);
 
@@ -183,28 +177,12 @@ impl Intermediary {
         self.debug_assert_newlines();
     }
 
-    fn handle_end(&mut self) {
-        self.current_line_metadata.set_has_end();
-    }
-
-    fn handle_def(&mut self) {
-        self.current_line_metadata.set_has_def();
-    }
-
-    fn handle_do_keyword(&mut self) {
-        self.current_line_metadata.set_has_do_keyword();
-    }
-
     fn handle_class_or_module(&mut self) {
         if let Some(prev) = &self.previous_line_metadata
             && !prev.gets_indented()
         {
             self.insert_trailing_blankline(BlanklineReason::ClassOrModule);
         }
-    }
-
-    fn handle_conditional(&mut self) {
-        self.current_line_metadata.set_has_conditional();
     }
 
     pub fn clear_breakable_garbage(&mut self) {

--- a/librubyfmt/src/line_metadata.rs
+++ b/librubyfmt/src/line_metadata.rs
@@ -1,10 +1,6 @@
 #[derive(Debug)]
 pub struct LineMetadata {
     gets_indented: bool,
-    conditional: bool,
-    end: bool,
-    def: bool,
-    do_keyword: bool,
     indent_level: Option<u32>,
     require: bool,
 }
@@ -17,10 +13,6 @@ impl LineMetadata {
     pub fn new() -> Self {
         LineMetadata {
             gets_indented: false,
-            conditional: false,
-            end: false,
-            def: false,
-            do_keyword: false,
             indent_level: None,
             require: false,
         }
@@ -44,21 +36,5 @@ impl LineMetadata {
 
     pub fn set_gets_indented(&mut self) {
         self.gets_indented = true;
-    }
-
-    pub fn set_has_conditional(&mut self) {
-        self.conditional = true;
-    }
-
-    pub fn set_has_end(&mut self) {
-        self.end = true;
-    }
-
-    pub fn set_has_def(&mut self) {
-        self.def = true;
-    }
-
-    pub fn set_has_do_keyword(&mut self) {
-        self.do_keyword = true;
     }
 }


### PR DESCRIPTION
On the tin -- these fields are written to but never read 🔪 
