### PR TITLE
Make LTStringContent tokens use `Cow<'_, str>`

### DIFF
--- a/librubyfmt/src/format.rs
+++ b/librubyfmt/src/format.rs
@@ -1419,7 +1419,7 @@ fn format_inner_string(ps: &mut ParserState, parts: Vec<StringContentPart>, tipe
             },
             StringContentPart::StringEmbexpr(e) => {
                 ps.with_formatting_context(FormattingContext::StringEmbexpr, |ps| {
-                    ps.emit_string_content("#{".to_string());
+                    ps.emit_string_content("#{");
                     // Embexpr must have at least one expression.
                     // If they have multiple, render them with an expression per line
                     // just like they are outside of embexprs.
@@ -1437,7 +1437,7 @@ fn format_inner_string(ps: &mut ParserState, parts: Vec<StringContentPart>, tipe
                             });
                         });
                     }
-                    ps.emit_string_content("}".to_string());
+                    ps.emit_string_content("}");
 
                     let on_line_skip = tipe == StringType::Heredoc
                         && match peekable.peek() {
@@ -1452,12 +1452,12 @@ fn format_inner_string(ps: &mut ParserState, parts: Vec<StringContentPart>, tipe
                 })
             }
             StringContentPart::StringDVar(dv) => {
-                ps.emit_string_content("#{".to_string());
+                ps.emit_string_content("#{");
                 ps.with_start_of_line(false, |ps| {
                     let expr = *(dv.1);
                     format_expression(ps, expr);
                 });
-                ps.emit_string_content("}".to_string());
+                ps.emit_string_content("}");
             }
         }
     }

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -771,7 +771,7 @@ fn format_interpolated_string_node<'src>(
         if needs_escape {
             ps.emit_double_quote();
         } else {
-            ps.emit_string_content(s.to_string());
+            ps.emit_string_content(*s);
         }
     }
 
@@ -809,7 +809,7 @@ fn format_interpolated_string_node<'src>(
                     if needs_escape {
                         ps.emit_double_quote();
                     } else {
-                        ps.emit_string_content(s.to_string());
+                        ps.emit_string_content(*s);
                     }
                 }
                 ps.emit_space();
@@ -827,7 +827,7 @@ fn format_interpolated_string_node<'src>(
         if needs_escape {
             ps.emit_double_quote();
         } else {
-            ps.emit_string_content(closer.to_string());
+            ps.emit_string_content(*closer);
         }
     }
 }
@@ -1098,7 +1098,7 @@ fn format_embedded_statements_node<'src>(
     ps: &mut ParserState<'src>,
     embedded_statements_node: prism::EmbeddedStatementsNode<'src>,
 ) {
-    ps.emit_string_content("#{".to_string());
+    ps.emit_string_content("#{");
     if let Some(statements) = embedded_statements_node.statements() {
         ps.with_formatting_context(FormattingContext::StringEmbexpr, |ps| {
             let has_multiple_statements = statements.body().len() > 1;
@@ -1113,16 +1113,16 @@ fn format_embedded_statements_node<'src>(
             });
         });
     }
-    ps.emit_string_content("}".to_string());
+    ps.emit_string_content("}");
 }
 
 fn format_embedded_variable_node<'src>(
     ps: &mut ParserState<'src>,
     embedded_variable_node: prism::EmbeddedVariableNode<'src>,
 ) {
-    ps.emit_string_content("#{".to_string());
+    ps.emit_string_content("#{");
     format_node(ps, embedded_variable_node.variable());
-    ps.emit_string_content("}".to_string());
+    ps.emit_string_content("}");
 }
 
 fn format_ensure_node<'src>(ps: &mut ParserState<'src>, ensure_node: prism::EnsureNode<'src>) {

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -54,7 +54,7 @@ pub enum ConcreteLineToken<'src> {
     CloseParen,
     Op { op: Cow<'src, str> },
     DoubleQuote,
-    LTStringContent { content: String },
+    LTStringContent { content: Cow<'src, str> },
     SingleSlash,
     Comment { contents: String },
     Delim { contents: &'static str },
@@ -98,7 +98,7 @@ impl<'src> ConcreteLineToken<'src> {
             Self::CloseParen => Cow::Borrowed(")"),
             Self::Op { op } => op,
             Self::DoubleQuote => Cow::Borrowed("\""),
-            Self::LTStringContent { content } => Cow::Owned(content),
+            Self::LTStringContent { content } => content,
             Self::SingleSlash => Cow::Borrowed("\\"),
             Self::Comment { contents } => Cow::Owned(contents),
             Self::Delim { contents } => Cow::Borrowed(contents),
@@ -128,12 +128,11 @@ impl<'src> ConcreteLineToken<'src> {
             Keyword { keyword: contents }
             | ModKeyword { contents }
             | ConditionalKeyword { contents } => contents.len(),
-            Op { op: contents } | DirectPart { part: contents } | MethodName { name: contents } => {
-                contents.len()
-            }
-            LTStringContent { content: contents }
-            | Comment { contents }
-            | HeredocClose { symbol: contents } => contents.len(),
+            Op { op: contents }
+            | DirectPart { part: contents }
+            | MethodName { name: contents }
+            | LTStringContent { content: contents } => contents.len(),
+            Comment { contents } | HeredocClose { symbol: contents } => contents.len(),
             HardNewLine | Comma | Space | Dot | OpenSquareBracket | CloseSquareBracket
             | OpenCurlyBracket | CloseCurlyBracket | OpenParen | CloseParen | SingleSlash
             | DoubleQuote => 1,

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -441,14 +441,15 @@ impl<'src> ParserState<'src> {
         self.push_concrete_token(ConcreteLineToken::DoubleQuote);
     }
 
-    pub(crate) fn emit_string_content(&mut self, s: String) {
-        let newline_count = s.matches('\n').count() as u64;
+    pub(crate) fn emit_string_content(&mut self, s: impl Into<Cow<'src, str>>) {
+        let content = s.into();
+        let newline_count = content.matches('\n').count() as u64;
         self.current_orig_line_number += newline_count;
         for be in self.breakable_entry_stack.iter_mut().rev() {
             be.push_line_number(self.current_orig_line_number);
         }
 
-        self.push_concrete_token(ConcreteLineToken::LTStringContent { content: s });
+        self.push_concrete_token(ConcreteLineToken::LTStringContent { content });
     }
 
     pub(crate) fn emit_ident(&mut self, ident: impl Into<Cow<'src, str>>) {


### PR DESCRIPTION
On the tin. There are some other places where we could eventually also pass in `&str`, but they would require more invasive changes to heredoc machinery etc. so I'm punting on them for now -- this just gets the lowest hanging fruit.