### PR TITLE
[prism] Only elide parens for it/describe with blocks

### DIFF
--- a/fixtures/small/rspec_its_actual.rb
+++ b/fixtures/small/rspec_its_actual.rb
@@ -17,6 +17,9 @@ end
 
 it("a", flag: true, other: "b", another: false) { 1 }
 
+describe(name, desc, opts, &block)
+describe name, desc, opts, &block
+
 describe "foo" do
   it "foo" do
   end

--- a/fixtures/small/rspec_its_expected.rb
+++ b/fixtures/small/rspec_its_expected.rb
@@ -19,6 +19,9 @@ end
 
 it("a", flag: true, other: "b", another: false) { 1 }
 
+describe(name, desc, opts, &block)
+describe(name, desc, opts, &block)
+
 describe "foo" do
   it "foo" do
   end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1661,7 +1661,13 @@ fn use_parens_for_call_node(
         return true;
     }
 
-    if RSPEC_METHODS.contains(method_name) && call_node.receiver().is_none() {
+    if RSPEC_METHODS.contains(method_name)
+        && call_node.receiver().is_none()
+        // Only elide parens for blocks, not block params (`&blk`)
+        && call_node
+            .block()
+            .is_some_and(|blk| blk.as_block_node().is_some())
+    {
         return false;
     }
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1666,7 +1666,8 @@ fn use_parens_for_call_node(
         // Only elide parens for blocks, not block params (`&blk`)
         && call_node
             .block()
-            .is_some_and(|blk| blk.as_block_node().is_some())
+            .and_then(|blk| blk.as_block_node())
+            .is_some()
     {
         return false;
     }


### PR DESCRIPTION
Closes #703 

We should only be eliding parens for `it` and `describe` where they pass a brace or do/end block and not just a block param.

How this works in Ripper is that `method_add_block` does [not explicitly say](https://github.com/fables-tales/rubyfmt/blob/00a1fc68efa853ad7d3abcbb3c2685bbe40cffb2/librubyfmt/src/format.rs#L2600) whether to add parens, so it falls through to `can_elide_parens_for_reserved_names`, which [essentially says](https://github.com/fables-tales/rubyfmt/blob/00a1fc68efa853ad7d3abcbb3c2685bbe40cffb2/librubyfmt/src/format.rs#L2397-L2414) no parens for do/end blocks, parens for brace blocks, but a regular non-block method call will [decide](https://github.com/fables-tales/rubyfmt/blob/reese-describe-block-param/librubyfmt/src/format.rs#L742-L748) using `use_parens_for_method_call`, which treats it/describe as plain method calls.