### PR TITLE
track a single `IndentDepth` rather than a stack

### DIFF
--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -846,7 +846,7 @@ impl ParserState {
 
     pub(crate) fn new_with_indent_from(ps: &ParserState) -> Self {
         let mut next_ps = ParserState::new_with_reset_indentation(ps);
-        next_ps.indent_depth = ps.indent_depth.clone();
+        next_ps.indent_depth = ps.indent_depth;
         next_ps
     }
 

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -204,10 +204,9 @@ impl ParserState {
     where
         F: FnOnce(&mut ParserState),
     {
-        let ds_length = self.depth_stack.len();
-        self.depth_stack[ds_length - 1].decrement();
+        self.end_indent();
         f(self);
-        self.depth_stack[ds_length - 1].increment();
+        self.start_indent();
     }
 
     pub(crate) fn start_indent(&mut self) {
@@ -351,10 +350,9 @@ impl ParserState {
     where
         F: FnOnce(&mut ParserState),
     {
-        let ds_length = self.depth_stack.len();
-        self.depth_stack[ds_length - 1].increment();
+        self.start_indent();
         f(self);
-        self.depth_stack[ds_length - 1].decrement();
+        self.end_indent();
     }
 
     pub(crate) fn with_formatting_context<F>(&mut self, fc: FormattingContext, f: F)

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -57,7 +57,7 @@ impl IndentDepth {
 
 #[derive(Debug)]
 pub struct ParserState {
-    depth_stack: Vec<IndentDepth>,
+    indent_depth: IndentDepth,
     start_of_line: Vec<bool>,
     suppress_comments_stack: Vec<bool>,
     render_queue: BaseQueue,
@@ -210,8 +210,7 @@ impl ParserState {
     }
 
     pub(crate) fn start_indent(&mut self) {
-        let ds_length = self.depth_stack.len();
-        self.depth_stack[ds_length - 1].increment();
+        self.indent_depth.increment();
     }
 
     pub(crate) fn start_indent_for_call_chain(&mut self) {
@@ -223,8 +222,7 @@ impl ParserState {
     }
 
     pub(crate) fn end_indent(&mut self) {
-        let ds_length = self.depth_stack.len();
-        self.depth_stack[ds_length - 1].decrement();
+        self.indent_depth.decrement();
     }
 
     pub(crate) fn with_start_of_line<F>(&mut self, start_of_line: bool, f: F)
@@ -764,7 +762,7 @@ impl ParserState {
 impl ParserState {
     pub(crate) fn new(fc: FileComments) -> Self {
         ParserState {
-            depth_stack: vec![IndentDepth::new()],
+            indent_depth: IndentDepth::new(),
             start_of_line: vec![true],
             suppress_comments_stack: vec![false],
             render_queue: BaseQueue::default(),
@@ -825,11 +823,7 @@ impl ParserState {
     }
 
     pub(crate) fn current_spaces(&self) -> ColNumber {
-        2 * self
-            .depth_stack
-            .last()
-            .expect("depth stack is never empty")
-            .get()
+        2 * self.indent_depth.get()
     }
 
     pub(crate) fn disable_user_newlines(&mut self) {
@@ -852,7 +846,7 @@ impl ParserState {
 
     pub(crate) fn new_with_depth_stack_from(ps: &ParserState) -> Self {
         let mut next_ps = ParserState::new_with_reset_depth_stack(ps);
-        next_ps.depth_stack = ps.depth_stack.clone();
+        next_ps.indent_depth = ps.indent_depth.clone();
         next_ps
     }
 

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -178,7 +178,7 @@ impl ParserState {
     where
         F: FnOnce(&mut ParserState),
     {
-        let mut next_ps = ParserState::new_with_depth_stack_from(self);
+        let mut next_ps = ParserState::new_with_indent_from(self);
         // Ignore commments when determining line length
         next_ps.with_suppress_comments(true, f);
         let data = next_ps.render_to_buffer();
@@ -844,15 +844,15 @@ impl ParserState {
         }
     }
 
-    pub(crate) fn new_with_depth_stack_from(ps: &ParserState) -> Self {
-        let mut next_ps = ParserState::new_with_reset_depth_stack(ps);
+    pub(crate) fn new_with_indent_from(ps: &ParserState) -> Self {
+        let mut next_ps = ParserState::new_with_reset_indentation(ps);
         next_ps.indent_depth = ps.indent_depth.clone();
         next_ps
     }
 
-    // Creates a copy of the parser state *with the depth_stack reset*.
+    // Creates a copy of the parser state *with the indent_depth reset*.
     // This is used for heredocs, where we explicitly want to ignore current indentation.
-    pub(crate) fn new_with_reset_depth_stack(ps: &ParserState) -> Self {
+    pub(crate) fn new_with_reset_indentation(ps: &ParserState) -> Self {
         let mut next_ps = ParserState::new(FileComments::default());
         next_ps.comments_hash = ps.comments_hash.clone();
         next_ps.start_of_line = ps.start_of_line.clone();
@@ -956,7 +956,7 @@ impl ParserState {
     where
         F: FnOnce(&mut ParserState),
     {
-        let mut next_ps = ParserState::new_with_reset_depth_stack(ps);
+        let mut next_ps = ParserState::new_with_reset_indentation(ps);
         f(&mut next_ps);
         next_ps
     }


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
We no longer use `ParserState::depthStack` as a stack -- I don't know the history here, but I assume that nowadays, the call stack does the relevant stack management for us.  We can simplify the code by just tracking a single `IndentDepth`, and nobody has to get confused about the stack management anymore.