### PR TITLE
[prism] Don't panic on invalid UTF-8 strings in heredocs

### DIFF
--- a/fixtures/small/prism/heredoc_invalid_utf8_escape_actual.rb
+++ b/fixtures/small/prism/heredoc_invalid_utf8_escape_actual.rb
@@ -1,0 +1,4 @@
+<<~EOF
+  line with \xFF escape
+ foo
+EOF

--- a/fixtures/small/prism/heredoc_invalid_utf8_escape_expected.rb
+++ b/fixtures/small/prism/heredoc_invalid_utf8_escape_expected.rb
@@ -1,0 +1,4 @@
+<<~EOF
+   line with \xFF escape
+  foo
+EOF

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -8,7 +8,7 @@ use crate::{
     parser_state::{FormattingContext, HashType, ParserState},
     render_targets::MultilineHandling,
     types::SourceOffset,
-    util::{const_to_str, loc_to_str, loc_to_string, u8_to_str},
+    util::{const_to_str, loc_to_str, loc_to_string},
 };
 
 pub fn format_node<'src>(ps: &mut ParserState<'src>, node: prism::Node<'src>) {
@@ -909,12 +909,14 @@ fn format_inner_string<'src>(
             .iter()
             .filter_map(|part| {
                 if let Some(node) = part.as_string_node() {
-                    let raw = loc_to_str(node.content_loc());
-                    let unescaped = u8_to_str(node.unescaped());
+                    let raw = node.content_loc().as_slice();
+                    let unescaped = node.unescaped();
 
-                    // Count leading whitespace in each
-                    let raw_leading = raw.len() - raw.trim_start().len();
-                    let unescaped_leading = unescaped.len() - unescaped.trim_start().len();
+                    let raw_leading = raw.iter().take_while(|&&b| b == b' ' || b == b'\t').count();
+                    let unescaped_leading = unescaped
+                        .iter()
+                        .take_while(|&&b| b == b' ' || b == b'\t')
+                        .count();
 
                     // The difference is the common indent (if raw has more leading whitespace)
                     if raw_leading > unescaped_leading {


### PR DESCRIPTION
The way we determine the "common indent" for a heredoc (that is, for squiggly heredocs, the farthest-left line that determines the indentation level) is to look for lines where the `unescaped` and the content_loc have different leading whitespaces. We previously did this by converting them to strings and looking at their length, but this panics on invalid UTF-8 because all the `*_to_str` functions assume they are given valid UTF-8 strings.

Instead, this PR just counts the whitespace chars directly at the beginning of each slice, which should achieve the same thing without panicking on invalid UTF-8.