### PR TITLE
[prism] bind a local variable for optional keyword params

### DIFF
--- a/fixtures/small/variable_binding_actual.rb
+++ b/fixtures/small/variable_binding_actual.rb
@@ -32,4 +32,12 @@ class Foo < T::Struct
   def has_same_name?(name:)
     name == name()
   end
+
+  def in_a_parameter_list(
+    with_parens = self.with_parens(),
+    nope_parens = self.nope_parens,
+    kw_with_parens: self.kw_with_parens(),
+    kw_nope_parens: self.kw_nope_parens
+  )
+  end
 end

--- a/fixtures/small/variable_binding_expected.rb
+++ b/fixtures/small/variable_binding_expected.rb
@@ -33,4 +33,12 @@ class Foo < T::Struct
   def has_same_name?(name:)
     name == name()
   end
+
+  def in_a_parameter_list(
+    with_parens = self.with_parens(),
+    nope_parens = self.nope_parens(),
+    kw_with_parens: self.kw_with_parens(),
+    kw_nope_parens: self.kw_nope_parens()
+  )
+  end
 end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4293,7 +4293,9 @@ fn format_optional_keyword_parameter_node(
     ps: &mut ParserState,
     optional_keyword_parameter_node: prism::OptionalKeywordParameterNode,
 ) {
-    ps.emit_ident(const_to_string(optional_keyword_parameter_node.name()));
+    let name = const_to_string(optional_keyword_parameter_node.name());
+    ps.bind_variable(name.clone());
+    ps.emit_ident(name);
     ps.emit_op(Cow::Borrowed(":"));
     ps.emit_space();
     ps.with_start_of_line(false, |ps| {


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
As the subject says.  We were doing this for all other parameters except this one, and wouldn't you know, this behavior change caused a formatting regression on Stripe's codebase.