### PR TITLE
Reorganize the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A fast, opinionated Ruby formatter written in Rust.
 
 - Try it online → [rubyfmt.run](https://rubyfmt.run)
 
+Pronunciation: (en) "Ruby Format", (jp) ルビーフォーマット
+
 ## Quick Start
 
 ```bash
@@ -158,10 +160,3 @@ Please check out our [contributing guide](./CONTRIBUTING.md).
 
 The original author (fables-tales) is no longer working on open source in their spare time.
 Other contributors work regularly on `rubyfmt`, and contributors with commit access are welcome to merge changes that pass CI.
-
-## FAQ
-
-**How do I pronounce rubyfmt?**
-
-- en: Ruby format
-- jp: ルビーフォーマット

--- a/README.md
+++ b/README.md
@@ -1,112 +1,167 @@
-# How do I pronounce `rubyfmt`
-* en: Ruby format
-* jp: ルビーフォーマット
+# rubyfmt
 
-## Maintenance policy
+A fast, opinionated Ruby formatter written in Rust.
 
-* I (fables-tales) am no longer working in spare time on open source
-* Folks who have commit bits are free to merge anything they'd like as long as it passes CI
-* I review important patches for my day job at request of a co-worker
+- Try it online → [rubyfmt.run](https://rubyfmt.run)
 
-## How do I use it
+## Quick Start
 
+```bash
+# Install
+brew install rubyfmt
 
-### Install from `brew`
+# Format a file in place
+rubyfmt -i myfile.rb
 
-On Mac and Linux, `rubyfmt` can be installed with [Homebrew](https://brew.sh/):
+# Format and print to stdout
+rubyfmt myfile.rb
+```
+
+## Installation
+
+### Homebrew
 
 ```bash
 brew install rubyfmt
 ```
 
-### Build from source
+### Build from Source
 
-1. Make sure you've got cargo installed
-2. Run `make all`
-3. Copy target/release/rubyfmt-main to somewhere on your path as `rubyfmt`
+1. Make sure you have Cargo installed
+2. Run `cargo build --release`
+3. Copy `target/release/rubyfmt-main` to somewhere on your path as `rubyfmt`
 
-Rubyfmt supports the following CLI invocations:
+## Usage
 
-* `<whatever> | rubyfmt` pipe from standard in
-* `rubyfmt -i -- files or directories` to format files and directories in place
-* `rubyfmt -- files or directories` output rubyfmtted code to STDOUT.
-* `rubyfmt -c -- files or directories` output a diff of input and rubyformatted input.
-* `rubyfmt --header-opt-in -- files or directories` to format files only with a `# rubyfmt: true` comment at the top of the file
-* `rubyfmt --header-opt-out -- files or directories` to skip formatting files with a `# rubyfmt: false` comment at the top of the file
+### Command Line
 
-`rubyfmt` also supports ignoring files with a `.rubyfmtignore` file when present in the root of the working directory.
-`.rubyfmtignore` uses the same syntax as `.gitignore`, so you can choose to ignore whole directories or use globs as needed.
-By default, `rubyfmt` also ignores files in `.gitignore` during file traversal, but you can force these files to be formatted by using the `--include-gitignored` flag.
+| Command                  | Description                     |
+| ------------------------ | ------------------------------- |
+| `rubyfmt file.rb`        | Output formatted code to stdout |
+| `rubyfmt -i file.rb`     | Format file in place            |
+| `rubyfmt -c file.rb`     | Show diff of changes            |
+| `cat file.rb \| rubyfmt` | Read from stdin                 |
 
-## Editor Support
+You can also pass directories to format multiple files at once.
 
-### Vim
+For the full command line interface, see `rubyfmt --help`.
 
-We aren't currently tested with any vim plugin managers, however, adding the
-plugin from a git clone is fairly easy:
+### Header Comments
 
-* Run `cargo build --release`
-* Add `source /path/to/rubyfmt.vim` to your `~/.vimrc` (e.g. [my dotfiles](https://github.com/penelopezone/dotfiles/commit/2c0e9c1215de368e64e063021e9523aa349c5454#diff-2152fa38b4d8bb10c75d6339a959650dR253) please note, this line is commented)
-* Add `let g:rubyfmt_path = /path/to/target/release/rubyfmt-main` beneath the source line
+Control formatting on a per-file basis with header comments:
 
-### Neovim + LSP + null-ls
+- `rubyfmt --header-opt-in` - Only format files with `# rubyfmt: true` at the top
+- `rubyfmt --header-opt-out` - Skip files with `# rubyfmt: false` at the top
 
-If you use the popular [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) LSP plugin to manage formatters, it supports `rubyfmt` out of the box. You can add the formatter to your existing `setup()` configuration:
+### Ignoring Files
 
-```diff
-local null_ls = require("null-ls")
+Create a `.rubyfmtignore` file in your project root to exclude files from formatting. It uses the same syntax as `.gitignore`.
 
+By default, rubyfmt also respects your `.gitignore`. Use `--include-gitignored` to format those files anyway.
+
+## Editor Integration
+
+### Visual Studio Code
+
+The popular [`ruby-lsp` extension](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp) has a [rubyfmt add-on](https://github.com/reese/ruby-lsp-rubyfmt-formatter). Install the extension:
+
+```bash
+# Add to project
+bundle add ruby-lsp-rubyfmt-formatter --group development
+
+# Install globally
+gem install ruby-lsp-rubyfmt-formatter
+```
+
+And then add the following to your `.vscode/settings.json`:
+
+```json
+{
+  "[ruby]": {
+    "editor.defaultFormatter": "Shopify.ruby-lsp",
+    "editor.formatOnSave": true
+  },
+  "rubyLsp.formatter": "rubyfmt"
+}
+```
+
+Rubyfmt is also supported by the (now-deprecated) [VSCode Ruby extension](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby). Add the following to your `settings.json`:
+
+```json
+{
+  "ruby.useLanguageServer": true,
+  "ruby.format": "rubyfmt",
+  "[ruby]": {
+    "editor.formatOnSave": true
+  }
+}
+```
+
+### Neovim + null-ls
+
+The [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) plugin supports rubyfmt out of the box:
+
+```lua
 null_ls.setup({
   sources = {
-+   null_ls.builtins.formatting.rubyfmt,
+    null_ls.builtins.formatting.rubyfmt,
   },
 })
 ```
 
-Read more in the [null-ls documentation](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md#rubyfmt).
+See the [null-ls documentation](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md#rubyfmt) for more details.
 
-### Visual Studio Code
+### Vim
 
-Rubyfmt is a supported formatter in the popular
-[vscode ruby extension](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby).
-You should copy `rubyfmt-main` to be called `rubyfmt` on your PATH .
-Once installed, add the following to vscode's `settings.json` file:
+1. Run `cargo build --release`
+2. Add `source /path/to/rubyfmt.vim` to your `~/.vimrc`
+3. Add `let g:rubyfmt_path = /path/to/target/release/rubyfmt-main` beneath the source line
 
-``` json
-  "ruby.useLanguageServer": true,
-  "ruby.format": "rubyfmt",
-  "[ruby]": {
-      "editor.formatOnSave": true
-  },
-```
+### RubyMine (and JetBrains IDEs)
 
-### RubyMine (and similar Jetbrains family IDE)
+1. Install the [File Watchers plugin](https://www.jetbrains.com/help/ruby/settings-tools-file-watchers.html)
+2. Go to File | Settings | Tools | File Watchers
+3. Import `watchers.xml` from `editor_plugins/rubymine/`
+4. Optionally set Level to Global for all projects
 
-[Install](https://www.jetbrains.com/help/ruby/settings-tools-file-watchers.html) the File Watchers plugin and go to `File | Settings | Tools | File Watchers`. Now import `watchers.xml` from `editor_plugins/rubymine/`. Optionally set `Level` to `Global` to have it available across all projects.
-
-See [this reference](https://www.jetbrains.com/help/ruby/using-file-watchers.html#ws_filewatcher_type_and_location_of_input_files) on using file watchers to learn more.
+See the [File Watchers documentation](https://www.jetbrains.com/help/ruby/using-file-watchers.html#ws_filewatcher_type_and_location_of_input_files) for more details.
 
 ### Sublime Text
 
-Install the [rubyfmt plugin](https://github.com/toreriklinnerud/sublime-rubyfmt/) from [Package Control](https://packagecontrol.io): Install Package -> rubyfmt.
+Install the [rubyfmt plugin](https://github.com/toreriklinnerud/sublime-rubyfmt/) via Package Control.
 
-Ruby files are formatted on save or by pressing `Alt + ;` or on macOS: `Cmd + ;`. `rubyfmt` is assumed to be on path.
+Files format on save or with `Cmd + ;` (macOS) / `Alt + ;` (other). Settings:
 
-Overridable default settings:
- ``` json
- {
-   "ruby_executable": "ruby",
-   "rubyfmt_executable": "rubyfmt",
-   "format_on_save": true,
- }
- ```
+```json
+{
+  "ruby_executable": "ruby",
+  "rubyfmt_executable": "rubyfmt",
+  "format_on_save": true
+}
+```
 
- ### Atom
+### Atom
 
 Install the [rubyfmt package](https://github.com/toreriklinnerud/atom-rubyfmt/) from Settings > Packages.
 
-Ruby files are formatted on save or by pressing `Alt + ;` or on macOS: `Cmd + ;` `rubyfmt` is assumed to be on path. See the package settings for more options.
+Files format on save or with `Cmd + ;` (macOS) / `Alt + ;` (other).
+
+## Rubocop
+
+For usage with Rubocop, see the [rubocop-rubyfmt](https://github.com/reese/rubocop-rubyfmt) gem.
 
 ## Contributing
 
-Please checkout [our contributing guide](./CONTRIBUTING.md)
+Please check out our [contributing guide](./CONTRIBUTING.md).
+
+## Maintenance Status
+
+The original author (fables-tales) is no longer working on open source in their spare time.
+Other contributors work regularly on `rubyfmt`, and contributors with commit access are welcome to merge changes that pass CI.
+
+## FAQ
+
+**How do I pronounce rubyfmt?**
+
+- en: Ruby format
+- jp: ルビーフォーマット


### PR DESCRIPTION
This rearranges the README to be more friendly to folks who don't already know what `rubyfmt` is. It leads with a one-liner about what it does, a link to rubyfmt.run to see it in action, and then tells them how to install and run it. It also updates the CLI flag docs in a bit more of a structured table format with separate sections for the different ignore mechanisms (headers and `.rubyfmtignore`/`.gitignore`).

The editor integrations are largely the same, though I did add a section for a `ruby-lsp` plugin since the old Ruby VSCode extension is now deprecated. I also put in a section on Rubocop since there were several open issues about it. (The ruby-lsp add-on and the rubocop-rubyfmt gem mentioned are mine, just plugging them since it doesn't seem like other community options exist/still work for these two cases.)

I also kept the pronunciation / maintenance policy here but just moved them to the bottom -- they're helpful to have, but not the first thing users need to see.
