### PR TITLE
 make paren stripping work good

### DIFF
--- a/fixtures/small/paren_expr_calls_expected.rb
+++ b/fixtures/small/paren_expr_calls_expected.rb
@@ -1,4 +1,4 @@
-a((1))
+a(1)
 other_cool_method((a + b).round(4))
 
 # rubocop:disable PrisonGuard/PrivateModule

--- a/fixtures/small/paren_expr_nested_actual.rb
+++ b/fixtures/small/paren_expr_nested_actual.rb
@@ -1,0 +1,17 @@
+# Test cases for nested redundant parentheses
+# Multiple levels of unnecessary parens should be stripped
+
+# Double nested
+foo ((1))
+bar ((a + b))
+
+# Triple nested
+foo (((1)))
+bar (((x)))
+
+# Mixed with method chains
+foo ((bar.baz))
+
+# Nested but inner contains keyword - should preserve inner parens
+foo ((a if b))
+bar ((x rescue y))

--- a/fixtures/small/paren_expr_nested_expected.rb
+++ b/fixtures/small/paren_expr_nested_expected.rb
@@ -1,0 +1,17 @@
+# Test cases for nested redundant parentheses
+# Multiple levels of unnecessary parens should be stripped
+
+# Double nested
+foo(1)
+bar(a + b)
+
+# Triple nested
+foo(1)
+bar(x)
+
+# Mixed with method chains
+foo(bar.baz)
+
+# Nested but inner contains keyword - should preserve inner parens
+foo((a if b))
+bar((x rescue y))

--- a/fixtures/small/paren_expr_preserve_actual.rb
+++ b/fixtures/small/paren_expr_preserve_actual.rb
@@ -26,17 +26,3 @@ check (condition and action)
 # `or` keyword (low precedence) - `foo (a or b)` must become `foo((a or b))`
 foo (a or b)
 provide (default or fallback)
-
-# case expressions
-foo (case x
-when 1 then :one
-when 2 then :two
-else :other
-end)
-
-# begin/end blocks
-foo (begin
-  risky_operation
-rescue
-  fallback
-end)

--- a/fixtures/small/paren_expr_preserve_actual.rb
+++ b/fixtures/small/paren_expr_preserve_actual.rb
@@ -1,0 +1,42 @@
+# Test cases for parentheses that MUST be preserved to maintain correct semantics
+# These contain Ruby keywords that would cause syntax errors if parens were removed
+
+# Modifier if - `foo (a if b)` must become `foo((a if b))` not `foo(a if b)` (syntax error)
+foo (a if b)
+method_call (value if condition)
+
+# Modifier unless
+foo (a unless b)
+method_call (value unless condition)
+
+# Modifier while
+foo (a while b)
+
+# Modifier until
+foo (a until b)
+
+# Inline rescue - `foo (x rescue y)` must become `foo((x rescue y))`
+foo (risky_call rescue fallback)
+method_call (might_fail rescue nil)
+
+# `and` keyword (low precedence) - `foo (a and b)` must become `foo((a and b))`
+foo (a and b)
+check (condition and action)
+
+# `or` keyword (low precedence) - `foo (a or b)` must become `foo((a or b))`
+foo (a or b)
+provide (default or fallback)
+
+# case expressions
+foo (case x
+when 1 then :one
+when 2 then :two
+else :other
+end)
+
+# begin/end blocks
+foo (begin
+  risky_operation
+rescue
+  fallback
+end)

--- a/fixtures/small/paren_expr_preserve_actual.rb
+++ b/fixtures/small/paren_expr_preserve_actual.rb
@@ -26,3 +26,17 @@ check (condition and action)
 # `or` keyword (low precedence) - `foo (a or b)` must become `foo((a or b))`
 foo (a or b)
 provide (default or fallback)
+
+# case expressions
+foo (case x
+when 1 then :one
+when 2 then :two
+else :other
+end)
+
+# begin/end blocks
+foo (begin
+  risky_operation
+rescue
+  fallback
+end)

--- a/fixtures/small/paren_expr_preserve_expected.rb
+++ b/fixtures/small/paren_expr_preserve_expected.rb
@@ -38,7 +38,6 @@ foo(
     else
       :other
     end
-
   )
 )
 
@@ -50,6 +49,5 @@ foo(
     rescue
       fallback
     end
-
   )
 )

--- a/fixtures/small/paren_expr_preserve_expected.rb
+++ b/fixtures/small/paren_expr_preserve_expected.rb
@@ -26,24 +26,3 @@ check((condition and action))
 # `or` keyword (low precedence) - `foo (a or b)` must become `foo((a or b))`
 foo((a or b))
 provide((default or fallback))
-
-# case expressions
-foo(
-  (case x
-  when 1
-    :one
-  when 2
-    :two
-  else
-    :other
-  end)
-)
-
-# begin/end blocks
-foo(
-  (begin
-    risky_operation
-  rescue
-    fallback
-  end)
-)

--- a/fixtures/small/paren_expr_preserve_expected.rb
+++ b/fixtures/small/paren_expr_preserve_expected.rb
@@ -26,3 +26,30 @@ check((condition and action))
 # `or` keyword (low precedence) - `foo (a or b)` must become `foo((a or b))`
 foo((a or b))
 provide((default or fallback))
+
+# case expressions
+foo(
+  (
+    case x
+    when 1
+      :one
+    when 2
+      :two
+    else
+      :other
+    end
+
+  )
+)
+
+# begin/end blocks
+foo(
+  (
+    begin
+      risky_operation
+    rescue
+      fallback
+    end
+
+  )
+)

--- a/fixtures/small/paren_expr_preserve_expected.rb
+++ b/fixtures/small/paren_expr_preserve_expected.rb
@@ -1,0 +1,49 @@
+# Test cases for parentheses that MUST be preserved to maintain correct semantics
+# These contain Ruby keywords that would cause syntax errors if parens were removed
+
+# Modifier if - `foo (a if b)` must become `foo((a if b))` not `foo(a if b)` (syntax error)
+foo((a if b))
+method_call((value if condition))
+
+# Modifier unless
+foo((a unless b))
+method_call((value unless condition))
+
+# Modifier while
+foo((a while b))
+
+# Modifier until
+foo((a until b))
+
+# Inline rescue - `foo (x rescue y)` must become `foo((x rescue y))`
+foo((risky_call rescue fallback))
+method_call((might_fail rescue nil))
+
+# `and` keyword (low precedence) - `foo (a and b)` must become `foo((a and b))`
+foo((a and b))
+check((condition and action))
+
+# `or` keyword (low precedence) - `foo (a or b)` must become `foo((a or b))`
+foo((a or b))
+provide((default or fallback))
+
+# case expressions
+foo(
+  (case x
+  when 1
+    :one
+  when 2
+    :two
+  else
+    :other
+  end)
+)
+
+# begin/end blocks
+foo(
+  (begin
+    risky_operation
+  rescue
+    fallback
+  end)
+)

--- a/fixtures/small/paren_expr_unwrap_actual.rb
+++ b/fixtures/small/paren_expr_unwrap_actual.rb
@@ -1,0 +1,39 @@
+# Test cases for parentheses that CAN be safely unwrapped when used as method arguments
+# These are simple expressions where `method (expr)` becomes `method(expr)`
+
+# Simple literals
+foo (1)
+foo ("hello")
+foo (:symbol)
+foo (nil)
+foo (true)
+
+# Simple variables
+foo (bar)
+foo (BAR)
+foo (@bar)
+
+# Simple method calls
+foo (bar.baz)
+
+# Array and hash literals
+foo ([1, 2, 3])
+foo ({a: 1})
+
+# Arithmetic expressions (these bind tighter than method args)
+foo (a + b)
+foo (a * b)
+
+# Comparison expressions
+foo (a == b)
+foo (a < b)
+
+# Logical operators (high precedence &&, ||)
+foo (a && b)
+foo (a || b)
+
+# Range expressions
+foo (1..10)
+
+# Ternary without keywords
+foo (condition ? a : b)

--- a/fixtures/small/paren_expr_unwrap_expected.rb
+++ b/fixtures/small/paren_expr_unwrap_expected.rb
@@ -1,0 +1,39 @@
+# Test cases for parentheses that CAN be safely unwrapped when used as method arguments
+# These are simple expressions where `method (expr)` becomes `method(expr)`
+
+# Simple literals
+foo(1)
+foo("hello")
+foo(:symbol)
+foo(nil)
+foo(true)
+
+# Simple variables
+foo(bar)
+foo(BAR)
+foo(@bar)
+
+# Simple method calls
+foo(bar.baz)
+
+# Array and hash literals
+foo([1, 2, 3])
+foo({a: 1})
+
+# Arithmetic expressions (these bind tighter than method args)
+foo(a + b)
+foo(a * b)
+
+# Comparison expressions
+foo(a == b)
+foo(a < b)
+
+# Logical operators (high precedence &&, ||)
+foo(a && b)
+foo(a || b)
+
+# Range expressions
+foo(1..10)
+
+# Ternary without keywords
+foo(condition ? a : b)

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4973,6 +4973,13 @@ fn unwrap_single_arg_paren<'src>(node: &prism::Node<'src>) -> Option<prism::Node
         return None;
     }
 
+    // Recursively unwrap nested parentheses
+    if inner.as_parentheses_node().is_some() {
+        if let Some(deeper) = unwrap_single_arg_paren(&inner) {
+            return Some(deeper);
+        }
+    }
+
     Some(inner)
 }
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1838,6 +1838,22 @@ fn format_call_node<'src>(
                     BreakableDelims::for_kw()
                 };
 
+                // Check if we can unwrap a single parenthesized argument when we're adding
+                // method call parens. This handles cases like `a (1)` -> `a(1)` where the
+                // parens around `1` were just for argument grouping, not expression grouping.
+                let maybe_unwrapped_single_arg = if should_use_parens
+                    && arguments.arguments().len() == 1
+                    && call_node
+                        .block()
+                        .and_then(|b| b.as_block_argument_node())
+                        .is_none()
+                {
+                    let first_arg = arguments.arguments().iter().next().unwrap();
+                    unwrap_single_arg_paren(&first_arg)
+                } else {
+                    None
+                };
+
                 let maybe_closing_line = call_node
                     .closing_loc()
                     .map(|closing_loc| ps.get_line_number_for_offset(closing_loc.start_offset()));
@@ -1846,7 +1862,14 @@ fn format_call_node<'src>(
                     ps.breakable_of(delims, |ps| {
                         let has_arguments = !arguments.arguments().is_empty();
 
-                        format_arguments_node(ps, arguments);
+                        if let Some(unwrapped_arg) = maybe_unwrapped_single_arg {
+                            ps.emit_collapsing_newline();
+                            ps.emit_soft_indent();
+                            format_node(ps, unwrapped_arg);
+                            ps.shift_comments();
+                        } else {
+                            format_arguments_node(ps, arguments);
+                        }
 
                         // Somewhat confusingly, the block argument node (&blk) is
                         // separate from the rest of the arguments node. If it's present,

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2979,6 +2979,40 @@ fn format_array_pattern_node<'src>(
     });
 }
 
+/// Returns true if a node is inherently multiline (like case, begin, def, class, etc.)
+/// Note: Modifier forms (if/unless/while/until without `end`) are NOT multiline.
+fn is_multiline_node(node: &prism::Node) -> bool {
+    use prism::Node;
+    match node {
+        // Case and begin are always multiline
+        Node::CaseNode { .. } | Node::CaseMatchNode { .. } | Node::BeginNode { .. } => true,
+        // If/unless are multiline only if they have an `end` keyword (not modifier form)
+        Node::IfNode { .. } => {
+            let if_node = node.as_if_node().unwrap();
+            if_node.end_keyword_loc().is_some()
+        }
+        Node::UnlessNode { .. } => {
+            let unless_node = node.as_unless_node().unwrap();
+            unless_node.end_keyword_loc().is_some()
+        }
+        // While/until are multiline only if they have an `end` keyword (not modifier form)
+        Node::WhileNode { .. } => {
+            let while_node = node.as_while_node().unwrap();
+            while_node.closing_loc().is_some()
+        }
+        Node::UntilNode { .. } => {
+            let until_node = node.as_until_node().unwrap();
+            until_node.closing_loc().is_some()
+        }
+        // These are always multiline
+        Node::ForNode { .. }
+        | Node::DefNode { .. }
+        | Node::ClassNode { .. }
+        | Node::ModuleNode { .. } => true,
+        _ => false,
+    }
+}
+
 fn format_parentheses_node<'src>(
     ps: &mut ParserState<'src>,
     parentheses_node: prism::ParenthesesNode<'src>,
@@ -2987,7 +3021,12 @@ fn format_parentheses_node<'src>(
 
     let is_multiline = if let Some(body) = parentheses_node.body() {
         if let Some(statements_node) = body.as_statements_node() {
+            // Multiline if multiple statements OR if single statement is inherently multiline
             statements_node.body().len() > 1
+                || statements_node
+                    .body()
+                    .first()
+                    .is_some_and(|node| is_multiline_node(&node))
         } else {
             true
         }
@@ -2998,7 +3037,12 @@ fn format_parentheses_node<'src>(
     if let Some(body) = parentheses_node.body() {
         ps.with_start_of_line(false, |ps| {
             if let Some(statements_node) = body.as_statements_node() {
-                if statements_node.body().len() == 1 {
+                let single_inline = statements_node.body().len() == 1
+                    && !statements_node
+                        .body()
+                        .first()
+                        .is_some_and(|node| is_multiline_node(&node));
+                if single_inline {
                     ps.with_start_of_line(false, |ps| {
                         format_node(ps, statements_node.body().first().unwrap())
                     });

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4837,6 +4837,78 @@ fn is_empty_parentheses_node<'src>(node: &prism::Node<'src>) -> bool {
     }
 }
 
+/// Returns true if this node represents a Ruby keyword expression that would cause
+/// a syntax error if used directly inside method call parentheses.
+///
+/// For example: `foo(a if b)` is a syntax error, so `foo (a if b)` must become
+/// `foo((a if b))` (double parens) to preserve semantics.
+///
+/// Note: `&&` and `||` operators are fine inside method call parens, but the
+/// `and` and `or` keywords are not. We distinguish by checking the operator string.
+fn is_keyword_expression(node: &prism::Node) -> bool {
+    use prism::Node;
+
+    match node {
+        // Modifier if: `x if y` (but NOT ternary `a ? b : c` which has no keyword)
+        Node::IfNode { .. } => {
+            let if_node = node.as_if_node().unwrap();
+            // Ternary has no if_keyword_loc, so only flag if keyword is present
+            if_node.if_keyword_loc().is_some()
+        }
+        // Modifier unless: `x unless y`
+        Node::UnlessNode { .. } => true,
+        // Modifier loops: `x while y`, `x until y`
+        Node::WhileNode { .. } | Node::UntilNode { .. } => true,
+        // Inline rescue: `x rescue y`
+        Node::RescueModifierNode { .. } => true,
+        // `and` keyword (but NOT `&&` operator)
+        Node::AndNode { .. } => {
+            let and_node = node.as_and_node().unwrap();
+            loc_to_str(and_node.operator_loc()) == "and"
+        }
+        // `or` keyword (but NOT `||` operator)
+        Node::OrNode { .. } => {
+            let or_node = node.as_or_node().unwrap();
+            loc_to_str(or_node.operator_loc()) == "or"
+        }
+        // Case expressions
+        Node::CaseNode { .. } | Node::CaseMatchNode { .. } => true,
+        // Begin/end blocks (may contain rescue)
+        Node::BeginNode { .. } => true,
+        // For completeness: other control flow that shouldn't be unwrapped
+        Node::ForNode { .. } => true,
+        _ => false,
+    }
+}
+
+/// Returns Some(inner_node) if this is a ParenthesesNode containing a single expression that
+/// can be unwrapped when used as a method argument.
+///
+/// Returns None if:
+/// - The node is not a ParenthesesNode
+/// - The parentheses contain multiple statements
+/// - The inner expression contains Ruby keywords (if, unless, and, or, rescue, etc.)
+///   that would change semantics if the parentheses were removed
+fn unwrap_single_arg_paren<'src>(node: &prism::Node<'src>) -> Option<prism::Node<'src>> {
+    let paren_node = node.as_parentheses_node()?;
+    let body = paren_node.body()?;
+    let statements = body.as_statements_node()?;
+
+    // Only unwrap if there's exactly one statement
+    if statements.body().len() != 1 {
+        return None;
+    }
+
+    let inner = statements.body().iter().next()?;
+
+    // Don't unwrap if the inner expression contains keywords that would change semantics
+    if is_keyword_expression(&inner) {
+        return None;
+    }
+
+    Some(inner)
+}
+
 fn format_list_like_thing<'src>(
     ps: &mut ParserState<'src>,
     node_list: prism::NodeList<'src>,

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4974,10 +4974,10 @@ fn unwrap_single_arg_paren<'src>(node: &prism::Node<'src>) -> Option<prism::Node
     }
 
     // Recursively unwrap nested parentheses
-    if inner.as_parentheses_node().is_some() {
-        if let Some(deeper) = unwrap_single_arg_paren(&inner) {
-            return Some(deeper);
-        }
+    if inner.as_parentheses_node().is_some()
+        && let Some(deeper) = unwrap_single_arg_paren(&inner)
+    {
+        return Some(deeper);
     }
 
     Some(inner)

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3092,7 +3092,7 @@ fn format_parentheses_node<'src>(
 
     if is_multiline {
         ps.emit_indent();
-        ps.emit_close_paren();
+        ps.emit_paren_expr_close();
     } else {
         ps.emit_close_paren();
     }

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -60,6 +60,7 @@ pub enum ConcreteLineToken<'src> {
     CloseCurlyBracket,
     OpenParen,
     CloseParen,
+    ParenExprClose,
     Op {
         op: Cow<'src, str>,
     },
@@ -113,7 +114,7 @@ impl<'src> ConcreteLineToken<'src> {
             Self::OpenCurlyBracket => Cow::Borrowed("{"),
             Self::CloseCurlyBracket => Cow::Borrowed("}"),
             Self::OpenParen => Cow::Borrowed("("),
-            Self::CloseParen => Cow::Borrowed(")"),
+            Self::CloseParen | Self::ParenExprClose => Cow::Borrowed(")"),
             Self::Op { op } => op,
             Self::DoubleQuote => Cow::Borrowed("\""),
             Self::LTStringContent { content } => content,
@@ -149,8 +150,8 @@ impl<'src> ConcreteLineToken<'src> {
             | LTStringContent { content: contents } => contents.len(),
             Comment { contents } | HeredocClose { symbol: contents } => contents.len(),
             HardNewLine | Comma | Space | Dot | OpenSquareBracket | CloseSquareBracket
-            | OpenCurlyBracket | CloseCurlyBracket | OpenParen | CloseParen | SingleSlash
-            | DoubleQuote => 1,
+            | OpenCurlyBracket | CloseCurlyBracket | OpenParen | CloseParen | ParenExprClose
+            | SingleSlash | DoubleQuote => 1,
             DoKeyword | CommaSpace | LonelyOperator | ColonColon => 2,
             DefKeyword | End => 3, // "def"/"..."/"end"
             ClassKeyword => 5,     // "class"
@@ -160,7 +161,7 @@ impl<'src> ConcreteLineToken<'src> {
 
     fn is_block_closing_token(&self) -> bool {
         match self {
-            Self::End => true,
+            Self::End | Self::ParenExprClose => true,
             Self::DirectPart { part } => part == "}" || part == "]" || part == ")",
             Self::Delim { contents } => *contents == "}" || *contents == "]" || *contents == ")",
             _ => false,

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -571,6 +571,10 @@ impl<'src> ParserState<'src> {
         self.push_concrete_token(ConcreteLineToken::CloseParen);
     }
 
+    pub(crate) fn emit_paren_expr_close(&mut self) {
+        self.push_concrete_token(ConcreteLineToken::ParenExprClose);
+    }
+
     pub(crate) fn emit_slash(&mut self) {
         self.push_concrete_token(ConcreteLineToken::SingleSlash);
     }


### PR DESCRIPTION
This reverts commit f54d5af66eb9111796eff781b378a233c2b95607.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
