### PR TITLE
[ripper] Don't indent multiline block vars for brace blocks

### DIFF
--- a/fixtures/small/long_blockvar_actual.rb
+++ b/fixtures/small/long_blockvar_actual.rb
@@ -10,3 +10,16 @@ things.each do |
   |
   do_things!
 end
+
+things.each { |
+    omg:,
+    really:,
+    dang:,
+    long:,
+    blockvar:,
+    that_is_so_long_if_you_write_this:,
+    you_should_refactor:,
+    like_really_this_is_so_long:
+  |
+  do_things!
+}

--- a/fixtures/small/long_blockvar_expected.rb
+++ b/fixtures/small/long_blockvar_expected.rb
@@ -11,3 +11,17 @@ things
     |
     do_things!
   end
+
+things
+  .each { |
+      omg:,
+      really:,
+      dang:,
+      long:,
+      blockvar:,
+      that_is_so_long_if_you_write_this:,
+      you_should_refactor:,
+      like_really_this_is_so_long:
+    |
+    do_things!
+  }

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -2650,7 +2650,9 @@ pub fn format_brace_block(ps: &mut ParserState, brace_block: BraceBlock) {
 
     ps.inline_breakable_of(BreakableDelims::for_brace_block(), |ps| {
         if let Some(bv) = bv {
-            format_blockvar(ps, bv);
+            ps.dedent(|ps| {
+                format_blockvar(ps, bv);
+            });
         }
 
         render_block_contents(ps, brace_block_render_method, body, end_line);


### PR DESCRIPTION
Closes #717

On the tin. Brace blocks indented their params by virtue of being wrapped in a breakable, but this is not an intended side effect. To counteract it, we can just `dedent` it.