### PR TITLE
Upgrade jemalloc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,12 +416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fs_extra"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
-
-[[package]]
 name = "getrandom"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,27 +500,6 @@ name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -852,7 +825,6 @@ version = "0.11.0-pre"
 dependencies = [
  "cc",
  "fancy-regex",
- "jemallocator",
  "libc",
  "log",
  "regex",
@@ -860,6 +832,7 @@ dependencies = [
  "ruby-prism",
  "serde",
  "simplelog",
+ "tikv-jemallocator",
  "winapi",
 ]
 
@@ -1028,6 +1001,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -17,7 +17,7 @@ simplelog = "0.12"
 ruby-prism="1.7.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { version = "0.3.0", features = ["disable_initial_exec_tls"], optional=true }
+tikv-jemallocator = { version = "0.6.1", features = ["disable_initial_exec_tls"], optional=true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["everything"] }
@@ -32,4 +32,4 @@ crate-type = ["staticlib", "rlib"]
 
 [features]
 default = ["use_jemalloc"]
-use_jemalloc = ["jemallocator"]
+use_jemalloc = ["tikv-jemallocator"]

--- a/librubyfmt/src/lib.rs
+++ b/librubyfmt/src/lib.rs
@@ -8,7 +8,7 @@ use std::str;
 
 #[cfg(all(feature = "use_jemalloc", not(target_env = "msvc")))]
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 pub type RawStatus = i64;
 


### PR DESCRIPTION
On the tin.

The `jemalloc` crate itself has not been maintained for many years and was later forked by the TiKV folks, so this switches over to that. The [changelog](https://github.com/tikv/jemallocator/blob/main/CHANGELOG.md) doesn't seem to have many major changes other than keeping up with some newer jemalloc versions and removing a deprecated `fs_extra` dep.

(Long term, I'm curious if we still want/need to use a custom allocator for such short-lived processes, but I'll leave that for a separate discussion/benchmarking/etc.)