### PR TITLE
speedup `has_comments_in_lines` with binary search

### DIFF
--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -1,4 +1,5 @@
 use memchr::memchr_iter;
+use std::cmp::Ordering;
 
 use crate::comment_block::CommentBlock;
 use crate::parser_state::line_difference_requires_newline;
@@ -186,10 +187,20 @@ impl FileComments {
     }
 
     pub fn has_comments_in_lines(&self, start_line: LineNumber, end_line: LineNumber) -> bool {
-        let line_range = start_line..end_line;
+        // We are essentially inlining `Range::contains` here, but with extra logic for the
+        // case where the line falls outside the range.  Note that since `contains` is
+        // non-inclusive, the greater-than case should be >=, not >.
         self.other_comments
-            .iter()
-            .any(|(ln, _)| line_range.contains(ln))
+            .binary_search_by(|(ln, _)| {
+                if *ln < start_line {
+                    Ordering::Less
+                } else if *ln >= end_line {
+                    Ordering::Greater
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .is_ok()
     }
 
     pub fn has_comment_in_offsets(


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
We don't hit this code very often, but we might as well try to be fast when we do.

This way performs a little bit more work than necessary -- there is probably a smarter way to do this based on binary searching for the start and then the end of the range, and then deciding based on those results, but this way is more elegant.