### PR TITLE
[prism] use `let Some` to clean up single-arg def node handling

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1738,23 +1738,9 @@ fn format_call_node(
             // For callers where the only arg is a def node,
             // we assume that's a `public def` style modifier and don't use parens
             if arguments.arguments().len() == 1
-                && arguments
-                    .arguments()
-                    .iter()
-                    .next()
-                    .unwrap()
-                    .as_def_node()
-                    .is_some()
+                && let Some(def_node) = arguments.arguments().iter().next().unwrap().as_def_node()
             {
                 ps.emit_space();
-
-                let def_node = arguments
-                    .arguments()
-                    .iter()
-                    .next()
-                    .unwrap()
-                    .as_def_node()
-                    .unwrap();
                 format_def_node(ps, def_node);
             } else if is_aref_write {
                 let arg_count = arguments.arguments().len();


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
🧹 