### PR TITLE
Use iterators for `insert_at`

### DIFF
--- a/librubyfmt/src/comment_block.rs
+++ b/librubyfmt/src/comment_block.rs
@@ -23,16 +23,13 @@ impl CommentBlock {
         self.comments.push(line);
     }
 
-    pub fn into_line_tokens(self) -> Vec<ConcreteLineToken> {
-        self.comments
-            .into_iter()
-            .flat_map(|c| {
-                vec![
-                    ConcreteLineToken::Comment { contents: c },
-                    ConcreteLineToken::HardNewLine,
-                ]
-            })
-            .collect()
+    pub fn into_line_tokens(self) -> impl Iterator<Item = ConcreteLineToken> {
+        self.comments.into_iter().flat_map(|c| {
+            [
+                ConcreteLineToken::Comment { contents: c },
+                ConcreteLineToken::HardNewLine,
+            ]
+        })
     }
 
     pub fn apply_spaces(mut self, indent_depth: ColNumber) -> Self {

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -813,12 +813,15 @@ impl ParserState {
         if let Some(entry) = self.breakable_entry_stack.last_mut() {
             entry.insert_at(
                 insert_idx,
-                &mut vec![AbstractLineToken::ConcreteLineToken(
+                Box::new(std::iter::once(AbstractLineToken::ConcreteLineToken(
                     ConcreteLineToken::HardNewLine,
-                )],
+                ))),
             );
         } else {
-            self.insert_concrete_tokens(insert_idx, vec![ConcreteLineToken::HardNewLine]);
+            self.insert_concrete_tokens(
+                insert_idx,
+                std::iter::once(ConcreteLineToken::HardNewLine),
+            );
         }
     }
 
@@ -897,9 +900,8 @@ impl ParserState {
             }
             Some(comments) => {
                 let line_count = comments.line_count();
-                let lts = comments.into_line_tokens();
-                for comment in lts.into_iter() {
-                    self.push_concrete_token(comment);
+                for token in comments.into_line_tokens() {
+                    self.push_concrete_token(token);
                 }
                 self.current_orig_line_number = line_count as LineNumber;
             }
@@ -909,22 +911,17 @@ impl ParserState {
     pub(crate) fn insert_concrete_tokens(
         &mut self,
         insert_idx: usize,
-        clts: Vec<ConcreteLineToken>,
+        clts: impl IntoIterator<Item = ConcreteLineToken>,
     ) {
         match self.breakable_entry_stack.last_mut() {
             Some(be) => be.insert_at(
                 insert_idx,
-                &mut clts
-                    .into_iter()
-                    .map(AbstractLineToken::ConcreteLineToken)
-                    .collect(),
+                Box::new(clts.into_iter().map(AbstractLineToken::ConcreteLineToken)),
             ),
             None => self.render_queue.insert_at(
                 insert_idx,
-                &mut clts
-                    .into_iter()
-                    .map(ConcreteLineTokenAndTargets::ConcreteLineToken)
-                    .collect(),
+                clts.into_iter()
+                    .map(ConcreteLineTokenAndTargets::ConcreteLineToken),
             ),
         }
     }

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -4,8 +4,8 @@ use crate::parser_state::FormattingContext;
 use crate::ripper_tree_types::CallChainElement;
 use crate::types::LineNumber;
 
-fn insert_at<T>(idx: usize, target: &mut Vec<T>, input: &mut Vec<T>) {
-    target.splice(idx..idx, input.drain(..));
+fn insert_at<T>(idx: usize, target: &mut Vec<T>, input: impl IntoIterator<Item = T>) {
+    target.splice(idx..idx, input);
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -24,7 +24,11 @@ impl BaseQueue {
         self.tokens.push(lt)
     }
 
-    pub fn insert_at(&mut self, idx: usize, tokens: &mut Vec<ConcreteLineTokenAndTargets>) {
+    pub fn insert_at(
+        &mut self,
+        idx: usize,
+        tokens: impl IntoIterator<Item = ConcreteLineTokenAndTargets>,
+    ) {
         insert_at(idx, &mut self.tokens, tokens)
     }
 
@@ -45,7 +49,7 @@ impl BaseQueue {
 
 pub trait AbstractTokenTarget: std::fmt::Debug {
     fn push(&mut self, lt: AbstractLineToken);
-    fn insert_at(&mut self, idx: usize, tokens: &mut Vec<AbstractLineToken>);
+    fn insert_at(&mut self, idx: usize, tokens: Box<dyn Iterator<Item = AbstractLineToken> + '_>);
     fn into_tokens(self, ct: ConvertType) -> Vec<ConcreteLineTokenAndTargets>;
     fn is_multiline(&self) -> bool;
     fn push_line_number(&mut self, number: LineNumber);
@@ -104,7 +108,7 @@ impl AbstractTokenTarget for BreakableEntry {
         self.tokens.push(lt);
     }
 
-    fn insert_at(&mut self, idx: usize, tokens: &mut Vec<AbstractLineToken>) {
+    fn insert_at(&mut self, idx: usize, tokens: Box<dyn Iterator<Item = AbstractLineToken> + '_>) {
         insert_at(idx, &mut self.tokens, tokens)
     }
 
@@ -233,7 +237,7 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
         self.tokens.push(lt);
     }
 
-    fn insert_at(&mut self, idx: usize, tokens: &mut Vec<AbstractLineToken>) {
+    fn insert_at(&mut self, idx: usize, tokens: Box<dyn Iterator<Item = AbstractLineToken> + '_>) {
         insert_at(idx, &mut self.tokens, tokens)
     }
 


### PR DESCRIPTION
This was a [suggestion](https://github.com/fables-tales/rubyfmt/pull/732#issuecomment-3693345328) by @froydnj to take #732 one step further: instead of taking a Vec, almost all of the callers already have iterators, so instead of `collect`ing into Vecs and then moving them back into iterators with `drain`, we can just keep the iterators and pass them directly. This should keep us from allocating a few more intermediary Vecs.