### PR TITLE
[prism] correctly pass the end of `when` conditions

### DIFF
--- a/fixtures/small/comment_when_actual.rb
+++ b/fixtures/small/comment_when_actual.rb
@@ -1,0 +1,10 @@
+case value
+when
+    Some::Extremely::Long::Name::For::The::Constant::BeingChecked,
+    Some::Extremely::Long::Other::Name::For::An::Alternative::One,
+    Something::Completely::Different
+  # You don't expect me to explain this, do you?
+  bees
+else
+  more_bees
+end

--- a/fixtures/small/comment_when_expected.rb
+++ b/fixtures/small/comment_when_expected.rb
@@ -1,0 +1,10 @@
+case value
+when
+    Some::Extremely::Long::Name::For::The::Constant::BeingChecked,
+    Some::Extremely::Long::Other::Name::For::An::Alternative::One,
+    Something::Completely::Different
+  # You don't expect me to explain this, do you?
+  bees
+else
+  more_bees
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4669,7 +4669,13 @@ fn format_when_node<'src>(ps: &mut ParserState<'src>, when_node: prism::WhenNode
                 format_list_like_thing(
                     ps,
                     when_node.conditions(),
-                    when_node.location().end_offset(),
+                    when_node
+                        .conditions()
+                        .iter()
+                        .last()
+                        .unwrap()
+                        .location()
+                        .end_offset(),
                     false,
                 );
             });


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Fixes #754.  The end of the `when` node is the end of all the statements associated with the node, but for formatting the conditions, we want the end of the conditions themselves, not the node.