### PR TITLE
[prism] Wrap calls with blocks in `BreakableCallChainEntry` for correct line length handling

### DIFF
--- a/fixtures/small/nested_block_breakable_actual.rb
+++ b/fixtures/small/nested_block_breakable_actual.rb
@@ -1,0 +1,4 @@
+Util::Callsite.capture_query_callsite(collection: self.collection_name, allow_disabling: true) do
+  for_each_this do |obj|
+  end
+end

--- a/fixtures/small/nested_block_breakable_expected.rb
+++ b/fixtures/small/nested_block_breakable_expected.rb
@@ -1,0 +1,4 @@
+Util::Callsite.capture_query_callsite(collection: self.collection_name, allow_disabling: true) do
+  for_each_this do |obj|
+  end
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -67,7 +67,18 @@ pub fn format_node(ps: &mut ParserState, node: prism::Node) {
         Node::CallNode { .. } => {
             let call_node = node.as_call_node().unwrap();
             let is_last_call_in_chain = call_node.receiver().is_none();
-            format_call_node(ps, call_node, false, is_last_call_in_chain)
+
+            // Wrap standalone calls (no receiver) with blocks in a BreakableCallChainEntry
+            // so that line-length machinery can ignore nested blocks.
+            let has_block = call_node.block().and_then(|b| b.as_block_node()).is_some();
+
+            if is_last_call_in_chain && has_block {
+                ps.breakable_call_chain_of(MultilineHandling::Prism(false), |ps| {
+                    format_call_node(ps, call_node, false, is_last_call_in_chain);
+                });
+            } else {
+                format_call_node(ps, call_node, false, is_last_call_in_chain)
+            }
         }
         Node::CallOperatorWriteNode { .. } => {
             format_call_operator_write_node(ps, node.as_call_operator_write_node().unwrap())


### PR DESCRIPTION
Closes #701 

When doing line-length calculations for block calls, we have some machinery that tries to ignore the contents of the block when calculating the length, essentially popping tokens until it gets back to the block params. This is so that multiline blocks at the end of a chain (like `Klass.do_some_stuff_in_a_block do |params| #...`) are only considered insofar as their line length affects the line of the call chain itself, meaning they won't for example break the whole chain if just the block contents go over the line length.

To do this, [this bit](https://github.com/fables-tales/rubyfmt/blob/933408494df678f2388e98262ad18f741bef822b/librubyfmt/src/render_targets.rs#L269-L303) handles this token-popping, and it assumes that blocks are always wrapped in a breakable entry. For brace blocks, this worked since the brace block is _itself_ a breakable, but in Ripper the entire block call would also have been wrapped in a `BreakableCallChainEntry` because that's [how `method_add_arg` blocks were handled](https://github.com/fables-tales/rubyfmt/blob/933408494df678f2388e98262ad18f741bef822b/librubyfmt/src/format.rs#L2600).

The prism implementation didn't do this before, so when calculating the line length of a block call with nested blocks inside of it, it was only unwinding until it saw block params, which would be inside the inner block and not the outer one. This caused some strange multilining that could seem ~random, since it only affected certain arrangements of block calls.