### PR TITLE
🧹  Convert some `Cow<'src, str>` usages into `&'src str`

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -629,7 +629,7 @@ fn format_case_node<'src>(ps: &mut ParserState<'src>, case_node: prism::CaseNode
 pub fn format_program<'src>(
     ps: &mut ParserState<'src>,
     program_node: prism::ProgramNode<'src>,
-    data_loc: Option<prism::Location>,
+    data_loc: Option<prism::Location<'src>>,
 ) {
     ps.with_start_of_line(true, |ps| {
         format_statements(ps, program_node.statements());
@@ -1395,7 +1395,7 @@ fn format_def_body<'src>(ps: &mut ParserState<'src>, def_node: prism::DefNode<'s
                     });
                 } else {
                     ps.emit_space();
-                    ps.emit_op(Cow::Borrowed("="));
+                    ps.emit_op("=");
                     ps.emit_space();
 
                     ps.with_start_of_line(
@@ -2485,7 +2485,7 @@ fn format_call_and_write_node<'src>(
     }
 
     ps.emit_space();
-    ps.emit_op(Cow::Borrowed("&&="));
+    ps.emit_op("&&=");
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| format_node(ps, call_and_write_node.value()));
@@ -2533,7 +2533,7 @@ fn format_call_or_write_node<'src>(
     }
 
     ps.emit_space();
-    ps.emit_op(Cow::Borrowed("||="));
+    ps.emit_op("||=");
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| format_node(ps, call_or_write_node.value()));
@@ -3932,7 +3932,7 @@ fn format_index_and_write_node<'src>(
     }
 
     ps.emit_space();
-    ps.emit_op(Cow::Borrowed("&&="));
+    ps.emit_op("&&=");
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| format_node(ps, index_and_write_node.value()));
@@ -3976,7 +3976,7 @@ fn format_index_or_write_node<'src>(
     }
 
     ps.emit_space();
-    ps.emit_op(Cow::Borrowed("||="));
+    ps.emit_op("||=");
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| format_node(ps, index_or_write_node.value()));
@@ -4476,7 +4476,7 @@ fn format_optional_keyword_parameter_node<'src>(
     let name = const_to_str(optional_keyword_parameter_node.name());
     ps.bind_variable(name);
     ps.emit_ident(name);
-    ps.emit_op(Cow::Borrowed(":"));
+    ps.emit_op(":");
     ps.emit_space();
     ps.with_start_of_line(false, |ps| {
         format_node(ps, optional_keyword_parameter_node.value());
@@ -4491,7 +4491,7 @@ fn format_optional_parameter_node<'src>(
     ps.bind_variable(name);
     ps.emit_ident(name);
     ps.emit_space();
-    ps.emit_op(Cow::Borrowed("="));
+    ps.emit_op("=");
     ps.emit_space();
     format_node(ps, optional_parameter_node.value());
 }
@@ -4653,7 +4653,7 @@ fn format_rescue_node<'src>(ps: &mut ParserState<'src>, rescue_node: prism::Resc
 
     if let Some(reference) = rescue_node.reference() {
         ps.emit_space();
-        ps.emit_op(Cow::Borrowed("=>"));
+        ps.emit_op("=>");
         ps.emit_space();
         ps.with_start_of_line(false, |ps| {
             format_node(ps, reference);

--- a/librubyfmt/src/intermediary.rs
+++ b/librubyfmt/src/intermediary.rs
@@ -131,7 +131,8 @@ impl<'src> Intermediary<'src> {
                 }
             }
             ConcreteLineToken::MethodName { name } => {
-                if name == "require" && self.tokens.last().map(|t| t.is_indent()).unwrap_or(false) {
+                if *name == "require" && self.tokens.last().map(|t| t.is_indent()).unwrap_or(false)
+                {
                     self.current_line_metadata.set_has_require();
                 }
             }

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -46,7 +46,7 @@ pub enum ConcreteLineToken<'src> {
         part: Cow<'src, str>,
     },
     MethodName {
-        name: Cow<'src, str>,
+        name: &'src str,
     },
     CommaSpace,
     Comma,
@@ -62,7 +62,7 @@ pub enum ConcreteLineToken<'src> {
     CloseParen,
     ParenExprClose,
     Op {
-        op: Cow<'src, str>,
+        op: &'src str,
     },
     DoubleQuote,
     LTStringContent {
@@ -86,7 +86,7 @@ pub enum ConcreteLineToken<'src> {
     EndCallChainIndent,
     HeredocStart {
         kind: HeredocKind,
-        symbol: Cow<'src, str>,
+        symbol: &'src str,
     },
 }
 
@@ -102,7 +102,7 @@ impl<'src> ConcreteLineToken<'src> {
             Self::DefKeyword => Cow::Borrowed("def"),
             Self::ModuleKeyword => Cow::Borrowed("module"),
             Self::DirectPart { part } => part,
-            Self::MethodName { name } => name,
+            Self::MethodName { name } => Cow::Borrowed(name),
             Self::CommaSpace => Cow::Borrowed(", "),
             Self::Comma => Cow::Borrowed(","),
             Self::Space => Cow::Borrowed(" "),
@@ -115,7 +115,7 @@ impl<'src> ConcreteLineToken<'src> {
             Self::CloseCurlyBracket => Cow::Borrowed("}"),
             Self::OpenParen => Cow::Borrowed("("),
             Self::CloseParen | Self::ParenExprClose => Cow::Borrowed(")"),
-            Self::Op { op } => op,
+            Self::Op { op } => Cow::Borrowed(op),
             Self::DoubleQuote => Cow::Borrowed("\""),
             Self::LTStringContent { content } => content,
             Self::SingleSlash => Cow::Borrowed("\\"),
@@ -123,7 +123,7 @@ impl<'src> ConcreteLineToken<'src> {
             Self::Delim { contents } => Cow::Borrowed(contents),
             Self::End => Cow::Borrowed("end"),
             Self::HeredocClose { symbol } => Cow::Owned(symbol),
-            Self::HeredocStart { symbol, .. } => symbol,
+            Self::HeredocStart { symbol, .. } => Cow::Borrowed(symbol),
             // no-op, this is purely semantic information
             // for the render queue
             Self::AfterCallChain | Self::BeginCallChainIndent | Self::EndCallChainIndent => {
@@ -144,10 +144,8 @@ impl<'src> ConcreteLineToken<'src> {
             Delim { contents } => contents.len(),
             Indent { depth } => *depth as usize,
             Keyword { keyword: contents } | ConditionalKeyword { contents } => contents.len(),
-            Op { op: contents }
-            | DirectPart { part: contents }
-            | MethodName { name: contents }
-            | LTStringContent { content: contents } => contents.len(),
+            Op { op } | MethodName { name: op } => op.len(),
+            DirectPart { part: contents } | LTStringContent { content: contents } => contents.len(),
             Comment { contents } | HeredocClose { symbol: contents } => contents.len(),
             HardNewLine | Comma | Space | Dot | OpenSquareBracket | CloseSquareBracket
             | OpenCurlyBracket | CloseCurlyBracket | OpenParen | CloseParen | ParenExprClose
@@ -162,7 +160,7 @@ impl<'src> ConcreteLineToken<'src> {
     fn is_block_closing_token(&self) -> bool {
         match self {
             Self::End | Self::ParenExprClose => true,
-            Self::DirectPart { part } => part == "}" || part == "]" || part == ")",
+            Self::DirectPart { part } => *part == "}" || *part == "]" || *part == ")",
             Self::Delim { contents } => *contents == "}" || *contents == "]" || *contents == ")",
             _ => false,
         }
@@ -172,7 +170,7 @@ impl<'src> ConcreteLineToken<'src> {
         match self {
             Self::ConditionalKeyword { contents } => !(*contents == "else" || *contents == "elsif"),
             Self::Dot | Self::LonelyOperator => false,
-            Self::DirectPart { part } => part != "&.",
+            Self::DirectPart { part } => *part != "&.",
             _ => true,
         }
     }
@@ -189,7 +187,7 @@ impl<'src> ConcreteLineToken<'src> {
         match self {
             Self::HardNewLine => true,
             Self::DirectPart { part } => {
-                if part == "\n" {
+                if *part == "\n" {
                     panic!("shouldn't ever have a single newline direct part");
                 } else {
                     false

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -123,15 +123,8 @@ impl<'src> ParserState<'src> {
         ));
     }
 
-    pub(crate) fn emit_heredoc_start(
-        &mut self,
-        symbol: impl Into<Cow<'src, str>>,
-        kind: HeredocKind,
-    ) {
-        self.push_concrete_token(ConcreteLineToken::HeredocStart {
-            kind,
-            symbol: symbol.into(),
-        });
+    pub(crate) fn emit_heredoc_start(&mut self, symbol: &'src str, kind: HeredocKind) {
+        self.push_concrete_token(ConcreteLineToken::HeredocStart { kind, symbol });
     }
 
     pub(crate) fn emit_heredoc_close(&mut self, symbol: String) {
@@ -416,8 +409,8 @@ impl<'src> ParserState<'src> {
             .merge(comments.apply_spaces(self.spaces_after_last_newline));
     }
 
-    pub(crate) fn emit_op(&mut self, op: impl Into<Cow<'src, str>>) {
-        self.push_concrete_token(ConcreteLineToken::Op { op: op.into() });
+    pub(crate) fn emit_op(&mut self, op: &'src str) {
+        self.push_concrete_token(ConcreteLineToken::Op { op });
     }
 
     pub(crate) fn emit_double_quote(&mut self) {
@@ -435,12 +428,12 @@ impl<'src> ParserState<'src> {
         self.push_concrete_token(ConcreteLineToken::LTStringContent { content });
     }
 
-    pub(crate) fn emit_ident(&mut self, ident: impl Into<Cow<'src, str>>) {
+    pub(crate) fn emit_ident(&mut self, ident: &'src str) {
         self.push_concrete_token(ConcreteLineToken::DirectPart { part: ident.into() });
     }
 
-    pub(crate) fn emit_method_name(&mut self, name: impl Into<Cow<'src, str>>) {
-        self.push_concrete_token(ConcreteLineToken::MethodName { name: name.into() });
+    pub(crate) fn emit_method_name(&mut self, name: &'src str) {
+        self.push_concrete_token(ConcreteLineToken::MethodName { name });
     }
 
     pub(crate) fn emit_newline(&mut self) {
@@ -627,9 +620,9 @@ impl<'src> ParserState<'src> {
         self.emit_conditional_keyword("else");
     }
 
-    pub(crate) fn emit_data(&mut self, data: &str) {
+    pub(crate) fn emit_data(&mut self, data: &'src str) {
         self.push_concrete_token(ConcreteLineToken::DirectPart {
-            part: Cow::Owned(data.to_string()),
+            part: Cow::Borrowed(data),
         })
     }
 


### PR DESCRIPTION
There are several places where we used `Cow`s as a way to handle `String` from ripper and `&str` from Prism, but now that the Ripper implementation is gone, we can convert those to just use `&str` instead.