### PR TITLE
Fix --check mode to exit non-zero on syntax errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -349,8 +349,9 @@ fn main() {
             let text_diffs: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
             let errors_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
 
-            iterate_input_files(&opts, &|(file_path, before)| {
-                match rubyfmt_string(&opts, before) {
+            iterate_input_files(
+                &opts,
+                &|(file_path, before)| match rubyfmt_string(&opts, before) {
                     Ok(None) => {}
                     Ok(Some(fmtted)) => {
                         let diff = TextDiff::from_lines(before, &fmtted);
@@ -361,11 +362,15 @@ fn main() {
                         ));
                     }
                     Err(e) => {
-                        handle_rubyfmt_error(e, &file_path.display().to_string(), ErrorExit::NoExit);
+                        handle_rubyfmt_error(
+                            e,
+                            &file_path.display().to_string(),
+                            ErrorExit::NoExit,
+                        );
                         *errors_count.lock().unwrap() += 1;
                     }
-                }
-            });
+                },
+            );
 
             let all_diffs = text_diffs.lock().unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,16 +347,23 @@ fn main() {
     match opts {
         CommandlineOpts { check: true, .. } => {
             let text_diffs: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+            let errors_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
 
-            iterate_formatted(&opts, &|(file_path, before, after)| match after {
-                None => {}
-                Some(fmtted) => {
-                    let diff = TextDiff::from_lines(before, &fmtted);
-                    let path_string = file_path.to_str().unwrap();
-                    text_diffs.lock().unwrap().push(format!(
-                        "{}",
-                        diff.unified_diff().header(path_string, path_string)
-                    ));
+            iterate_input_files(&opts, &|(file_path, before)| {
+                match rubyfmt_string(&opts, before) {
+                    Ok(None) => {}
+                    Ok(Some(fmtted)) => {
+                        let diff = TextDiff::from_lines(before, &fmtted);
+                        let path_string = file_path.to_str().unwrap();
+                        text_diffs.lock().unwrap().push(format!(
+                            "{}",
+                            diff.unified_diff().header(path_string, path_string)
+                        ));
+                    }
+                    Err(e) => {
+                        handle_rubyfmt_error(e, &file_path.display().to_string(), ErrorExit::NoExit);
+                        *errors_count.lock().unwrap() += 1;
+                    }
                 }
             });
 
@@ -370,7 +377,10 @@ fn main() {
                     diffs_reported += 1
                 }
             }
-            if diffs_reported > 0 {
+            let errors = *errors_count.lock().unwrap();
+            if errors > 0 {
+                exit(rubyfmt::FormatError::SyntaxError as i32);
+            } else if diffs_reported > 0 {
                 exit(rubyfmt::FormatError::DiffDetected as i32);
             } else {
                 exit(0)

--- a/tests/cli_interface_test.rs
+++ b/tests/cli_interface_test.rs
@@ -500,6 +500,46 @@ fn format_input_file_without_changes() {
 }
 
 #[test]
+fn test_check_flag_with_syntax_error() {
+    let mut file = NamedTempFile::new().unwrap();
+    // Use actually invalid Ruby syntax (incomplete def statement)
+    writeln!(file, "def (").unwrap();
+
+    let output = Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .arg(file.path())
+        .arg("--check")
+        .assert()
+        .code(1)
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(
+        stderr.contains("syntax error"),
+        "Expected stderr to contain 'syntax error', got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_check_flag_stdin_with_syntax_error() {
+    let output = Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .arg("--check")
+        .write_stdin("def (")
+        .assert()
+        .code(1)
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(
+        stderr.contains("syntax error"),
+        "Expected stderr to contain 'syntax error', got: {}",
+        stderr
+    );
+}
+
+#[test]
 fn test_format_respects_opt_in_header() {
     let mut file_one = NamedTempFile::new().unwrap();
     writeln!(file_one, "# rubyfmt: true\na 1, 2, 3").unwrap();


### PR DESCRIPTION
Previously, --check would exit with code 0 even when syntax errors were encountered in input files. This changes the check mode to track errors and exit with code 1 (SyntaxError) when any syntax errors occur.

Also adds tests for --check with syntax errors for both file and stdin input.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
