### PR TITLE
avoid `write!` for very basic output

### DIFF
--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -310,7 +310,7 @@ impl<'src> RenderQueueWriter<'src> {
 
         for line_token in tokens.into_iter() {
             let s = line_token.into_ruby();
-            write!(writer, "{}", s)?
+            writer.write(s.as_bytes())?;
         }
         Ok(())
     }

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -310,7 +310,7 @@ impl<'src> RenderQueueWriter<'src> {
 
         for line_token in tokens.into_iter() {
             let s = line_token.into_ruby();
-            writer.write(s.as_bytes())?;
+            writer.write_all(s.as_bytes())?;
         }
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,7 +331,7 @@ fn iterate_formatted(opts: &CommandlineOpts, f: FormattingFunc) {
 
 fn puts_stdout(input: &String) {
     io::stdout()
-        .write(input.as_bytes())
+        .write_all(input.as_bytes())
         .expect("Could not write to stdout");
     io::stdout().flush().expect("flush works");
 }
@@ -388,7 +388,7 @@ fn main() {
                             .write(true)
                             .truncate(true)
                             .open(file_path)
-                            .and_then(|mut file| file.write(fmtted.as_bytes()));
+                            .and_then(|mut file| file.write_all(fmtted.as_bytes()));
 
                         match file_write {
                             Ok(_) => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,7 +330,9 @@ fn iterate_formatted(opts: &CommandlineOpts, f: FormattingFunc) {
 }
 
 fn puts_stdout(input: &String) {
-    write!(io::stdout(), "{}", input).expect("Could not write to stdout");
+    io::stdout()
+        .write(input.as_bytes())
+        .expect("Could not write to stdout");
     io::stdout().flush().expect("flush works");
 }
 
@@ -386,7 +388,7 @@ fn main() {
                             .write(true)
                             .truncate(true)
                             .open(file_path)
-                            .and_then(|mut file| write!(file, "{}", fmtted));
+                            .and_then(|mut file| file.write(fmtted.as_bytes()));
 
                         match file_write {
                             Ok(_) => {}


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
I understand using `write!` when things get complicated, but all these places can already use straightforward code.