### PR TITLE
Remove lingering `ruby_checkout` references in release scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 */target/*
 *target*
-*librubyfmt/ruby_checkout/*
 *.git/*
 *out/*
 *releases/*

--- a/script/make_source_release
+++ b/script/make_source_release
@@ -9,13 +9,8 @@ git checkout "$1"
 git archive --format=zip HEAD > archive.zip
 git submodule init
 git submodule update
-(
-cd librubyfmt/ruby_checkout/
-git reset --hard && git clean -fdx
-)
 mkdir /tmp/rubyfmt_source
 unzip archive.zip -d /tmp/rubyfmt_source
-cp -r librubyfmt/ruby_checkout/ /tmp/rubyfmt_source/librubyfmt/ruby_checkout/
 )
 tar -cvz -f "rubyfmt-$1-sources.tar.gz" -C "/tmp/rubyfmt_source" .
 mkdir -p "out/release/source"


### PR DESCRIPTION
On the tin -- these release build scripts assume we still have `librubyfmt/ruby_checkout` lingering around and fail now that it's not there.