### PR TITLE
[prism] retain parenthesis around multiple assignments

### DIFF
--- a/fixtures/small/massign_actual.rb
+++ b/fixtures/small/massign_actual.rb
@@ -1,6 +1,7 @@
 class Foo
   def bees
     a, b = [1, 2]
+    (a, b) = [1, 2]
     *nums = [a, b, c]
   end
 end

--- a/fixtures/small/massign_expected.rb
+++ b/fixtures/small/massign_expected.rb
@@ -1,6 +1,7 @@
 class Foo
   def bees
     a, b = [1, 2]
+    (a, b) = [1, 2]
     *nums = [a, b, c]
   end
 end

--- a/fixtures/small/massign_omg_actual.rb
+++ b/fixtures/small/massign_omg_actual.rb
@@ -1,3 +1,4 @@
 desc = *foo
 a = 1, *foo
 a, b = 1, 2, *foo, a, *d
+(a, b) = 1, 2, *foo, a, *d

--- a/fixtures/small/massign_omg_expected.rb
+++ b/fixtures/small/massign_omg_expected.rb
@@ -1,3 +1,4 @@
 desc = *foo
 a = 1, *foo
 a, b = 1, 2, *foo, a, *d
+(a, b) = 1, 2, *foo, a, *d

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4184,20 +4184,13 @@ fn format_match_write_node(ps: &mut ParserState, match_write_node: prism::MatchW
 fn format_multi_target_node(ps: &mut ParserState, multi_target_node: prism::MultiTargetNode) {
     let has_parens = multi_target_node.lparen_loc().is_some();
 
-    if has_parens {
-        ps.emit_open_paren();
-    }
-
     format_multi_targets(
         ps,
         multi_target_node.lefts(),
         multi_target_node.rest(),
         multi_target_node.rights(),
+        has_parens,
     );
-
-    if has_parens {
-        ps.emit_close_paren();
-    }
 }
 
 fn format_multi_targets(
@@ -4205,7 +4198,12 @@ fn format_multi_targets(
     lefts: prism::NodeList,
     rest: Option<prism::Node>,
     rights: prism::NodeList,
+    has_parens: bool,
 ) {
+    if has_parens {
+        ps.emit_open_paren();
+    }
+
     let has_lefts = !lefts.is_empty();
     let has_rest = rest.is_some();
     let has_rights = !rights.is_empty();
@@ -4235,14 +4233,21 @@ fn format_multi_targets(
             format_list_like_thing(ps, rights, rights_offset, true);
         }
     });
+
+    if has_parens {
+        ps.emit_close_paren();
+    }
 }
 
 fn format_multi_write_node(ps: &mut ParserState, multi_write_node: prism::MultiWriteNode) {
+    let has_parens = multi_write_node.lparen_loc().is_some();
+
     format_multi_targets(
         ps,
         multi_write_node.lefts(),
         multi_write_node.rest(),
         multi_write_node.rights(),
+        has_parens,
     );
 
     ps.emit_ident(" = ");


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
We were keeping the parens around `MultiTargetNode`, but not around `MultiWriteNode`.  We push the paren emission into formatting the parts of a multi target so it's harder to make mistakes.