### PR TITLE
Add support for `--stdin-filepath`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 use clap::Parser;
 use ignore::WalkBuilder;
+use ignore::gitignore::GitignoreBuilder;
 use regex::Regex;
 use rubyfmt::init_logger;
 use similar::TextDiff;
@@ -60,6 +61,11 @@ struct CommandlineOpts {
     /// Write files back in place, do not write output to STDOUT.
     #[clap(short, long, name = "in-place")]
     in_place: bool,
+
+    /// When reading from stdin, treat the input as if it were at this path.
+    /// This allows .rubyfmtignore and .gitignore patterns to be applied to stdin input.
+    #[clap(long, name = "stdin-filepath", conflicts_with_all = ["include-paths", "in-place"])]
+    stdin_filepath: Option<String>,
 
     /// Paths for rubyfmt to analyze. By default the output will be printed to STDOUT. See `--in-place` to write files back in-place.
     /// Acceptable paths are:{n}
@@ -190,6 +196,27 @@ fn rubyfmt_string(
 /* Helpers                                            */
 /******************************************************/
 
+/// Check if a path should be ignored based on .gitignore and .rubyfmtignore patterns.
+/// The path should be relative to the current working directory.
+fn is_path_ignored(path: &Path, include_gitignored: bool) -> bool {
+    let cwd = std::env::current_dir().unwrap();
+    let mut builder = GitignoreBuilder::new(&cwd);
+
+    if !include_gitignored {
+        builder.add(".gitignore");
+    }
+    builder.add(".rubyfmtignore");
+
+    if let Ok(gitignore) = builder.build() {
+        let is_dir = path.is_dir();
+        gitignore
+            .matched_path_or_any_parents(path, is_dir)
+            .is_ignore()
+    } else {
+        false
+    }
+}
+
 fn file_walker_builder(include_paths: Vec<&String>, include_gitignored: bool) -> WalkBuilder {
     // WalkBuilder does not have an API for adding multiple inputs.
     // Must pass the first input to the constructor, and the tail afterwards.
@@ -249,7 +276,22 @@ fn iterate_input_files(opts: &CommandlineOpts, f: &dyn Fn((&Path, &String))) {
         io::stdin()
             .read_to_string(&mut buffer)
             .expect("reading from stdin to not fail");
-        f((Path::new("stdin"), &buffer))
+
+        let path = if let Some(stdin_filepath) = &opts.stdin_filepath {
+            let path = Path::new(stdin_filepath);
+            if is_path_ignored(path, opts.include_gitignored) {
+                // Print unchanged output for ignored files unless we're in check mode
+                if !opts.check {
+                    puts_stdout(&buffer);
+                }
+                return;
+            }
+            path
+        } else {
+            Path::new("stdin")
+        };
+
+        f((path, &buffer))
     } else {
         let mut file_paths = Vec::new();
         let mut dir_paths = Vec::new();

--- a/tests/cli_interface_test.rs
+++ b/tests/cli_interface_test.rs
@@ -911,3 +911,246 @@ fn test_error_uses_rubyfmt_name() {
         "Error output should not contain 'rubyfmt-main', got: {stderr}"
     );
 }
+
+#[test]
+fn test_stdin_filepath_respects_rubyfmtignore() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".rubyfmtignore"), "ignored.rb").unwrap();
+
+    // File matching .rubyfmtignore pattern should not be formatted, but output unchanged
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--stdin-filepath")
+        .arg("ignored.rb")
+        .write_stdin("a 1,2,3")
+        .assert()
+        .stdout("a 1,2,3")
+        .code(0)
+        .success();
+
+    // File not matching .rubyfmtignore pattern should be formatted
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--stdin-filepath")
+        .arg("not_ignored.rb")
+        .write_stdin("a 1,2,3")
+        .assert()
+        .stdout("a(1, 2, 3)\n")
+        .code(0)
+        .success();
+}
+
+#[test]
+fn test_stdin_filepath_respects_gitignore() {
+    let dir = tempdir().unwrap();
+    // Fake a git repo
+    create_dir(dir.path().join(".git")).unwrap();
+    fs::write(dir.path().join(".gitignore"), "ignored.rb").unwrap();
+
+    // File matching .gitignore pattern should not be formatted, but output unchanged
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--stdin-filepath")
+        .arg("ignored.rb")
+        .write_stdin("a 1,2,3")
+        .assert()
+        .stdout("a 1,2,3")
+        .code(0)
+        .success();
+
+    // File matching .gitignore but with --include-gitignored should be formatted
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--stdin-filepath")
+        .arg("ignored.rb")
+        .arg("--include-gitignored")
+        .write_stdin("a 1,2,3")
+        .assert()
+        .stdout("a(1, 2, 3)\n")
+        .code(0)
+        .success();
+}
+
+#[test]
+fn test_stdin_filepath_uses_path_in_check_output() {
+    let dir = tempdir().unwrap();
+
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--check")
+        .arg("--stdin-filepath")
+        .arg("lib/foo.rb")
+        .write_stdin("a 1,2,3\n")
+        .assert()
+        .stdout(
+            "--- lib/foo.rb
++++ lib/foo.rb
+@@ -1 +1 @@
+-a 1,2,3
++a(1, 2, 3)
+",
+        )
+        .code(5)
+        .failure();
+}
+
+#[test]
+fn test_stdin_filepath_respects_rubyfmtignore_directory_pattern() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".rubyfmtignore"), "ignored/").unwrap();
+
+    // File in ignored directory should not be formatted, but output unchanged
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--stdin-filepath")
+        .arg("ignored/foo.rb")
+        .write_stdin("a 1,2,3")
+        .assert()
+        .stdout("a 1,2,3")
+        .code(0)
+        .success();
+
+    // File not in ignored directory should be formatted
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--stdin-filepath")
+        .arg("not_ignored/foo.rb")
+        .write_stdin("a 1,2,3")
+        .assert()
+        .stdout("a(1, 2, 3)\n")
+        .code(0)
+        .success();
+}
+
+#[test]
+fn test_stdin_filepath_respects_gitignore_directory_pattern() {
+    let dir = tempdir().unwrap();
+    create_dir(dir.path().join(".git")).unwrap();
+    fs::write(dir.path().join(".gitignore"), "ignored/").unwrap();
+
+    // File in ignored directory should not be formatted, but output unchanged
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--stdin-filepath")
+        .arg("ignored/foo.rb")
+        .write_stdin("a 1,2,3")
+        .assert()
+        .stdout("a 1,2,3")
+        .code(0)
+        .success();
+
+    // File in ignored directory with --include-gitignored should be formatted
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--stdin-filepath")
+        .arg("ignored/foo.rb")
+        .arg("--include-gitignored")
+        .write_stdin("a 1,2,3")
+        .assert()
+        .stdout("a(1, 2, 3)\n")
+        .code(0)
+        .success();
+}
+
+#[test]
+fn test_stdin_filepath_check_mode_ignored_file() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".rubyfmtignore"), "ignored.rb").unwrap();
+
+    // Check mode with ignored file should produce no output and exit 0
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--check")
+        .arg("--stdin-filepath")
+        .arg("ignored.rb")
+        .write_stdin("a 1,2,3")
+        .assert()
+        .stdout("")
+        .code(0)
+        .success();
+}
+
+#[test]
+fn test_stdin_filepath_conflicts_with_file_paths() {
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(file, "a 1,2,3").unwrap();
+
+    let output = Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .arg("--stdin-filepath")
+        .arg("lib/foo.rb")
+        .arg(file.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--stdin-filepath") && stderr.contains("cannot be used with"),
+        "Expected error about --stdin-filepath conflict, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_stdin_filepath_conflicts_with_in_place() {
+    let output = Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .arg("--stdin-filepath")
+        .arg("lib/foo.rb")
+        .arg("-i")
+        .write_stdin("a 1,2,3")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--stdin-filepath") && stderr.contains("cannot be used with"),
+        "Expected error about --stdin-filepath conflict with -i, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_explicit_file_path_ignores_rubyfmtignore() {
+    // When a file is passed explicitly (not via directory traversal),
+    // ignore patterns should not apply - the user explicitly asked for this file.
+    let dir = tempdir().unwrap();
+
+    let mut file = tempfile::Builder::new()
+        .prefix("rubyfmt")
+        .suffix(".rb")
+        .tempfile_in(dir.path())
+        .unwrap();
+    writeln!(file, "a 1,2,3").unwrap();
+
+    fs::write(
+        dir.path().join(".rubyfmtignore"),
+        file.path().file_name().unwrap().to_str().unwrap(),
+    )
+    .unwrap();
+
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("-i")
+        .arg(file.path())
+        .assert()
+        .stdout("")
+        .code(0)
+        .success();
+
+    // File should be formatted despite being in .rubyfmtignore
+    assert_eq!("a(1, 2, 3)\n", read_to_string(file.path()).unwrap());
+}


### PR DESCRIPTION
Closes #365 

This adds support for the equivalent of [prettier's `--stdin-filepath`](https://prettier.io/docs/options.html#file-path). This would be valuable for things like VSCode extensions to properly support `.gitignore`/`.rubyfmtignore` files, which currently aren't heavily used but could be valuable in the future, since currently some ignores are kinda [shoehorned into extensions like Sorbet](https://github.com/sorbet/sorbet/blob/d68b882e70217f396c5d9f6091cd9951b87a371f/main/lsp/requests/document_formatting.cc#L88-L90) that could use this instead.

Also just to call this out, `--stdin-filepath` matches [what prettier does](https://github.com/prettier/prettier/pull/3618/changes#diff-a1489d380e2e3986584e73d3f58312a0cb45e28853116312abc1d801474bd6b3R246-R249) where if the stdin-filepath is ignored, it still prints the original contents back to stdout. This is because I think editor integrations is primarily the place where you would use this, and returning `""` would probably remove the whole file contents.