### PR TITLE
Set the bin_name for the CLI to `rubyfmt`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ enum ExecutionError {
 
 /// Rubyfmt CLI
 #[derive(Debug, Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(bin_name = "rubyfmt", author, version, about, long_about = None)]
 struct CommandlineOpts {
     /// Turn on check mode. This outputs diffs of inputs to STDOUT. Will exit non-zero when differences are detected.
     #[clap(short, long)]


### PR DESCRIPTION
This is a _mega nit_ but when you run `rubyfmt -h`, the usage instructions says `Usage: rubyfmt-main` instead of `rubyfmt` because `clap` defaults to the crate name (and we have the binary in `rubyfmt-main` and the library in `rubyfmt`). This sets the CLI's `bin_name` to `rubyfmt` so that it now says

```bash
% cargo run -- -h
Rubyfmt CLI

Usage: rubyfmt [OPTIONS] [include-paths]...
```