### PR TITLE
fix fixing heredoc duplicate indents

### DIFF
--- a/fixtures/small/heredoc_trailing_stuff_actual.rb
+++ b/fixtures/small/heredoc_trailing_stuff_actual.rb
@@ -1,0 +1,49 @@
+module Adapter
+  class Test
+    describe "start does" do
+      it "well" do
+        Dir.mktmpdir do |root|
+
+          example_files.each { |file|
+            something_to_fill_the_block = do_work(file)
+
+            # Need a comment in here to botch things up.
+            more_work = do_work
+
+            error_message = <<~EOS
+              X with #{more_computation}.
+              This is outdated.
+
+              Another line
+
+              #{insert_computed_thing}
+            EOS
+            call_the_thing(with_an_arg, error_message)
+          }
+        end
+      end
+
+      it "well" do
+        Dir.mktmpdir do |root|
+
+          example_files.each { |file|
+            something_to_fill_the_block = do_work(file)
+
+            # Need a comment in here to botch things up.
+            more_work = do_work
+
+            error_message = <<~EOS
+              X with #{more_computation}.
+              This is outdated.
+
+              Another line
+
+              #{insert_computed_thing}
+            EOS
+            more_work
+          }
+        end
+      end
+    end
+  end
+end

--- a/fixtures/small/heredoc_trailing_stuff_expected.rb
+++ b/fixtures/small/heredoc_trailing_stuff_expected.rb
@@ -1,0 +1,49 @@
+module Adapter
+  class Test
+    describe "start does" do
+      it "well" do
+        Dir.mktmpdir do |root|
+
+          example_files.each { |file|
+            something_to_fill_the_block = do_work(file)
+
+            # Need a comment in here to botch things up.
+            more_work = do_work
+
+            error_message = <<~EOS
+              X with #{more_computation}.
+              This is outdated.
+
+              Another line
+
+              #{insert_computed_thing}
+            EOS
+            call_the_thing(with_an_arg, error_message)
+          }
+        end
+      end
+
+      it "well" do
+        Dir.mktmpdir do |root|
+
+          example_files.each { |file|
+            something_to_fill_the_block = do_work(file)
+
+            # Need a comment in here to botch things up.
+            more_work = do_work
+
+            error_message = <<~EOS
+              X with #{more_computation}.
+              This is outdated.
+
+              Another line
+
+              #{insert_computed_thing}
+            EOS
+            more_work
+          }
+        end
+      end
+    end
+  end
+end

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -199,7 +199,8 @@ impl<'src> RenderQueueWriter<'src> {
                     ConcreteLineToken::Indent { .. },
                     ConcreteLineToken::Delim { .. }
                     | ConcreteLineToken::Dot
-                    | ConcreteLineToken::DirectPart { .. },
+                    | ConcreteLineToken::DirectPart { .. }
+                    | ConcreteLineToken::MethodName { .. },
                 ],
             ) = accum.last::<5>()
             {


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Fixes #768 .  We just needed to check for `MethodName` in addition to `DirectPart` -- `DirectPart` can still arise from variable names and the like.