### PR TITLE
Use `Vec::splice` to insert tokens instead of `Vec::split_off`

### DIFF
--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -5,9 +5,7 @@ use crate::ripper_tree_types::CallChainElement;
 use crate::types::LineNumber;
 
 fn insert_at<T>(idx: usize, target: &mut Vec<T>, input: &mut Vec<T>) {
-    let mut tail = target.split_off(idx);
-    target.append(input);
-    target.append(&mut tail);
+    target.splice(idx..idx, input.drain(..));
 }
 
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
`Vec::split_off` allocates a new intermediate Vec on every single token insertion (!), and then promptly deallocates it when appended to the new Vec. `splice` will instead move all the elements at the end (which in theory should generally be a single item, a newline token) to the right with a single `memmove` and then insert the `input` Vec in without an intermediary Vec.

I was looking at a flamegraph (see #731) and saw that we spent a significant amount of time each run allocating in `insert_at`, so this should cut down a decent amount of memory churn.