### PR TITLE
[prism] simplify peeking logic when formatting block bodies

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2608,8 +2608,8 @@ fn format_block_node<'src>(ps: &mut ParserState<'src>, block_node: prism::BlockN
                     ps.with_start_of_line(false, |ps| {
                         let statements = body.as_statements_node().unwrap().body();
                         let mut peekable = statements.iter().peekable();
-                        while peekable.peek().is_some() {
-                            format_node(ps, peekable.next().unwrap());
+                        while let Some(node) = peekable.next() {
+                            format_node(ps, node);
                             ps.emit_soft_newline();
                             if peekable.peek().is_some() {
                                 ps.emit_soft_indent();


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
We can just look at the next node in the sequence at the head of loop, there's no need for peeking here.