### PR TITLE
 Avoid cloning and converting tokens when doing line length checks 

### DIFF
--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -1,7 +1,5 @@
 use crate::heredoc_string::{HeredocKind, HeredocString};
-use crate::render_targets::{
-    AbstractTokenTarget, BreakableCallChainEntry, BreakableEntry, ConvertType,
-};
+use crate::render_targets::{BreakableCallChainEntry, BreakableEntry};
 use crate::types::ColNumber;
 use std::borrow::Cow;
 
@@ -236,30 +234,6 @@ impl ConcreteLineTokenAndTargets {
             _ => false,
         }
     }
-
-    pub fn into_ruby(self) -> Cow<'static, str> {
-        match self {
-            Self::BreakableEntry(be) => {
-                Cow::Owned(be.into_tokens(ConvertType::SingleLine).into_iter().fold(
-                    String::new(),
-                    |mut accum, tok| {
-                        accum.push_str(&tok.into_ruby());
-                        accum
-                    },
-                ))
-            }
-            Self::BreakableCallChainEntry(bcce) => {
-                Cow::Owned(bcce.into_tokens(ConvertType::SingleLine).into_iter().fold(
-                    String::new(),
-                    |mut accum, tok| {
-                        accum.push_str(&tok.into_ruby());
-                        accum
-                    },
-                ))
-            }
-            Self::ConcreteLineToken(clt) => clt.into_ruby(),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -369,6 +343,35 @@ impl AbstractLineToken {
             Self::SoftNewline(_) => true,
             Self::CollapsingNewLine(_) => true,
             _ => false,
+        }
+    }
+
+    /// Returns the length of this token when rendered as single-line,
+    /// without cloning or allocating intermediate structures. This assumes
+    /// that its caller is purely checking if the line is over MAX_LINE_LENGTH,
+    /// so heredocs are not actually calculated and instead just return `MAX_LINE_LENGTH` + 1
+    pub fn single_line_len(&self) -> usize {
+        use crate::render_queue_writer::MAX_LINE_LENGTH;
+
+        match self {
+            Self::CollapsingNewLine(heredoc_strings) => {
+                if heredoc_strings.is_some() {
+                    MAX_LINE_LENGTH + 1
+                } else {
+                    0
+                }
+            }
+            Self::SoftNewline(heredoc_strings) => {
+                if heredoc_strings.is_some() {
+                    MAX_LINE_LENGTH + 1
+                } else {
+                    1
+                }
+            }
+            Self::SoftIndent { .. } => 0,
+            Self::ConcreteLineToken(clt) => clt.len(),
+            Self::BreakableEntry(be) => be.single_line_len(),
+            Self::BreakableCallChainEntry(bcce) => bcce.single_line_len(),
         }
     }
 }

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -283,14 +283,14 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
                 // Pop off all tokens that make up the block (but not the block params!),
                 // since we assume that the block contents will handle their own line
                 // length appropriately.
-                while let Some(token) = tokens.last() {
+                while let Some((token, rest)) = tokens.split_last() {
                     if matches!(
                         token,
                         AbstractLineToken::BreakableEntry(BreakableEntry { delims, .. }) if *delims == BreakableDelims::for_block_params()
                     ) {
                         break;
                     }
-                    tokens = &tokens[..(tokens.len() - 1)];
+                    tokens = rest;
                 }
             } else if let AbstractLineToken::BreakableEntry(be) = token
                 && be.delims == BreakableDelims::for_brace_block()
@@ -299,16 +299,18 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
             }
         }
 
-        if let Some(AbstractLineToken::BreakableEntry(_)) = tokens.first() {
+        if let Some((AbstractLineToken::BreakableEntry(_), rest)) = tokens.split_first() {
             if let Some(idx) = brace_block_params_only_index {
                 brace_block_params_only_index = Some(idx - 1);
             }
-            tokens = &tokens[1..];
+            tokens = rest;
         }
-        if let Some(AbstractLineToken::ConcreteLineToken(ConcreteLineToken::EndCallChainIndent)) =
-            tokens.last()
+        if let Some((
+            AbstractLineToken::ConcreteLineToken(ConcreteLineToken::EndCallChainIndent),
+            rest,
+        )) = tokens.split_last()
         {
-            tokens = &tokens[..(tokens.len() - 1)];
+            tokens = rest;
         }
         let call_count = tokens
             .iter()
@@ -326,7 +328,7 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
         //
         // However, if there's only one item in the chain, try our best to leave that in place.
         // `foo\n.bar` is always a little awkward.
-        if let Some(AbstractLineToken::BreakableEntry(be)) = tokens.last()
+        if let Some((AbstractLineToken::BreakableEntry(be), rest)) = tokens.split_last()
             && (call_count == 1 || be.is_multiline())
             && be.delims != BreakableDelims::for_brace_block()
             && be.delims != BreakableDelims::for_block_params()
@@ -336,7 +338,7 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
             {
                 brace_block_params_only_index = None;
             }
-            tokens = &tokens[..(tokens.len() - 1)];
+            tokens = rest;
         }
 
         tokens

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -134,13 +134,7 @@ impl AbstractTokenTarget for BreakableEntry {
     }
 
     fn single_line_string_length(&self, current_line_length: usize) -> usize {
-        self.tokens
-            .iter()
-            .flat_map(|tok| tok.clone().into_single_line())
-            .map(|tok| tok.into_ruby().len())
-            .sum::<usize>()
-            + self.delims.single_line_len()
-            + current_line_length
+        self.single_line_len() + current_line_length
     }
 
     fn push_line_number(&mut self, number: LineNumber) {
@@ -194,6 +188,14 @@ impl BreakableEntry {
                 AbstractLineToken::ConcreteLineToken(ConcreteLineToken::HardNewLine)
             )
         })
+    }
+
+    pub fn single_line_len(&self) -> usize {
+        self.tokens
+            .iter()
+            .map(|tok| tok.single_line_len())
+            .sum::<usize>()
+            + self.delims.single_line_len()
     }
 }
 
@@ -343,9 +345,8 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
 
         tokens
             .into_iter()
-            .flat_map(|t| t.into_single_line())
-            .map(|t| t.into_ruby().len())
-            .sum()
+            .map(|t| t.single_line_len())
+            .sum::<usize>()
     }
 
     fn push_line_number(&mut self, _number: LineNumber) {
@@ -464,6 +465,10 @@ impl BreakableCallChainEntry {
                 ConcreteLineToken::HeredocStart { .. }
             ))
         )
+    }
+
+    pub fn single_line_len(&self) -> usize {
+        self.tokens.iter().map(|tok| tok.single_line_len()).sum()
     }
 }
 

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -197,6 +197,17 @@ impl BreakableEntry {
             .sum::<usize>()
             + self.delims.single_line_len()
     }
+
+    /// Returns the single-line length of just the block params (if any),
+    /// excluding the body. Used by call chain line length calculation.
+    pub fn single_line_len_params_only(&self) -> usize {
+        if let Some(AbstractLineToken::BreakableEntry(params)) = self.tokens.first() {
+            if params.delims == BreakableDelims::for_block_params() {
+                return params.single_line_len() + self.delims.single_line_len();
+            }
+        }
+        0
+    }
 }
 
 /// This struct is a bit of a hack to support both
@@ -259,10 +270,12 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
         // have multiline blocks (which will often be quite long vertically, even if
         // they're under 120 characters horizontally). In this case, look for the longest
         // individual line and get _that_ max length.
-        let mut tokens = self.tokens.clone();
+        let mut tokens = self.tokens.as_slice();
+        let mut brace_block_params_only_index = None;
+
         if tokens.len() > 2 {
             let index = tokens.len() - 2;
-            let token = tokens.get_mut(index).unwrap();
+            let token = &tokens[index];
             if matches!(
                 token,
                 AbstractLineToken::ConcreteLineToken(ConcreteLineToken::End)
@@ -277,37 +290,25 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
                     ) {
                         break;
                     }
-                    tokens.pop();
+                    tokens = &tokens[..(tokens.len() - 1)];
                 }
-            } else if let AbstractLineToken::BreakableEntry(BreakableEntry {
-                delims, tokens, ..
-            }) = token
-                && *delims == BreakableDelims::for_brace_block()
+            } else if let AbstractLineToken::BreakableEntry(be) = token
+                && be.delims == BreakableDelims::for_brace_block()
             {
-                if let Some(AbstractLineToken::BreakableEntry(BreakableEntry { delims, .. })) =
-                    tokens.first()
-                {
-                    if *delims == BreakableDelims::for_block_params() {
-                        // Wipe away the body of the block and leave only the params
-                        *tokens = vec![tokens.first().unwrap().clone()];
-                    } else {
-                        // No params, so wipe away the whole thing
-                        *tokens = Vec::new();
-                    }
-                } else {
-                    // No params, so wipe away the whole thing
-                    *tokens = Vec::new();
-                }
+                brace_block_params_only_index = Some(index);
             }
         }
 
         if let Some(AbstractLineToken::BreakableEntry(_)) = tokens.first() {
-            tokens.remove(0);
+            if let Some(idx) = brace_block_params_only_index {
+                brace_block_params_only_index = Some(idx - 1);
+            }
+            tokens = &tokens[1..];
         }
         if let Some(AbstractLineToken::ConcreteLineToken(ConcreteLineToken::EndCallChainIndent)) =
             tokens.last()
         {
-            tokens.pop();
+            tokens = &tokens[..(tokens.len() - 1)];
         }
         let call_count = tokens
             .iter()
@@ -330,23 +331,28 @@ impl AbstractTokenTarget for BreakableCallChainEntry {
             && be.delims != BreakableDelims::for_brace_block()
             && be.delims != BreakableDelims::for_block_params()
         {
-            tokens.pop();
+            if let Some(params_index) = brace_block_params_only_index
+                && params_index == tokens.len() - 1
+            {
+                brace_block_params_only_index = None;
+            }
+            tokens = &tokens[..(tokens.len() - 1)];
         }
-        tokens.insert(
-            0,
-            AbstractLineToken::ConcreteLineToken(
-                // Push the starting indentation for the first line -- other
-                // lines will already have the appropriate indentation
-                ConcreteLineToken::Indent {
-                    depth: current_line_length as u32,
-                },
-            ),
-        );
 
         tokens
-            .into_iter()
-            .map(|t| t.single_line_len())
+            .iter()
+            .enumerate()
+            .map(|(i, t)| {
+                if let Some(params_only_idx) = brace_block_params_only_index
+                    && params_only_idx == i
+                    && let AbstractLineToken::BreakableEntry(be) = t
+                {
+                    return be.single_line_len_params_only();
+                }
+                t.single_line_len()
+            })
             .sum::<usize>()
+            + current_line_length
     }
 
     fn push_line_number(&mut self, _number: LineNumber) {

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -201,10 +201,10 @@ impl BreakableEntry {
     /// Returns the single-line length of just the block params (if any),
     /// excluding the body. Used by call chain line length calculation.
     pub fn single_line_len_params_only(&self) -> usize {
-        if let Some(AbstractLineToken::BreakableEntry(params)) = self.tokens.first() {
-            if params.delims == BreakableDelims::for_block_params() {
-                return params.single_line_len() + self.delims.single_line_len();
-            }
+        if let Some(AbstractLineToken::BreakableEntry(params)) = self.tokens.first()
+            && params.delims == BreakableDelims::for_block_params()
+        {
+            return params.single_line_len() + self.delims.single_line_len();
         }
         0
     }


### PR DESCRIPTION
For breakables, we currently check if it will go over the 120 character line limit by rendering the tokens into a string and then looking at the length of the string. We don't actually need to do this -- we know how long the tokens will be based on their contents, so we could just look at that and have tokens report their (future) length, allowing us to avoid cloning the whole token array, doing string conversions, and so on.

The most notable refactor is in how call chain breakables work. There's a lot of token munging happening in there, the main one requiring mutation being the way we handle brace blocks. For the last brace block in a chain, we ignore the contents of the block and only look at the params. Since we want to avoid mutations, we instead have the token do that ignoring in a helper method.