### PR TITLE
[prism] Don't prematurely wind comments in attr_writes

### DIFF
--- a/fixtures/small/attr_write_array_comments_actual.rb
+++ b/fixtures/small/attr_write_array_comments_actual.rb
@@ -1,0 +1,17 @@
+a.items = [
+  # First item comment
+  1,
+  # Second item comment
+  2
+]
+
+x.list = [
+  "value"
+  # trailing
+]
+
+foo.bar.values = [
+  # inside array
+  :a,
+  :b
+]

--- a/fixtures/small/attr_write_array_comments_expected.rb
+++ b/fixtures/small/attr_write_array_comments_expected.rb
@@ -1,0 +1,17 @@
+a.items = [
+  # First item comment
+  1,
+  # Second item comment
+  2
+]
+
+x.list = [
+  "value"
+  # trailing
+]
+
+foo.bar.values = [
+  # inside array
+  :a,
+  :b
+]

--- a/fixtures/small/attr_write_hash_comments_actual.rb
+++ b/fixtures/small/attr_write_hash_comments_actual.rb
@@ -1,0 +1,32 @@
+a.bees = {
+  # Stuff
+  honey: "hive"
+}
+
+x.config = {
+  # First setting
+  debug: true,
+  # Second setting
+  verbose: false
+}
+
+y.options = {
+  enabled: true
+  # trailing comment
+}
+
+obj.data = {
+  # Comment line 1
+  # Comment line 2
+  key: "value"
+}
+
+foo.bar.baz = {
+  # inside hash
+  item: 123
+}
+
+maybe&.setting = {
+  # safe navigation comment
+  value: nil
+}

--- a/fixtures/small/attr_write_hash_comments_expected.rb
+++ b/fixtures/small/attr_write_hash_comments_expected.rb
@@ -1,0 +1,32 @@
+a.bees = {
+  # Stuff
+  honey: "hive"
+}
+
+x.config = {
+  # First setting
+  debug: true,
+  # Second setting
+  verbose: false
+}
+
+y.options = {
+  enabled: true
+  # trailing comment
+}
+
+obj.data = {
+  # Comment line 1
+  # Comment line 2
+  key: "value"
+}
+
+foo.bar.baz = {
+  # inside hash
+  item: 123
+}
+
+maybe&.setting = {
+  # safe navigation comment
+  value: nil
+}

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1716,7 +1716,17 @@ fn format_call_node<'src>(
     skip_attr_write_value: bool,
 ) {
     let method_name = const_to_str(call_node.name());
-    let end_offset = call_node.location().end_offset();
+    // When we skip the attr_write value (because it will be formatted separately),
+    // we should only wind to the end of the method name, not the full call.
+    // Otherwise we'd extract comments from inside the value prematurely.
+    let end_offset = if skip_attr_write_value {
+        call_node
+            .message_loc()
+            .expect("Attribute writes must have a message")
+            .end_offset()
+    } else {
+        call_node.location().end_offset()
+    };
     let is_dot_call = method_name == "call" && call_node.message_loc().is_none(); // e.g. `a.()`
 
     // Only treat [] and []= as aref syntax when there's no explicit call operator.


### PR DESCRIPTION
Closes #761 

For attr_writes, we now separately handle the left and write sides of the write, but we were still winding comments to the end of the whole write (i.e. to the end of the RHS), causing comments to get misplaced. This now only winds comments through the end of the LHS first, then letting the RHS value do its own winding when it gets rendered, which should fix the comment placement.