### PR TITLE
[prism] Never use parens with `next`

### DIFF
--- a/fixtures/small/next_with_args_actual.rb
+++ b/fixtures/small/next_with_args_actual.rb
@@ -1,3 +1,13 @@
 [].each do ||
 next 1
+next Foo.new(
+    a,
+    b
+)
+next(
+    Foo.new(
+        a,
+        b
+    )
+)
 end

--- a/fixtures/small/next_with_args_expected.rb
+++ b/fixtures/small/next_with_args_expected.rb
@@ -1,3 +1,11 @@
 [].each do
   next 1
+  next Foo.new(
+    a,
+    b
+  )
+  next (Foo.new(
+    a,
+    b
+  ))
 end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4258,9 +4258,8 @@ fn format_next_node(ps: &mut ParserState, next_node: prism::NextNode) {
     ps.emit_ident("next");
     if let Some(arguments_node) = next_node.arguments() {
         ps.with_start_of_line(false, |ps| {
-            ps.breakable_of(BreakableDelims::for_kw(), |ps| {
-                format_arguments_node(ps, arguments_node);
-            });
+            ps.emit_space();
+            format_arguments_node(ps, arguments_node);
         });
     }
 }


### PR DESCRIPTION
Closes #696 