### PR TITLE
[prism] avoid parens for uppercase methods with blocks

### DIFF
--- a/fixtures/small/const_call_actual.rb
+++ b/fixtures/small/const_call_actual.rb
@@ -13,3 +13,8 @@ Foo::Bar
 Foo::Bar()
 Foo.Bar
 Foo.Bar()
+Bar(1, &fun_returning_blk)
+Bar(&fun_returning_blk)
+Bar do
+  other_call
+end

--- a/fixtures/small/const_call_actual.rb
+++ b/fixtures/small/const_call_actual.rb
@@ -15,6 +15,10 @@ Foo.Bar
 Foo.Bar()
 Bar(1, &fun_returning_blk)
 Bar(&fun_returning_blk)
+Bar(1) do
+  other_call
+end
+
 Bar do
   other_call
 end

--- a/fixtures/small/const_call_expected.rb
+++ b/fixtures/small/const_call_expected.rb
@@ -17,3 +17,8 @@ Foo::Bar
 Foo::Bar()
 Foo.Bar()
 Foo.Bar()
+Bar(1, &fun_returning_blk)
+Bar(&fun_returning_blk)
+Bar do
+  other_call
+end

--- a/fixtures/small/const_call_expected.rb
+++ b/fixtures/small/const_call_expected.rb
@@ -19,6 +19,10 @@ Foo.Bar()
 Foo.Bar()
 Bar(1, &fun_returning_blk)
 Bar(&fun_returning_blk)
+Bar(1) do
+  other_call
+end
+
 Bar do
   other_call
 end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1608,7 +1608,19 @@ fn use_parens_for_call_node(
     // Foo # class reference
     // Foo() # method call
     // ```
+    let has_arguments = call_node
+        .arguments()
+        .map(|args| {
+            !(args.arguments().is_empty()
+                || (args.arguments().len() == 1
+                    && is_empty_parentheses_node(&args.arguments().iter().next().unwrap())))
+        })
+        .unwrap_or(false);
+
     if is_terminal_call && method_name.chars().next().is_some_and(|c| c.is_uppercase()) {
+        if !has_arguments && call_node.block().is_some() {
+            return false;
+        }
         return true;
     }
 
@@ -1648,15 +1660,6 @@ fn use_parens_for_call_node(
     {
         return original_used_parens;
     }
-
-    let has_arguments = call_node
-        .arguments()
-        .map(|args| {
-            !(args.arguments().is_empty()
-                || (args.arguments().len() == 1
-                    && is_empty_parentheses_node(&args.arguments().iter().next().unwrap())))
-        })
-        .unwrap_or(false);
 
     if !has_arguments {
         return false;


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Fixes #697

This doesn't exactly feel like the right fix -- I would expect the zero-arg block case to be handled by something else, but since returning `true` from this function unconditionally seems to force the parens, we have to be a little more careful in when uppercase method calls need parens.