### PR TITLE
use `Option` chaining in `index_of_prev_newline`

### DIFF
--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -65,14 +65,14 @@ pub trait AbstractTokenTarget: std::fmt::Debug {
         self.tokens()
             .iter()
             .rposition(|v| v.is_newline() || v.is_comment())
-            .and_then(|x| {
+            .map(|x| {
                 let token = &self.tokens()[x];
                 if matches!(token, AbstractLineToken::CollapsingNewLine(_))
                     || matches!(token, AbstractLineToken::SoftNewline(_))
                 {
-                    Some(x + 1)
+                    x + 1
                 } else {
-                    Some(x)
+                    x
                 }
             })
     }

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -62,22 +62,19 @@ pub trait AbstractTokenTarget: std::fmt::Debug {
     }
 
     fn index_of_prev_newline(&self) -> Option<usize> {
-        let first_idx = self
-            .tokens()
+        self.tokens()
             .iter()
-            .rposition(|v| v.is_newline() || v.is_comment());
-        match first_idx {
-            Some(x) => {
-                if matches!(self.tokens()[x], AbstractLineToken::CollapsingNewLine(_))
-                    || matches!(self.tokens()[x], AbstractLineToken::SoftNewline(_))
+            .rposition(|v| v.is_newline() || v.is_comment())
+            .and_then(|x| {
+                let token = &self.tokens()[x];
+                if matches!(token, AbstractLineToken::CollapsingNewLine(_))
+                    || matches!(token, AbstractLineToken::SoftNewline(_))
                 {
                     Some(x + 1)
                 } else {
                     Some(x)
                 }
-            }
-            None => None,
-        }
+            })
     }
 
     fn last_token_is_a_newline(&self) -> bool {


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
This probably isn't any more efficient, but I think it is slightly cleaner and easier to read.