### PR TITLE
fix spelling error in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -9,7 +9,7 @@ Hi there! Thanks for taking the time to file an issue against rubyfmt!
 To make filling out this form faster:
 
 1. Create a program showing the bug on https://rubyfmt.run
-3. Click "Gihub" in the header, then "Create issue with example" in the dropdown menu
+3. Click "GitHub" in the header, then "Create issue with example" in the dropdown menu
 
 This will pre-populate most of the form below.
 


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Like the subject says.  The capitalization here follows the button on `rubyfmt.run`.