### PR TITLE
[prism] Remove final usages of `loc_to_string`

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -8,7 +8,7 @@ use crate::{
     parser_state::{FormattingContext, HashType, ParserState},
     render_targets::MultilineHandling,
     types::SourceOffset,
-    util::{const_to_str, loc_to_str, loc_to_string},
+    util::{const_to_str, loc_to_str},
 };
 
 pub fn format_node<'src>(ps: &mut ParserState<'src>, node: prism::Node<'src>) {
@@ -684,7 +684,7 @@ fn format_string_node<'src>(ps: &mut ParserState<'src>, string_node: prism::Stri
         // means the contents must already be appropriately escaped -- hence we default to `true` here
         let in_escaped_context = is_heredoc || opener.map(|s| s.starts_with("\"")).unwrap_or(true);
         let string_content = if in_escaped_context {
-            loc_to_string(string_node.content_loc())
+            Cow::Borrowed(loc_to_str(string_node.content_loc()))
         } else {
             // For character literals (`?a`), there can be an opening loc without
             // a closing loc. In that case, fall back to a double quote, since
@@ -4236,7 +4236,7 @@ fn format_match_last_line_node<'src>(
     match_last_line_node: prism::MatchLastLineNode<'src>,
 ) {
     ps.emit_ident(loc_to_str(match_last_line_node.opening_loc()));
-    ps.emit_string_content(loc_to_string(match_last_line_node.content_loc()));
+    ps.emit_string_content(loc_to_str(match_last_line_node.content_loc()));
     ps.emit_ident(loc_to_str(match_last_line_node.closing_loc()));
 }
 
@@ -4538,7 +4538,7 @@ fn format_regular_expression_node<'src>(
     regular_expression_node: prism::RegularExpressionNode<'src>,
 ) {
     ps.emit_ident(loc_to_str(regular_expression_node.opening_loc()));
-    ps.emit_string_content(loc_to_string(regular_expression_node.content_loc()));
+    ps.emit_string_content(loc_to_str(regular_expression_node.content_loc()));
     ps.emit_ident(loc_to_str(regular_expression_node.closing_loc()));
 }
 
@@ -4761,7 +4761,7 @@ fn format_while_node<'src>(ps: &mut ParserState<'src>, while_node: prism::WhileN
 
 fn format_x_string_node<'src>(ps: &mut ParserState<'src>, x_string_node: prism::XStringNode<'src>) {
     ps.emit_ident("`");
-    ps.emit_string_content(loc_to_string(x_string_node.content_loc()));
+    ps.emit_string_content(loc_to_str(x_string_node.content_loc()));
     ps.emit_ident("`");
 }
 

--- a/librubyfmt/src/string_escape.rs
+++ b/librubyfmt/src/string_escape.rs
@@ -1,12 +1,19 @@
+use std::borrow::Cow;
+
 use fancy_regex::Regex;
 
-pub fn single_to_double_quoted(content: &str, start_delim: &str, end_delim: &str) -> String {
+pub fn single_to_double_quoted<'src>(
+    content: &'src str,
+    start_delim: &'src str,
+    end_delim: &'src str,
+) -> Cow<'src, str> {
     if start_delim == "'" || start_delim.starts_with("%q") {
         escape_string(
             content,
             start_delim.chars().last().unwrap(),
             end_delim.chars().last().unwrap(),
         )
+        .into()
     } else {
         // For percent literals, we only care about the delimiter
         // e.g. for `%<` we're looking for the `<`
@@ -23,24 +30,22 @@ pub fn single_to_double_quoted(content: &str, start_delim: &str, end_delim: &str
         ))
         .unwrap();
 
-        regexp
-            .replace_all(content, |captures: &fancy_regex::Captures| {
-                // first capture is the entire match
-                let val = captures.get(0).unwrap();
-                let val_str = val.as_str();
-                if val_str.ends_with("\"") {
-                    // Ends with a quote, which we transform to `\"`
-                    format!("{}\\\"", &val_str[0..(val_str.len() - 1)])
-                } else {
-                    // drop unnecessary escape
-                    format!(
-                        "{}{}",
-                        &val_str[0..(val_str.len() - 2)],
-                        val_str.chars().last().unwrap()
-                    )
-                }
-            })
-            .to_string()
+        regexp.replace_all(content, |captures: &fancy_regex::Captures| {
+            // first capture is the entire match
+            let val = captures.get(0).unwrap();
+            let val_str = val.as_str();
+            if val_str.ends_with("\"") {
+                // Ends with a quote, which we transform to `\"`
+                format!("{}\\\"", &val_str[0..(val_str.len() - 1)])
+            } else {
+                // drop unnecessary escape
+                format!(
+                    "{}{}",
+                    &val_str[0..(val_str.len() - 2)],
+                    val_str.chars().last().unwrap()
+                )
+            }
+        })
     }
 }
 

--- a/librubyfmt/src/util.rs
+++ b/librubyfmt/src/util.rs
@@ -32,7 +32,3 @@ pub fn const_to_str(constant_id: ConstantId<'_>) -> &str {
 pub fn loc_to_str(loc: Location<'_>) -> &str {
     u8_to_str(loc.as_slice())
 }
-
-pub fn loc_to_string(loc: Location) -> String {
-    u8_to_string(loc.as_slice())
-}


### PR DESCRIPTION
This converts our last few usages of `loc_to_string` to `loc_to_str`.

🔪 
