### PR TITLE
[prism] Always format block parameters as `with_start_of_line(false, …`

### DIFF
--- a/fixtures/small/super_with_block_actual.rb
+++ b/fixtures/small/super_with_block_actual.rb
@@ -3,3 +3,12 @@ end
 
 super(1) do
 end
+
+class X
+  def m(&blk)
+    # super-duper
+    super do |x|
+      yield(maybe_track("*", x))
+    end
+  end
+end

--- a/fixtures/small/super_with_block_expected.rb
+++ b/fixtures/small/super_with_block_expected.rb
@@ -3,3 +3,12 @@ end
 
 super(1) do
 end
+
+class X
+  def m(&blk)
+    # super-duper
+    super do |x|
+      yield(maybe_track("*", x))
+    end
+  end
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2539,7 +2539,9 @@ fn format_block_node(ps: &mut ParserState, block_node: prism::BlockNode) {
                 && block_parameters.as_numbered_parameters_node().is_none()
                 && block_parameters.as_it_parameters_node().is_none()
             {
-                format_node(ps, block_parameters);
+                ps.with_start_of_line(false, |ps| {
+                    format_node(ps, block_parameters);
+                });
             }
 
             // Even if there's no body, we still need a newline for


### PR DESCRIPTION
Closes #700 

On the tin -- this was causing issues only with `super` nodes because it was the only caller of `format_block_node` without `with_start_of_line(false)`, but this should be always be true -- block parameters are always nested in the expression. Without this, some renders had excessive spacing since `format_node` was inserting extra indents and newlines.