### PR TITLE
Bump to `v0.12.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "rubyfmt"
-version = "0.11.0-pre"
+version = "0.12.0"
 dependencies = [
  "fancy-regex",
  "log",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "rubyfmt-main"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "rubyfmt-main"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
 edition = "2024"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "rubyfmt-main"
 version = "0.12.0"
-authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
+authors = ["Fable Tales <penelopedotzone@gmail.com>"]
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Penelope Phippen
+Copyright (c) 2019 Fable Tales
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rubyfmt"
 version = "0.12.0"
-authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
+authors = ["Fable Tales <penelopedotzone@gmail.com>"]
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rubyfmt"
-version = "0.11.0-pre"
+version = "0.12.0"
 authors = ["Penelope Phippen <penelopedotzone@gmail.com>"]
 edition = "2024"
 


### PR DESCRIPTION
It's probably 'bout time we cut a release now that we've fully moved over to Prism -- this bumps us to `0.12.0`!