### PR TITLE
[prism] Match Ripper's multilining logic for call chains beginning with literal expressions

### DIFF
--- a/fixtures/small/array_call_chain_with_block_comment_actual.rb
+++ b/fixtures/small/array_call_chain_with_block_comment_actual.rb
@@ -1,0 +1,10 @@
+[
+  CommonFields::OBVIOUSLY,
+  CommonFields::THESE,
+  CommonFields::ARE,
+  CommonFields::FAKE_RESOURCE.with_wombo(true).with_combo(true).with_explosion(true)
+]
+  .map do |field|
+  # Swap things out, to make sure.
+  override || field
+end

--- a/fixtures/small/array_call_chain_with_block_comment_expected.rb
+++ b/fixtures/small/array_call_chain_with_block_comment_expected.rb
@@ -1,0 +1,10 @@
+[
+  CommonFields::OBVIOUSLY,
+  CommonFields::THESE,
+  CommonFields::ARE,
+  CommonFields::FAKE_RESOURCE.with_wombo(true).with_combo(true).with_explosion(true)
+]
+  .map do |field|
+    # Swap things out, to make sure.
+    override || field
+  end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2340,7 +2340,7 @@ fn call_chain_elements_are_user_multilined<'src>(
         // placement, the user probably intended to break this onto multiple lines anyways.
         let has_comment = ps.has_comment_in_offset_span(
             call_chain_elements[0].location().end_offset(),
-            start_loc_for_call_node_in_chain(&call_chain_elements[1].as_call_node().unwrap()),
+            call_chain_elements.last().unwrap().location().end_offset(),
         );
         if is_literal_expression && !has_comment {
             call_chain_elements = &call_chain_elements[1..];


### PR DESCRIPTION
Closes #764 

For call chains, we do some ~finicky logic for cases where the first item in a call chain is an expression like an array/hash literal. This is to accommodate some common use cases where something like calling `.freeze` or `.map(&:foo)` after a big multiline expression. However, if there's comments in the middle of all this, we'll still need to fully multiline it, but the Ripper implementation multilines [if there's comments _anywhere_ in call chain's tokens](https://github.com/fables-tales/rubyfmt/blob/trunk/librubyfmt/src/render_targets.rs#L365-L370), whereas the Prism one only was looking if they're [between the end of the first expression and the first dot operator](https://github.com/fables-tales/rubyfmt/blob/02fb1545310998c22a27b28833c3d3b90dbf97eb/librubyfmt/src/format_prism.rs#L2341-L2344).

(For the record, I think the Prism logic is probably more correct, but I'm fine with shooting for as much consistency with Ripper as possible for now, and we can explicitly choose this later.)