### PR TITLE
[ripper] align singleton class formatting with prism

### DIFF
--- a/fixtures/small/sclass_actual.rb
+++ b/fixtures/small/sclass_actual.rb
@@ -9,6 +9,14 @@ end
 
 class Bar
   class << self
+    # This is a comment.
+    # This is another comment
+  end
+
+  class << self
+    # This is another comment.  You like it.
+    def additional
+    end
   end
 
   def another_method!; end

--- a/fixtures/small/sclass_expected.rb
+++ b/fixtures/small/sclass_expected.rb
@@ -9,6 +9,14 @@ end
 
 class Bar
   class << self
+    # This is a comment.
+    # This is another comment
+  end
+
+  class << self
+    # This is another comment.  You like it.
+    def additional
+    end
   end
 
   def another_method!

--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -3030,7 +3030,10 @@ pub fn format_sclass(ps: &mut ParserState, sc: SClass) {
         ps.emit_newline();
         ps.new_block(|ps| {
             ps.with_start_of_line(true, |ps| {
-                format_bodystmt(ps, body, end_line);
+                ps.with_formatting_context(FormattingContext::ClassOrModule, |ps| {
+                    ps.emit_collapsing_newline();
+                    format_bodystmt(ps, body, end_line);
+                });
             });
         });
     });


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Fixes #664.
Fixes #412.

There are enough of these cases in Stripe's codebase that I'd like to just make the formatting identical between Ripper and Prism to reduce the noise on diffs.

I freely admit to cargo-culting here: I tried to make the Ripper code identical to the Prism code, and adding the collapsing newline seems to make things work OK.  It is not obvious to me _why_, exactly, but it does seem to work.