### PR TITLE
Update `ignore` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,12 +141,12 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
- "regex-automata 0.3.9",
+ "regex-automata",
  "serde",
 ]
 
@@ -399,7 +399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
  "bit-set",
- "regex-automata 0.4.9",
+ "regex-automata",
  "regex-syntax",
 ]
 
@@ -408,12 +408,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
@@ -435,15 +429,15 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
 dependencies = [
  "aho-corasick",
  "bstr",
- "fnv",
  "log",
- "regex",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -465,17 +459,16 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "ignore"
-version = "0.4.20"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
 dependencies = [
+ "crossbeam-deque",
  "globset",
- "lazy_static",
  "log",
  "memchr",
- "regex",
+ "regex-automata",
  "same-file",
- "thread_local",
  "walkdir",
  "winapi-util",
 ]
@@ -510,12 +503,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -553,12 +540,9 @@ checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -763,15 +747,9 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 
 [[package]]
 name = "regex-automata"
@@ -979,15 +957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
-name = "thread_local"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "tikv-jemalloc-sys"
 version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,12 +1042,11 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 

--- a/tests/cli_interface_test.rs
+++ b/tests/cli_interface_test.rs
@@ -766,6 +766,75 @@ fn test_respects_gitignore() {
     assert_eq!("a 4, 5, 6\n", read_to_string(file_two.path()).unwrap());
 }
 
+// Reproduces https://github.com/BurntSushi/ripgrep/issues/829 for .gitignore
+#[test]
+fn test_respects_gitignore_with_subdirectory_argument() {
+    let dir = tempdir().unwrap();
+    // Fake a git repo
+    create_dir(dir.path().join(".git")).unwrap();
+
+    create_dir(dir.path().join("a")).unwrap();
+    create_dir(dir.path().join("a").join("b")).unwrap();
+
+    // Create a file in a/ (should be formatted)
+    let file_one_path = dir.path().join("a").join("test.rb");
+    fs::write(&file_one_path, "a 1, 2, 3\n").unwrap();
+
+    // Create a file in a/b/ (should be ignored)
+    let file_two_path = dir.path().join("a").join("b").join("test.rb");
+    fs::write(&file_two_path, "a 4, 5, 6\n").unwrap();
+
+    fs::write(dir.path().join(".gitignore"), "/a/b/\n").unwrap();
+
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("-i")
+        .arg("a")
+        .assert()
+        .stdout("")
+        .code(0)
+        .success();
+
+    // a/test.rb should be formatted
+    assert_eq!("a(1, 2, 3)\n", read_to_string(&file_one_path).unwrap());
+    // a/b/test.rb is gitignored
+    assert_eq!("a 4, 5, 6\n", read_to_string(&file_two_path).unwrap());
+}
+
+// Reproduces https://github.com/BurntSushi/ripgrep/issues/829 for .rubyfmtignore
+#[test]
+fn test_respects_rubyfmtignore_with_subdirectory_argument() {
+    let dir = tempdir().unwrap();
+
+    // Create nested directory structure: a/b/
+    create_dir(dir.path().join("a")).unwrap();
+    create_dir(dir.path().join("a").join("b")).unwrap();
+
+    // Create a file in a/ (should be formatted)
+    let file_one_path = dir.path().join("a").join("test.rb");
+    fs::write(&file_one_path, "a 1, 2, 3\n").unwrap();
+
+    // Create a file in a/b/ (should be ignored)
+    let file_two_path = dir.path().join("a").join("b").join("test.rb");
+    fs::write(&file_two_path, "a 4, 5, 6\n").unwrap();
+
+    fs::write(dir.path().join(".rubyfmtignore"), "/a/b/\n").unwrap();
+
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("-i")
+        .arg("a")
+        .assert()
+        .stdout("")
+        .code(0)
+        .success();
+
+    assert_eq!("a(1, 2, 3)\n", read_to_string(&file_one_path).unwrap());
+    assert_eq!("a 4, 5, 6\n", read_to_string(&file_two_path).unwrap());
+}
+
 #[test]
 fn test_formats_non_rb_files() {
     let mut file = tempfile::Builder::new()


### PR DESCRIPTION
https://github.com/BurntSushi/ripgrep/issues/829 causes the same issue in `rubyfmt` but has since been fixed. This adds test cases that fail without updating and pass afterwards, and then updates the crate.