### PR TITLE
don't unwrap parenthesized assignments in calls

### DIFF
--- a/fixtures/small/paren_expr_unwrap_actual.rb
+++ b/fixtures/small/paren_expr_unwrap_actual.rb
@@ -37,3 +37,9 @@ foo (1..10)
 
 # Ternary without keywords
 foo (condition ? a : b)
+
+# Assignments we leave alone, for consistency with code like:
+#
+# if (var = thing)
+foo ((var = thing))
+foo(1, (var2 = thing))

--- a/fixtures/small/paren_expr_unwrap_expected.rb
+++ b/fixtures/small/paren_expr_unwrap_expected.rb
@@ -37,3 +37,9 @@ foo(1..10)
 
 # Ternary without keywords
 foo(condition ? a : b)
+
+# Assignments we leave alone, for consistency with code like:
+#
+# if (var = thing)
+foo((var = thing))
+foo(1, (var2 = thing))

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4943,6 +4943,9 @@ fn is_keyword_expression(node: &prism::Node) -> bool {
         Node::BeginNode { .. } => true,
         // For completeness: other control flow that shouldn't be unwrapped
         Node::ForNode { .. } => true,
+        // Assignments to local variables can be left wrapped for consistency with
+        // wrapping assignments in `if` conditions and the like.
+        Node::LocalVariableWriteNode { .. } => true,
         _ => false,
     }
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Rubocop's `Lint/AssignmentInCondition` checks for code like:

```ruby
if var = thing
  # stuff
end
```

and complains at you.  A common way to work around this is to wrap the assignment in parens, like so:

```ruby
if (var = thing)
  # stuff
end
```

which indicates that, yes, I really mean to do this assignment here and I know what I'm doing.

(This is also a technique used in C/C++/etc.)

Stripe has a similar lint, but it checks for assignments in method call arguments:

```ruby
foo(var = thing)
```

would be disallowed.  Similarly to the above cop, wrapping the assignment in parens is the workaround:

```ruby
foo((var = thing))
```

This was allowed by the ripper implementation (accidentally?) -- i.e the parens were not removed -- and I think it is reasonable to do the same in the prism implementation.