### PR TITLE
[CI] Use `actions-rust-lang/setup-rust-toolchain` caching instead of manual caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           toolchain: stable
           components: rustfmt
           override: true
+          cache: true
       - run: cargo fmt --all -- --check
 
   clippy:
@@ -26,12 +27,7 @@ jobs:
           toolchain: 1.91.1
           components: clippy
           override: true
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
+          cache: true
       - run: cargo clippy --all --all-features -- -D warnings
 
   lint:
@@ -63,18 +59,14 @@ jobs:
         toolchain: 1.91.1
         target: aarch64-apple-darwin
         override: true
+        cache: true
     - if: runner.os != 'macOS'
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: 1.91.1
         override: true
         target: aarch64-unknown-linux-gnu
-    - uses: actions/cache@v5
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: ${{ runner.os }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
+        cache: true
     - if: runner.os == 'macOS'
       run: |
         brew install automake bison

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -41,12 +41,14 @@ jobs:
           toolchain: 1.91.1
           target: aarch64-apple-darwin
           override: true
+          cache: true
       - if: runner.os != 'macOS'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.91.1
           override: true
           target: aarch64-unknown-linux-gnu
+          cache: true
       - if: runner.os == 'macOS'
         run: |
           brew install automake bison


### PR DESCRIPTION
Our current CI times are dominated by compilation time, the main reason being that we don't cache the `target/` directory, so we do a full recompilation of every dependency on every run.

This PR attempts to speed these up by using our Rust toolchain action's built-in caching mechanism (which should cache our `target/` output for all of our dependencies) instead of our own hand-rolled actions cache.