### PR TITLE
[prism] Fix splitting logic for aref grouping

### DIFF
--- a/fixtures/small/aref_in_call_chain_actual.rb
+++ b/fixtures/small/aref_in_call_chain_actual.rb
@@ -1,0 +1,29 @@
+assert_equal(
+  1,
+  T.cast(T.must(pages[1]&.elements)[0], Name::Spacing::To::Extend::CodeQuality::AcrossManyLines).table[
+    :line_items
+  ]
+    .length
+)
+
+foo.bar[some_really_long_index][another_really_long_index]
+  .baz
+  .qux
+
+result.data[
+  :first_key,
+  :second_key
+]
+  .transform
+  .process
+
+outer_method(
+  inner.call[0]
+    .chain
+    .another
+)
+
+matrix[row][col]
+  .value
+  .to_s
+  .upcase

--- a/fixtures/small/aref_in_call_chain_expected.rb
+++ b/fixtures/small/aref_in_call_chain_expected.rb
@@ -1,0 +1,29 @@
+assert_equal(
+  1,
+  T.cast(T.must(pages[1]&.elements)[0], Name::Spacing::To::Extend::CodeQuality::AcrossManyLines).table[
+    :line_items
+  ]
+    .length
+)
+
+foo.bar[some_really_long_index][another_really_long_index]
+  .baz
+  .qux
+
+result.data[
+  :first_key,
+  :second_key
+]
+  .transform
+  .process
+
+outer_method(
+  inner.call[0]
+    .chain
+    .another
+)
+
+matrix[row][col]
+  .value
+  .to_s
+  .upcase

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3037,7 +3037,18 @@ fn split_node_into_call_chains<'src>(node: prism::Node<'src>) -> Vec<Vec<prism::
             let is_aref: bool = !node_is_dot_call;
 
             if is_aref && seen_dot_call && has_dot_after[i] {
-                split_before.push(i);
+                let mut split_idx = i;
+                while split_idx < elements.len() {
+                    if let Some(call_node) = elements[split_idx].as_call_node()
+                        && call_node.call_operator_loc().is_none()
+                    {
+                        // Still an aref, advance past it
+                        split_idx += 1;
+                        continue;
+                    }
+                    break;
+                }
+                split_before.push(split_idx);
                 seen_dot_call = false;
                 continue;
             }


### PR DESCRIPTION
Closes #713 

I kinda goofed the logic on grouping arefs as part of a segment when I first wrote this. We shouldn't split before an aref -- we should instead split _after_ that aref, and we also would want to split after _all_ the arefs in that group. This was causing all the "trailing aref" logic to not work quite as expected so arefs were still getting rendered inside a breakable (hence the extra indentation).

It was unclear to me if we preferred the indentation of the Prism or Ripper implementations, but IMO we should shoot for the same output first and then we can adjust the formatting later if we want -- I'd rather that be an intentional choice and not an accident. (Even then, I think this is more correct and would make an intentional choice to further indent it ~trivial.)