### PR TITLE
Fix multiline rescue exception formatting (#356)

### DIFF
--- a/fixtures/small/rescue_multiline_exceptions_actual.rb
+++ b/fixtures/small/rescue_multiline_exceptions_actual.rb
@@ -24,3 +24,7 @@ end
 begin
 rescue StandardError
 end
+
+begin
+rescue OpenSSL::SSL::SSLError, OpenSSL::SSL::SSLError, OpenSSL::SSL::SSLError, OpenSSL::SSL::SSLError, OpenSSL::SSL::SSLError => exception
+end

--- a/fixtures/small/rescue_multiline_exceptions_actual.rb
+++ b/fixtures/small/rescue_multiline_exceptions_actual.rb
@@ -1,0 +1,26 @@
+begin
+rescue OpenSSL::SSL::SSLError,
+       OpenSSL::SSL::SSLError,
+       OpenSSL::SSL::SSLError,
+       OpenSSL::SSL::SSLError,
+       OpenSSL::SSL::SSLError,
+       OpenSSL::SSL::SSLError,
+       OpenSSL::SSL::SSLError,
+       OpenSSL::SSL::SSLError => exception
+end
+
+begin
+rescue A, B, C => e
+end
+
+begin
+rescue StandardError => e
+end
+
+begin
+rescue A, B
+end
+
+begin
+rescue StandardError
+end

--- a/fixtures/small/rescue_multiline_exceptions_expected.rb
+++ b/fixtures/small/rescue_multiline_exceptions_expected.rb
@@ -24,3 +24,11 @@ end
 begin
 rescue StandardError
 end
+
+begin
+rescue OpenSSL::SSL::SSLError,
+  OpenSSL::SSL::SSLError,
+  OpenSSL::SSL::SSLError,
+  OpenSSL::SSL::SSLError,
+  OpenSSL::SSL::SSLError => exception
+end

--- a/fixtures/small/rescue_multiline_exceptions_expected.rb
+++ b/fixtures/small/rescue_multiline_exceptions_expected.rb
@@ -1,0 +1,26 @@
+begin
+rescue OpenSSL::SSL::SSLError,
+  OpenSSL::SSL::SSLError,
+  OpenSSL::SSL::SSLError,
+  OpenSSL::SSL::SSLError,
+  OpenSSL::SSL::SSLError,
+  OpenSSL::SSL::SSLError,
+  OpenSSL::SSL::SSLError,
+  OpenSSL::SSL::SSLError => exception
+end
+
+begin
+rescue A, B, C => e
+end
+
+begin
+rescue StandardError => e
+end
+
+begin
+rescue A, B
+end
+
+begin
+rescue StandardError
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4632,30 +4632,41 @@ fn format_rescue_node<'src>(ps: &mut ParserState<'src>, rescue_node: prism::Resc
 
     ps.emit_keyword("rescue");
     let exceptions = rescue_node.exceptions();
+    let reference = rescue_node.reference();
     if !exceptions.is_empty() {
         ps.with_start_of_line(false, |ps| {
-            ps.emit_space();
-            format_list_like_thing(
-                ps,
-                exceptions,
-                rescue_node
-                    .exceptions()
-                    .iter()
-                    .last()
-                    .unwrap()
-                    .location()
-                    .end_offset(),
-                true,
-            );
-        });
-    }
+            ps.inline_breakable_of(BreakableDelims::for_binary_op(), |ps| {
+                let exceptions_count = exceptions.len();
+                for (idx, exception) in exceptions.iter().enumerate() {
+                    if idx == 0 {
+                        // First exception: just a space after 'rescue', no indent
+                        ps.emit_space();
+                        format_node(ps, exception);
+                    } else {
+                        // Subsequent exceptions: indent on new line
+                        ps.emit_soft_indent();
+                        format_node(ps, exception);
+                    }
 
-    if let Some(reference) = rescue_node.reference() {
+                    if idx != exceptions_count - 1 {
+                        ps.emit_comma();
+                        ps.emit_soft_newline();
+                    }
+                }
+                if let Some(ref_node) = reference {
+                    ps.emit_space();
+                    ps.emit_op("=>");
+                    ps.emit_space();
+                    format_node(ps, ref_node);
+                }
+            });
+        });
+    } else if let Some(ref_node) = reference {
         ps.emit_space();
         ps.emit_op("=>");
         ps.emit_space();
         ps.with_start_of_line(false, |ps| {
-            format_node(ps, reference);
+            format_node(ps, ref_node);
         });
     }
 


### PR DESCRIPTION
When rescue has many exception types that exceed the line length, format them across multiple lines with proper indentation:

  rescue OpenSSL::SSL::SSLError,
    OpenSSL::SSL::SSLError,
    OpenSSL::SSL::SSLError => exception

Short lists still stay on one line: rescue A, B, C => e

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
