### PR TITLE
more efficient `single_line_string_length` for breakable call chains

### DIFF
--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -349,9 +349,8 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
         tokens
             .into_iter()
             .flat_map(|t| t.into_single_line())
-            .map(|t| t.into_ruby())
-            .collect::<String>()
-            .len()
+            .map(|t| t.into_ruby().len())
+            .sum()
     }
 
     fn push_line_number(&mut self, _number: LineNumber) {


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
We do this length adding for breakables, we should be able to do the same thing for breakable call chains.