### PR TITLE
[prism] Only add parens for self calls at the end of chains

### DIFF
--- a/fixtures/small/scoping_actual.rb
+++ b/fixtures/small/scoping_actual.rb
@@ -28,3 +28,5 @@ class MyTestClass
     File.write(path(), 'One medium-sized bufo, if I may')
   end
 end
+
+foo = self.foo.any?

--- a/fixtures/small/scoping_expected.rb
+++ b/fixtures/small/scoping_expected.rb
@@ -30,3 +30,5 @@ class MyTestClass
     File.write(path(), "One medium-sized bufo, if I may")
   end
 end
+
+foo = self.foo.any?

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1608,7 +1608,8 @@ fn use_parens_for_call_node(
     if ps.scope_has_variable(method_name) {
         if call_node.receiver().is_none() {
             return original_used_parens;
-        } else if let Some(receiver) = call_node.receiver()
+        } else if is_terminal_call
+            && let Some(receiver) = call_node.receiver()
             && receiver.as_self_node().is_some()
         {
             return true;


### PR DESCRIPTION
Closes #698 

I believe the intent of [this change](https://github.com/fables-tales/rubyfmt/blob/8fbc6c12e15c579668e3d06d5ec664a02278481d/librubyfmt/src/format.rs#L651) is that we should only be adding parens if the method name is the last item in the chain and the chain is _only_ a receiver of `self`. To that end, I'm updating the Prism paren logic to only add parens to the terminal call so it only affects `foo = self.foo()` and not chains like `foo = self.foo.any?`.