### PR TITLE
Clean up misleading `is_comment` method

### DIFF
--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -213,10 +213,6 @@ impl<'src> ConcreteLineToken<'src> {
         matches!(self, ConcreteLineToken::Indent { .. })
     }
 
-    pub fn is_comment(&self) -> bool {
-        matches!(self, Self::Indent { .. })
-    }
-
     pub fn is_in_need_of_a_trailing_blankline(&self) -> bool {
         self.is_conditional_spaced_token() && !self.is_block_closing_token()
     }
@@ -259,9 +255,9 @@ impl<'src> ConcreteLineTokenAndTargets<'src> {
         }
     }
 
-    pub fn is_comment(&self) -> bool {
+    pub fn is_indent(&self) -> bool {
         match self {
-            Self::ConcreteLineToken(clt) => clt.is_comment(),
+            Self::ConcreteLineToken(clt) => clt.is_indent(),
             _ => false,
         }
     }
@@ -359,9 +355,9 @@ impl<'src> AbstractLineToken<'src> {
         }
     }
 
-    pub fn is_comment(&self) -> bool {
+    pub fn is_indent(&self) -> bool {
         match self {
-            Self::ConcreteLineToken(clt) => clt.is_comment(),
+            Self::ConcreteLineToken(clt) => clt.is_indent(),
             _ => false,
         }
     }

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -43,7 +43,7 @@ impl<'src> BaseQueue<'src> {
     pub fn index_of_prev_newline(&self) -> Option<usize> {
         self.tokens
             .iter()
-            .rposition(|v| v.is_newline() || v.is_comment())
+            .rposition(|v| v.is_newline() || v.is_indent())
     }
 }
 
@@ -62,7 +62,7 @@ pub trait AbstractTokenTarget<'src>: std::fmt::Debug {
     fn index_of_prev_newline(&self) -> Option<usize> {
         self.tokens()
             .iter()
-            .rposition(|v| v.is_newline() || v.is_comment())
+            .rposition(|v| v.is_newline() || v.is_indent())
             .map(|x| {
                 let token = &self.tokens()[x];
                 if matches!(token, AbstractLineToken::CollapsingNewLine(_))


### PR DESCRIPTION
From ages long past (as in, it was written several years ago and never touched), there's a method called `is_comment` on `ConcreteLineToken` that for whatever reason checks for an `Indent` token. There's a method directly next to it called `is_indent` with the same implementation, and changing `is_comment` to actually check for comments breaks ~everything, so this PR just deletes it an replaces its few callers with `is_indent`.

(_Do as I do, not as I say_ etc.)