### PR TITLE
Remove `MultilineHandling` enum

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -6,7 +6,6 @@ use crate::{
     delimiters::BreakableDelims,
     heredoc_string::HeredocKind,
     parser_state::{FormattingContext, HashType, ParserState},
-    render_targets::MultilineHandling,
     types::SourceOffset,
     util::{const_to_str, loc_to_str},
 };
@@ -85,7 +84,7 @@ pub fn format_node<'src>(ps: &mut ParserState<'src>, node: prism::Node<'src>) {
             let has_block = call_node.block().and_then(|b| b.as_block_node()).is_some();
 
             if is_last_call_in_chain && has_block {
-                ps.breakable_call_chain_of(MultilineHandling::Prism(false), |ps| {
+                ps.breakable_call_chain_of(false, |ps| {
                     format_call_node(ps, call_node, false, is_last_call_in_chain, false);
                 });
             } else {
@@ -2173,7 +2172,7 @@ fn format_call_chain_segments<'src>(
 
         let is_user_multilined = call_chain_elements_are_user_multilined(ps, &chain_elements);
 
-        ps.breakable_call_chain_of(MultilineHandling::Prism(is_user_multilined), |ps| {
+        ps.breakable_call_chain_of(is_user_multilined, |ps| {
             // Recurse and format previous segments inside this breakable
             format_call_chain_segments(ps, segments);
 

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -4,9 +4,7 @@ use crate::file_comments::FileComments;
 use crate::heredoc_string::{HeredocKind, HeredocString};
 use crate::line_tokens::*;
 use crate::render_queue_writer::{MAX_LINE_LENGTH, RenderQueueWriter};
-use crate::render_targets::{
-    BaseQueue, Breakable, BreakableCallChainEntry, BreakableEntry, MultilineHandling,
-};
+use crate::render_targets::{BaseQueue, Breakable, BreakableCallChainEntry, BreakableEntry};
 use crate::types::{ColNumber, LineNumber, SourceOffset};
 use log::debug;
 use std::borrow::Cow;
@@ -304,15 +302,12 @@ impl<'src> ParserState<'src> {
         self.push_target(ConcreteLineTokenAndTargets::BreakableEntry(insert_be));
     }
 
-    pub(crate) fn breakable_call_chain_of<F>(
-        &mut self,
-        mulitiline_handling: MultilineHandling,
-        f: F,
-    ) where
+    pub(crate) fn breakable_call_chain_of<F>(&mut self, is_user_multilined: bool, f: F)
+    where
         F: FnOnce(&mut ParserState<'src>),
     {
         self.shift_comments();
-        let mut be = BreakableCallChainEntry::new(&self.formatting_context, mulitiline_handling);
+        let mut be = BreakableCallChainEntry::new(&self.formatting_context, is_user_multilined);
         be.push_line_number(self.current_orig_line_number);
         self.breakable_entry_stack.push(Breakable::CallChain(be));
 

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -199,21 +199,10 @@ impl<'src> BreakableEntry<'src> {
     }
 }
 
-/// This struct is a bit of a hack to support both
-/// the Ripper tree and the Prism tree at the same time.
-/// The Prism tree has more accurate offset handling that obviates
-/// the hacks put in to support Ripper, but for now we need to support
-/// and I didn't want to have to fork the implementation of BreakableCallChainEntry.
-/// Once Prism is fully featured, we should delete this Ripper handling entirely.
-#[derive(Debug, Clone)]
-pub enum MultilineHandling {
-    Prism(bool),
-}
-
 #[derive(Debug, Clone)]
 pub struct BreakableCallChainEntry<'src> {
     tokens: Vec<AbstractLineToken<'src>>,
-    multiline_handling: MultilineHandling,
+    is_user_multilined: bool,
     in_string_embexpr: bool,
 }
 
@@ -338,9 +327,7 @@ impl<'src> AbstractTokenTarget<'src> for BreakableCallChainEntry<'src> {
             return true;
         }
 
-        match &self.multiline_handling {
-            MultilineHandling::Prism(is_user_multilined) => *is_user_multilined,
-        }
+        self.is_user_multilined
     }
 
     fn any_collapsing_newline_has_heredoc_content(&self) -> bool {
@@ -361,10 +348,7 @@ impl<'src> AbstractTokenTarget<'src> for BreakableCallChainEntry<'src> {
 }
 
 impl<'src> BreakableCallChainEntry<'src> {
-    pub fn new(
-        formatting_context: &[FormattingContext],
-        multiline_handling: MultilineHandling,
-    ) -> Self {
+    pub fn new(formatting_context: &[FormattingContext], is_user_multilined: bool) -> Self {
         let in_string_embexpr = formatting_context
             .iter()
             .any(|fc| fc == &FormattingContext::StringEmbexpr);
@@ -372,7 +356,7 @@ impl<'src> BreakableCallChainEntry<'src> {
         BreakableCallChainEntry {
             tokens: Vec::new(),
             in_string_embexpr,
-            multiline_handling,
+            is_user_multilined,
         }
     }
 


### PR DESCRIPTION
This is a holdover from the Ripper days (remember those?) that is no longer needed, since it now only has a `Prism` entry.