### PR TITLE
Fix `break` multilining

### DIFF
--- a/fixtures/small/breaks_actual.rb
+++ b/fixtures/small/breaks_actual.rb
@@ -12,4 +12,9 @@ loop do
       attemptes: off_reservation_payment.attempts + 1
     )
   ]
+  break([
+    off_reservation_payment,
+    payment_intent_mode,
+    Return.new(outcome: Outcome::Succeeded, attemptes: off_reservation_payment.attempts + 1)
+  ])
 end

--- a/fixtures/small/breaks_actual.rb
+++ b/fixtures/small/breaks_actual.rb
@@ -1,4 +1,6 @@
 loop do
   break no
   break
+  break Some::Very::Long::Thing::That::Will::Extend::Over::Multiple::Lines::And::Never::Ends.await_result(workflow_id: workflow_id)
+  break Some::Very::Long::Thing::That::Will::Extend::Over::Multiple::Lines::And::Never::Ends.await_result(workflow_id: workflow_id), with_a_second_value
 end

--- a/fixtures/small/breaks_actual.rb
+++ b/fixtures/small/breaks_actual.rb
@@ -3,4 +3,13 @@ loop do
   break
   break Some::Very::Long::Thing::That::Will::Extend::Over::Multiple::Lines::And::Never::Ends.await_result(workflow_id: workflow_id)
   break Some::Very::Long::Thing::That::Will::Extend::Over::Multiple::Lines::And::Never::Ends.await_result(workflow_id: workflow_id), with_a_second_value
+  break [off_reservation_payment, payment_intent_mode, Return.new(outcome: Outcome::Succeeded, attemptes: off_reservation_payment.attempts + 1)]
+  break [
+    off_reservation_payment,
+    payment_intent_mode,
+    Return.new(
+      outcome: Outcome::Succeeded,
+      attemptes: off_reservation_payment.attempts + 1
+    )
+  ]
 end

--- a/fixtures/small/breaks_expected.rb
+++ b/fixtures/small/breaks_expected.rb
@@ -7,4 +7,17 @@ loop do
   break Some::Very::Long::Thing::That::Will::Extend::Over::Multiple::Lines::And::Never::Ends.await_result(
     workflow_id: workflow_id
   ), with_a_second_value
+  break [
+    off_reservation_payment,
+    payment_intent_mode,
+    Return.new(outcome: Outcome::Succeeded, attemptes: off_reservation_payment.attempts + 1)
+  ]
+  break [
+    off_reservation_payment,
+    payment_intent_mode,
+    Return.new(
+      outcome: Outcome::Succeeded,
+      attemptes: off_reservation_payment.attempts + 1
+    )
+  ]
 end

--- a/fixtures/small/breaks_expected.rb
+++ b/fixtures/small/breaks_expected.rb
@@ -20,4 +20,9 @@ loop do
       attemptes: off_reservation_payment.attempts + 1
     )
   ]
+  break ([
+    off_reservation_payment,
+    payment_intent_mode,
+    Return.new(outcome: Outcome::Succeeded, attemptes: off_reservation_payment.attempts + 1)
+  ])
 end

--- a/fixtures/small/breaks_expected.rb
+++ b/fixtures/small/breaks_expected.rb
@@ -1,4 +1,10 @@
 loop do
   break no
   break
+  break Some::Very::Long::Thing::That::Will::Extend::Over::Multiple::Lines::And::Never::Ends.await_result(
+    workflow_id: workflow_id
+  )
+  break Some::Very::Long::Thing::That::Will::Extend::Over::Multiple::Lines::And::Never::Ends.await_result(
+    workflow_id: workflow_id
+  ), with_a_second_value
 end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -552,9 +552,11 @@ fn format_break_node<'src>(ps: &mut ParserState<'src>, break_node: prism::BreakN
     ps.emit_ident("break");
     if let Some(arguments_node) = break_node.arguments() {
         ps.with_start_of_line(false, |ps| {
-            ps.breakable_of(BreakableDelims::for_kw(), |ps| {
-                format_arguments_node(ps, arguments_node);
-            });
+            let arguments = arguments_node.arguments();
+            let end_offset = arguments.last().unwrap().location().end_offset();
+
+            ps.emit_space();
+            format_list_like_thing(ps, arguments, end_offset, true);
         });
     }
 }


### PR DESCRIPTION
Closes #806 

`break` in the grammar does not support being called with parens, so our multiline strategy is currently incorrect. I'm open to bikeshedding about how this should look (see the discussion in #806) but for the sake of un-breaking this, this PR formats multiline `break` calls the way we did historically, which is using `format_list_like_thing(... single_line: true)`.