### PR TITLE
[ripper] Eagerly render heredocs for parens starting call chains

### DIFF
--- a/fixtures/small/heredoc_parens_chain_actual.rb
+++ b/fixtures/small/heredoc_parens_chain_actual.rb
@@ -1,0 +1,4 @@
+(<<~BEOWULF).freeze
+  So. The Spear-Danes in days gone by
+  and the kings who ruled them had courage and greatness.
+BEOWULF

--- a/fixtures/small/heredoc_parens_chain_expected.rb
+++ b/fixtures/small/heredoc_parens_chain_expected.rb
@@ -1,0 +1,5 @@
+(<<~BEOWULF)
+  So. The Spear-Danes in days gone by
+  and the kings who ruled them had courage and greatness.
+BEOWULF
+  .freeze

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2479,7 +2479,12 @@ fn format_call_chain_elements(
         };
 
         match cc_elem {
-            CallChainElement::Paren(p) => format_paren(ps, p),
+            CallChainElement::Paren(p) => {
+                format_paren(ps, p);
+                // Eagerly render heredocs before the BeginCallChainIndent is applied,
+                // same as for CallChainElement::Expression.
+                ps.render_heredocs(true);
+            }
             CallChainElement::IdentOrOpOrKeywordOrConst(i) => {
                 let ident = i.into_ident();
                 next_args_list_must_use_parens = ident.1 == "super" || ident.1 == ".()";


### PR DESCRIPTION
Closes #715 

Heredocs at the start of call chains shouldn't have their contents indented with the rest of the chain. This PR eagerly renders heredocs for Parens (to match the treatment of Expressions) in chains to make sure they are emitted before the indentation begins.