### PR TITLE
use `extend` when reading @-files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -218,13 +218,7 @@ fn get_command_line_options() -> CommandlineOpts {
             match File::open(file_name) {
                 Ok(file) => {
                     let buf = BufReader::new(file);
-                    let lines: Vec<String> = buf
-                        .lines()
-                        .map(|l| l.expect("Could not parse line"))
-                        .collect();
-                    for line in lines {
-                        expanded_paths.push(line);
-                    }
+                    expanded_paths.extend(buf.lines().map(|l| l.expect("Could not parse line")));
                 }
                 Err(e) => handle_io_error(e, &path, ErrorExit::Exit),
             }


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
🧹 