### PR TITLE
Fix `rubyfmt` name in CLI version output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ enum ExecutionError {
 
 /// Rubyfmt CLI
 #[derive(Debug, Parser)]
-#[clap(bin_name = "rubyfmt", author, version, about, long_about = None)]
+#[clap(name = "rubyfmt", bin_name = "rubyfmt", author, version, about, long_about = None)]
 struct CommandlineOpts {
     /// Turn on check mode. This outputs diffs of inputs to STDOUT. Will exit non-zero when differences are detected.
     #[clap(short, long)]

--- a/tests/cli_interface_test.rs
+++ b/tests/cli_interface_test.rs
@@ -785,3 +785,60 @@ fn test_formats_non_rb_files() {
         .success();
     assert_eq!("a(1, 2, 3)\n", read_to_string(file.path()).unwrap());
 }
+
+#[test]
+fn test_version_uses_rubyfmt_name() {
+    let output = Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .arg("-V")
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.starts_with("rubyfmt "),
+        "Version output should start with 'rubyfmt ', got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("rubyfmt-main"),
+        "Version output should not contain 'rubyfmt-main', got: {stdout}"
+    );
+}
+
+#[test]
+fn test_help_uses_rubyfmt_name() {
+    let output = Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .arg("-h")
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Usage: rubyfmt"),
+        "Help output should contain 'Usage: rubyfmt', got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("rubyfmt-main"),
+        "Help output should not contain 'rubyfmt-main', got: {stdout}"
+    );
+}
+
+#[test]
+fn test_error_uses_rubyfmt_name() {
+    let output = Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .arg("--not-a-real-flag")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("rubyfmt"),
+        "Error output should contain 'rubyfmt', got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("rubyfmt-main"),
+        "Error output should not contain 'rubyfmt-main', got: {stderr}"
+    );
+}


### PR DESCRIPTION
This output is currently using the wrong name:

```bash
% rubyfmt -V
rubyfmt-main 0.12.0
```

In #793, I set the `bin_name` to be `rubyfmt`, but apparently there's a separate clap attribute for the name used by things like the version flag implementation. This sets `name` to also be `rubyfmt` and adds some tests that we properly output `rubyfmt` (and not `rubyfmt-main`) in the cases I could think of where we print it.