### PR TITLE
[prism] Don't emit soft tokens in `next` arguments

### DIFF
--- a/fixtures/small/next_with_args_inline_if_actual.rb
+++ b/fixtures/small/next_with_args_inline_if_actual.rb
@@ -1,0 +1,3 @@
+items.map do |config|
+  next config if config.is_a?(UrlConfig)
+end

--- a/fixtures/small/next_with_args_inline_if_expected.rb
+++ b/fixtures/small/next_with_args_inline_if_expected.rb
@@ -1,0 +1,3 @@
+items.map do |config|
+  next config if config.is_a?(UrlConfig)
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4297,7 +4297,14 @@ fn format_next_node<'src>(ps: &mut ParserState<'src>, next_node: prism::NextNode
     if let Some(arguments_node) = next_node.arguments() {
         ps.with_start_of_line(false, |ps| {
             ps.emit_space();
-            format_arguments_node(ps, arguments_node);
+            ps.with_start_of_line(false, |ps| {
+                format_list_like_thing(
+                    ps,
+                    arguments_node.arguments(),
+                    arguments_node.location().end_offset(),
+                    true,
+                );
+            });
         });
     }
 }


### PR DESCRIPTION
I ran into this while poking around running the prism implementation against some large open-source ruby repos.

This prevents a panic when formatting a `next` node inside of a conditional modifier. We were using `format_list_like_thing` with `single_line: false` (the last arg), which uses soft indents and collapsing newlines. These will fail in the render queue if they're not rendered inside a breakable, and while this just so happened to work before (since `next` is always in a call chain or block breakable), when rendered with `will_render_as_multiline` in mod conditionals, the breakable stack is temporarily stashed so there's no wrapping breakable, causing a panic.

The fix here is to use _exactly_ what the Ripper implementation does, which is to always emit a space and a `single_line: true` list.