### PR TITLE
avoid inserting tokens at the beginning of the flattened tokens vector

### DIFF
--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -99,22 +99,16 @@ impl<'src> AbstractTokenTarget<'src> for BreakableEntry<'src> {
     fn into_tokens(self, ct: ConvertType) -> Vec<ConcreteLineTokenAndTargets<'src>> {
         match ct {
             ConvertType::MultiLine => {
-                let mut new_tokens: Vec<_> = self
-                    .tokens
-                    .into_iter()
-                    .flat_map(|t| t.into_multi_line())
-                    .collect();
-                new_tokens.insert(0, self.delims.multi_line_open().into());
+                let mut new_tokens: Vec<_> = Vec::with_capacity(self.tokens.len() + 2);
+                new_tokens.push(self.delims.multi_line_open().into());
+                new_tokens.extend(self.tokens.into_iter().flat_map(|t| t.into_multi_line()));
                 new_tokens.push(self.delims.multi_line_close().into());
                 new_tokens
             }
             ConvertType::SingleLine => {
-                let mut new_tokens: Vec<_> = self
-                    .tokens
-                    .into_iter()
-                    .flat_map(|t| t.into_single_line())
-                    .collect();
-                new_tokens.insert(0, self.delims.single_line_open().into());
+                let mut new_tokens: Vec<_> = Vec::with_capacity(self.tokens.len() + 2);
+                new_tokens.push(self.delims.single_line_open().into());
+                new_tokens.extend(self.tokens.into_iter().flat_map(|t| t.into_single_line()));
                 new_tokens.push(self.delims.single_line_close().into());
                 new_tokens
             }


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
`insert`'ing into vectors is generally bad; we can avoid calling `insert` here with a slightly more verbose way of constructing the vector.  This way appears to be slightly faster on the benchmark suite.