### PR TITLE
[prism] Check for whitespaces escsapes at front of heredoc lines

### DIFF
--- a/fixtures/small/heredoc_escape_sequence_indent_actual.rb
+++ b/fixtures/small/heredoc_escape_sequence_indent_actual.rb
@@ -1,0 +1,6 @@
+<<~EOS
+  \t*Source: /bats task
+  \t*By*: #{self.created_by}
+  \t*Filepath*: #{filename}
+  \t*Tokens*: #{self.fields[:tokens]}
+EOS

--- a/fixtures/small/heredoc_escape_sequence_indent_expected.rb
+++ b/fixtures/small/heredoc_escape_sequence_indent_expected.rb
@@ -1,0 +1,6 @@
+<<~EOS
+  \t*Source: /bats task
+  \t*By*: #{self.created_by}
+  \t*Filepath*: #{filename}
+  \t*Tokens*: #{self.fields[:tokens]}
+EOS

--- a/fixtures/small/heredoc_mixed_escape_lines_actual.rb
+++ b/fixtures/small/heredoc_mixed_escape_lines_actual.rb
@@ -1,0 +1,7 @@
+<<~EOS
+  \tLine starting with tab escape
+  Normal line without escape
+  \sLine starting with space escape
+  Another normal line
+  \t\sLine with both escapes
+EOS

--- a/fixtures/small/heredoc_mixed_escape_lines_expected.rb
+++ b/fixtures/small/heredoc_mixed_escape_lines_expected.rb
@@ -1,0 +1,7 @@
+<<~EOS
+  \tLine starting with tab escape
+  Normal line without escape
+  \sLine starting with space escape
+  Another normal line
+  \t\sLine with both escapes
+EOS

--- a/fixtures/small/heredoc_multiple_escape_indent_actual.rb
+++ b/fixtures/small/heredoc_multiple_escape_indent_actual.rb
@@ -1,0 +1,5 @@
+<<~EOS
+  \t\t\tTriple tab escape
+  \t\tDouble tab escape
+  \tSingle tab escape
+EOS

--- a/fixtures/small/heredoc_multiple_escape_indent_expected.rb
+++ b/fixtures/small/heredoc_multiple_escape_indent_expected.rb
@@ -1,0 +1,5 @@
+<<~EOS
+  \t\t\tTriple tab escape
+  \t\tDouble tab escape
+  \tSingle tab escape
+EOS

--- a/fixtures/small/heredoc_nonuniform_escape_indent_actual.rb
+++ b/fixtures/small/heredoc_nonuniform_escape_indent_actual.rb
@@ -1,0 +1,6 @@
+<<~EOS
+    \tMore indented line with escape
+  Less indented line
+    \sAnother more indented with space escape
+  Back to less indent
+EOS

--- a/fixtures/small/heredoc_nonuniform_escape_indent_expected.rb
+++ b/fixtures/small/heredoc_nonuniform_escape_indent_expected.rb
@@ -1,0 +1,6 @@
+<<~EOS
+    \tMore indented line with escape
+  Less indented line
+    \sAnother more indented with space escape
+  Back to less indent
+EOS

--- a/fixtures/small/heredoc_space_escape_indent_actual.rb
+++ b/fixtures/small/heredoc_space_escape_indent_actual.rb
@@ -1,0 +1,5 @@
+<<~EOS
+  \sLeading space escape
+  \s\sDouble space escape
+  \t\sMixed tab and space escape
+EOS

--- a/fixtures/small/heredoc_space_escape_indent_expected.rb
+++ b/fixtures/small/heredoc_space_escape_indent_expected.rb
@@ -1,0 +1,5 @@
+<<~EOS
+  \sLeading space escape
+  \s\sDouble space escape
+  \t\sMixed tab and space escape
+EOS

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -913,10 +913,31 @@ fn format_inner_string<'src>(
                     let unescaped = node.unescaped();
 
                     let raw_leading = raw.iter().take_while(|&&b| b == b' ' || b == b'\t').count();
+
+                    // Count consecutive escape sequences after leading whitespace that produce
+                    // whitespace chars (like \t -> tab, \s -> space). These shouldn't count toward
+                    // unescaped_leading since they're content, not indentation.
+                    let escaped_ws_count = {
+                        let after_ws = &raw[raw_leading..];
+                        let mut count = 0;
+                        let mut i = 0;
+                        while i + 1 < after_ws.len() && after_ws[i] == b'\\' {
+                            match after_ws[i + 1] {
+                                b't' | b's' => {
+                                    count += 1;
+                                    i += 2;
+                                }
+                                _ => break,
+                            }
+                        }
+                        count
+                    };
+
                     let unescaped_leading = unescaped
                         .iter()
                         .take_while(|&&b| b == b' ' || b == b'\t')
-                        .count();
+                        .count()
+                        - escaped_ws_count;
 
                     // The difference is the common indent (if raw has more leading whitespace)
                     if raw_leading > unescaped_leading {


### PR DESCRIPTION
Closes #771 

We check heredoc indents by counting whitespace characters at the front of a line and detecting discrepancies. However, the `unescaped` value will have escape characters transformed, so `\t` in the source will show up in the unescaped as a rendered tab. To circumvent this, we go ahead and look for the number of leading escape whitespace characters and deduct that from the unescaped value to avoid overcounting.