### PR TITLE
drain directly into `heredoc_strings` vector

### DIFF
--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -103,9 +103,8 @@ impl ParserState {
     {
         let mut next_ps = ParserState::render_with_blank_state(self, formatting_func);
 
-        for hs in next_ps.heredoc_strings.drain(0..) {
-            self.heredoc_strings.push(hs);
-        }
+        self.heredoc_strings
+            .extend(next_ps.heredoc_strings.drain(0..));
 
         // Update line number and clear out any comments we might have rendered in e.g. an embexpr
         //


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
This is a tiny bit faster, because the compiler can see that the element movements are happening all at once, rather than piece-by-piece.