### PR TITLE
Use `&str` refs for heredoc start tokens

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -667,9 +667,7 @@ fn format_string_node<'src>(ps: &mut ParserState<'src>, string_node: prism::Stri
         format_heredoc(
             ps,
             HeredocNodeType::Plain(string_node),
-            opener
-                .expect("Heredocs must have an opening loc for the opening tag (<<FOO etc.)")
-                .to_string(),
+            opener.expect("Heredocs must have an opening loc for the opening tag (<<FOO etc.)"),
         );
         return;
     }
@@ -758,9 +756,7 @@ fn format_interpolated_string_node<'src>(
         format_heredoc(
             ps,
             HeredocNodeType::Interpolated(interpolated_string_node),
-            opener
-                .expect("Heredocs must have an opening loc for the opening tag (<<FOO etc.)")
-                .to_string(),
+            opener.expect("Heredocs must have an opening loc for the opening tag (<<FOO etc.)"),
         );
         // The rest of this machinery is handled in format_inner_string
         // From here on out, assume we're not in a heredoc
@@ -862,14 +858,14 @@ impl<'src> HeredocNodeType<'src> {
 fn format_heredoc<'src>(
     ps: &mut ParserState<'src>,
     heredoc: HeredocNodeType<'src>,
-    heredoc_symbol: String,
+    heredoc_symbol: &'src str,
 ) {
     let heredoc_kind = HeredocKind::from_string(&heredoc_symbol);
     ps.emit_heredoc_start(heredoc_symbol, heredoc_kind);
 
     let parts = heredoc.parts();
     ps.push_heredoc_content(
-        loc_to_str(heredoc.closing_loc()).trim().to_string(),
+        loc_to_str(heredoc.closing_loc()).trim(),
         heredoc_kind,
         ps.get_line_number_for_offset(heredoc.closing_loc().start_offset()),
         |n: &mut ParserState<'src>| {

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -860,7 +860,7 @@ fn format_heredoc<'src>(
     heredoc: HeredocNodeType<'src>,
     heredoc_symbol: &'src str,
 ) {
-    let heredoc_kind = HeredocKind::from_string(&heredoc_symbol);
+    let heredoc_kind = HeredocKind::from_string(heredoc_symbol);
     ps.emit_heredoc_start(heredoc_symbol, heredoc_kind);
 
     let parts = heredoc.parts();

--- a/librubyfmt/src/heredoc_string.rs
+++ b/librubyfmt/src/heredoc_string.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::types::ColNumber;
 use crate::util::get_indent;
 
@@ -29,15 +31,15 @@ impl HeredocKind {
 }
 
 #[derive(Debug, Clone)]
-pub struct HeredocString {
-    symbol: String,
+pub struct HeredocString<'src> {
+    symbol: Cow<'src, str>,
     pub kind: HeredocKind,
     pub buf: Vec<u8>,
     pub indent: ColNumber,
 }
 
-impl HeredocString {
-    pub fn new(symbol: String, kind: HeredocKind, buf: Vec<u8>, indent: ColNumber) -> Self {
+impl<'src> HeredocString<'src> {
+    pub fn new(symbol: Cow<'src, str>, kind: HeredocKind, buf: Vec<u8>, indent: ColNumber) -> Self {
         HeredocString {
             symbol,
             kind,

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -29,16 +29,28 @@ pub fn clats_indent<'src>(depth: ColNumber) -> ConcreteLineTokenAndTargets<'src>
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConcreteLineToken<'src> {
     HardNewLine,
-    Indent { depth: u32 },
-    Keyword { keyword: &'static str },
+    Indent {
+        depth: u32,
+    },
+    Keyword {
+        keyword: &'static str,
+    },
     DefKeyword,
     ClassKeyword,
     ModuleKeyword,
     DoKeyword,
-    ModKeyword { contents: &'static str },
-    ConditionalKeyword { contents: &'static str },
-    DirectPart { part: Cow<'src, str> },
-    MethodName { name: Cow<'src, str> },
+    ModKeyword {
+        contents: &'static str,
+    },
+    ConditionalKeyword {
+        contents: &'static str,
+    },
+    DirectPart {
+        part: Cow<'src, str>,
+    },
+    MethodName {
+        name: Cow<'src, str>,
+    },
     CommaSpace,
     Comma,
     Space,
@@ -52,21 +64,34 @@ pub enum ConcreteLineToken<'src> {
     CloseCurlyBracket,
     OpenParen,
     CloseParen,
-    Op { op: Cow<'src, str> },
+    Op {
+        op: Cow<'src, str>,
+    },
     DoubleQuote,
-    LTStringContent { content: Cow<'src, str> },
+    LTStringContent {
+        content: Cow<'src, str>,
+    },
     SingleSlash,
-    Comment { contents: String },
-    Delim { contents: &'static str },
+    Comment {
+        contents: String,
+    },
+    Delim {
+        contents: &'static str,
+    },
     End,
-    HeredocClose { symbol: String },
+    HeredocClose {
+        symbol: String,
+    },
     DataEnd,
     // These are "magic" tokens. They have no concrete representation,
     // but they're meaningful inside of the render queue
     AfterCallChain,
     BeginCallChainIndent,
     EndCallChainIndent,
-    HeredocStart { kind: HeredocKind, symbol: String },
+    HeredocStart {
+        kind: HeredocKind,
+        symbol: Cow<'src, str>,
+    },
 }
 
 impl<'src> ConcreteLineToken<'src> {
@@ -105,7 +130,7 @@ impl<'src> ConcreteLineToken<'src> {
             Self::End => Cow::Borrowed("end"),
             Self::HeredocClose { symbol } => Cow::Owned(symbol),
             Self::DataEnd => Cow::Borrowed("__END__"),
-            Self::HeredocStart { symbol, .. } => Cow::Owned(symbol),
+            Self::HeredocStart { symbol, .. } => symbol,
             // no-op, this is purely semantic information
             // for the render queue
             Self::AfterCallChain | Self::BeginCallChainIndent | Self::EndCallChainIndent => {
@@ -246,8 +271,8 @@ impl<'src> ConcreteLineTokenAndTargets<'src> {
 pub enum AbstractLineToken<'src> {
     // this is all bodil's fault
     ConcreteLineToken(ConcreteLineToken<'src>),
-    CollapsingNewLine(Option<Vec<HeredocString>>),
-    SoftNewline(Option<Vec<HeredocString>>),
+    CollapsingNewLine(Option<Vec<HeredocString<'src>>>),
+    SoftNewline(Option<Vec<HeredocString<'src>>>),
     SoftIndent { depth: u32 },
     BreakableEntry(BreakableEntry<'src>),
     BreakableCallChainEntry(BreakableCallChainEntry<'src>),

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -63,7 +63,7 @@ pub struct ParserState<'src> {
     render_queue: BaseQueue<'src>,
     current_orig_line_number: LineNumber,
     comments_hash: FileComments,
-    heredoc_strings: Vec<HeredocString>,
+    heredoc_strings: Vec<HeredocString<'src>>,
     comments_to_insert: Option<CommentBlock>,
     breakable_entry_stack: Vec<Breakable<'src>>,
     formatting_context: Vec<FormattingContext>,
@@ -97,7 +97,7 @@ impl<'src> ParserState<'src> {
     }
     pub(crate) fn push_heredoc_content<F>(
         &mut self,
-        symbol: String,
+        symbol: impl Into<Cow<'src, str>>,
         kind: HeredocKind,
         end_line: LineNumber,
         formatting_func: F,
@@ -119,15 +119,22 @@ impl<'src> ParserState<'src> {
 
         let data = next_ps.render_to_buffer();
         self.heredoc_strings.push(HeredocString::new(
-            symbol,
+            symbol.into(),
             kind,
             data,
             self.current_spaces(),
         ));
     }
 
-    pub(crate) fn emit_heredoc_start(&mut self, symbol: String, kind: HeredocKind) {
-        self.push_concrete_token(ConcreteLineToken::HeredocStart { kind, symbol });
+    pub(crate) fn emit_heredoc_start(
+        &mut self,
+        symbol: impl Into<Cow<'src, str>>,
+        kind: HeredocKind,
+    ) {
+        self.push_concrete_token(ConcreteLineToken::HeredocStart {
+            kind,
+            symbol: symbol.into(),
+        });
     }
 
     pub(crate) fn emit_heredoc_close(&mut self, symbol: String) {
@@ -792,7 +799,7 @@ impl<'src> ParserState<'src> {
         self.render_queue.into_tokens()
     }
 
-    pub(crate) fn gather_heredocs(&mut self) -> Option<Vec<HeredocString>> {
+    pub(crate) fn gather_heredocs(&mut self) -> Option<Vec<HeredocString<'src>>> {
         if self.heredoc_strings.is_empty() {
             None
         } else {


### PR DESCRIPTION
On the tin -- heredoc openers are never modified, so we can just keep them as `&str` instead of allocating them.