### PR TITLE
[prism] Add tests around comments after call chains with leading expressions

### DIFF
--- a/fixtures/small/prism/expression_calls_actual.rb
+++ b/fixtures/small/prism/expression_calls_actual.rb
@@ -1,0 +1,49 @@
+[
+  CommonFields::OBVIOUSLY,
+  CommonFields::THESE,
+  CommonFields::ARE,
+  CommonFields::FAKE_RESOURCE.with_wombo(true).with_combo(true).with_explosion(true)
+].map do |field|
+  # Swap things out, to make sure.
+  override || field
+end
+
+{
+  having: "Having a Coke With You",
+  with: you
+}.freeze
+
+{
+  having: "Having a Coke With You",
+  with: you
+} # by Mark Leidner
+  .freeze
+
+{
+  having: "Having a Coke With You",
+  with: you
+}.# by Mark Leidner
+freeze
+
+{
+  having: "Having a Coke With You",
+  with: you
+}
+# by Mark Leidner
+.freeze
+
+{
+  something: "wicked"
+}.this_way {
+  comes
+  # spookyyyy
+}
+
+{musical: "wicked"}
+  # The original broadway cast recording!
+  .sing("Defying Gravity")
+
+
+# TODO(@reese): Fix this failing test case
+# {musical: "wicked"}
+#   .sing("Defying Gravity") # The original broadway cast recording!

--- a/fixtures/small/prism/expression_calls_expected.rb
+++ b/fixtures/small/prism/expression_calls_expected.rb
@@ -1,0 +1,48 @@
+[
+  CommonFields::OBVIOUSLY,
+  CommonFields::THESE,
+  CommonFields::ARE,
+  CommonFields::FAKE_RESOURCE.with_wombo(true).with_combo(true).with_explosion(true)
+].map do |field|
+  # Swap things out, to make sure.
+  override || field
+end
+
+{
+  having: "Having a Coke With You",
+  with: you
+}.freeze
+
+{
+  having: "Having a Coke With You",
+  with: you
+  # by Mark Leidner
+}.freeze
+
+{
+  having: "Having a Coke With You",
+  with: you
+  # by Mark Leidner
+}.freeze
+
+{
+  having: "Having a Coke With You",
+  with: you
+}
+  # by Mark Leidner
+  .freeze
+
+{
+  something: "wicked"
+}.this_way {
+  comes
+  # spookyyyy
+}
+
+{musical: "wicked"}
+  # The original broadway cast recording!
+  .sing("Defying Gravity")
+
+# TODO(@reese): Fix this failing test case
+# {musical: "wicked"}
+#   .sing("Defying Gravity") # The original broadway cast recording!


### PR DESCRIPTION
This adds a test case I promised in #770. I did leave a `TODO` in there because I uncovered a bug (fun!) while writing tests for this, but while I figure out the right fix for that I wanted to add these tests before I forgot about it.