### PR TITLE
[prism] add a testcase for correctly binding masgns

### DIFF
--- a/fixtures/small/multi_variable_binding_actual.rb
+++ b/fixtures/small/multi_variable_binding_actual.rb
@@ -1,0 +1,9 @@
+def foo
+  some, method = self.method()
+  some, method = self.field.method
+end
+
+def bar
+  (other, method) = self.method()
+  (other, method) = self.field.method
+end

--- a/fixtures/small/multi_variable_binding_expected.rb
+++ b/fixtures/small/multi_variable_binding_expected.rb
@@ -1,0 +1,9 @@
+def foo
+  some, method = self.method()
+  some, method = self.field.method
+end
+
+def bar
+  (other, method) = self.method()
+  (other, method) = self.field.method
+end

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -15,6 +15,7 @@ const DISABLED_RIPPER_TESTS: &[&'static str] = &[
     // https://github.com/fables-tales/rubyfmt/issues/474
     "small_args_forwarding_additional_args",
     "small_alias_global_var",
+    "small_multi_variable_binding",
 ];
 
 fn main() -> io::Result<()> {


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
I noticed that we get this correct in prism, but wrong in ripper.  I'm not really motivated to try to tease apart the intricacies here in ripper, but it would be good to have test coverage for this case.