### PR TITLE
be smarter about accessing `breakable_entry_stack`

### DIFF
--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -814,8 +814,8 @@ impl ParserState {
         let idx = self.index_of_prev_hard_newline();
         let insert_idx = idx.unwrap_or(0);
 
-        if self.breakable_entry_stack.last().is_some() {
-            self.breakable_entry_stack.last_mut().unwrap().insert_at(
+        if let Some(entry) = self.breakable_entry_stack.last_mut() {
+            entry.insert_at(
                 insert_idx,
                 &mut vec![AbstractLineToken::ConcreteLineToken(
                     ConcreteLineToken::HardNewLine,


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
🧹 