### PR TITLE
Use a shared `&'static str` for indentation

### DIFF
--- a/librubyfmt/src/comment_block.rs
+++ b/librubyfmt/src/comment_block.rs
@@ -2,6 +2,7 @@ use std::ops::Range;
 
 use crate::line_tokens::ConcreteLineToken;
 use crate::types::{ColNumber, LineNumber};
+use crate::util::get_indent;
 
 #[derive(Clone, Debug)]
 pub struct CommentBlock {
@@ -36,7 +37,7 @@ impl CommentBlock {
     }
 
     pub fn apply_spaces(mut self, indent_depth: ColNumber) -> Self {
-        let indent = str::repeat(" ", indent_depth as _);
+        let indent = get_indent(indent_depth as usize);
         for comment in &mut self.comments {
             // Ignore empty strings -- these represent blank lines between
             // groups of comments

--- a/librubyfmt/src/heredoc_string.rs
+++ b/librubyfmt/src/heredoc_string.rs
@@ -1,4 +1,5 @@
 use crate::types::ColNumber;
+use crate::util::get_indent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HeredocKind {
@@ -53,7 +54,7 @@ impl HeredocString {
             string
                 .split('\n')
                 .map(|l| {
-                    String::from(format!("{}{}", " ".repeat(indent as usize + 2), l).trim_end())
+                    String::from(format!("{}{}", get_indent(indent as usize + 2), l).trim_end())
                 })
                 .collect::<Vec<String>>()
                 .join("\n")

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -3,6 +3,7 @@ use crate::render_targets::{
     AbstractTokenTarget, BreakableCallChainEntry, BreakableEntry, ConvertType,
 };
 use crate::types::ColNumber;
+use crate::util::get_indent;
 use std::borrow::Cow;
 
 pub fn cltats_hard_newline() -> ConcreteLineTokenAndTargets {
@@ -71,7 +72,7 @@ impl ConcreteLineToken {
     pub fn into_ruby(self) -> Cow<'static, str> {
         match self {
             Self::HardNewLine => Cow::Borrowed("\n"),
-            Self::Indent { depth } => Cow::Owned((0..depth).map(|_| ' ').collect()),
+            Self::Indent { depth } => get_indent(depth as usize),
             Self::Keyword { keyword } => Cow::Borrowed(keyword),
             Self::ModKeyword { contents } => Cow::Borrowed(contents),
             Self::ConditionalKeyword { contents } => Cow::Borrowed(contents),

--- a/librubyfmt/src/util.rs
+++ b/librubyfmt/src/util.rs
@@ -1,4 +1,21 @@
+use std::borrow::Cow;
+
 use ruby_prism::{ConstantId, Location};
+
+/// Maximum indent depth we cache without allocation.
+const MAX_CACHED_INDENT: usize = 128;
+/// A pre-allocated string of spaces for efficient indentation
+const SPACES: &str = unsafe { std::str::from_utf8_unchecked(&[b' '; MAX_CACHED_INDENT]) };
+
+/// Returns a string of `depth` spaces. For common indent depths (<= 128),
+/// this returns a static slice and only allocates for huge indents.
+pub fn get_indent(depth: usize) -> Cow<'static, str> {
+    if depth <= MAX_CACHED_INDENT {
+        Cow::Borrowed(&SPACES[..depth])
+    } else {
+        Cow::Owned(" ".repeat(depth))
+    }
+}
 
 pub fn u8_to_str(arr: &[u8]) -> &str {
     std::str::from_utf8(arr).unwrap()


### PR DESCRIPTION
Currently we're allocating a new `String` for every single indent. This is silly -- indentation is essentially the same handful of values every time: 2 spaces, 4 spaces, 6 spaces, etc. What I've done in this PR is generate a large `&str` at compile time that's 128 spaces long (it falls back to allocating if you go over 128, but also if you're over 64 blocks deep in a single Ruby file then I would be getting worried) that we just read string slices from, which means we should ~never have to allocate anything for indentation.