### PR TITLE
Render paren expressions as breakables when multinable

### DIFF
--- a/fixtures/small/paren_expr_breakable_actual.rb
+++ b/fixtures/small/paren_expr_breakable_actual.rb
@@ -1,0 +1,33 @@
+# Modifier if that becomes block if due to line length (the original idempotency bug)
+{
+  descendent_members: (team[:descendant_members].map { |v| self.trim_person } if team[:descendant_members]
+    .present?)
+}
+
+# Similar case with unless
+{
+  filtered_items: (collection[:items].select { |item| item.valid? && item.active? } unless collection[:items]
+    .empty?)
+}
+
+# Already block form should stay the same
+(
+  if condition
+    result
+  end
+)
+
+# Block unless
+(
+  unless skip?
+    do_something
+  end
+)
+
+# Case expression in parens
+(case status
+  when :active
+    handle_active
+  when :pending
+    handle_pending
+  end)

--- a/fixtures/small/paren_expr_breakable_expected.rb
+++ b/fixtures/small/paren_expr_breakable_expected.rb
@@ -1,0 +1,43 @@
+# Modifier if that becomes block if due to line length (the original idempotency bug)
+{
+  descendent_members: (
+    if team[:descendant_members]
+        .present?
+      team[:descendant_members].map { |v| self.trim_person }
+    end
+  )
+}
+
+# Similar case with unless
+{
+  filtered_items: (
+    unless collection[:items]
+        .empty?
+      collection[:items].select { |item| item.valid? && item.active? }
+    end
+  )
+}
+
+# Already block form should stay the same
+(
+  if condition
+    result
+  end
+)
+
+# Block unless
+(
+  unless skip?
+    do_something
+  end
+)
+
+# Case expression in parens
+(
+  case status
+  when :active
+    handle_active
+  when :pending
+    handle_pending
+  end
+)

--- a/librubyfmt/src/delimiters.rs
+++ b/librubyfmt/src/delimiters.rs
@@ -82,6 +82,13 @@ impl BreakableDelims {
         }
     }
 
+    pub fn for_parens() -> Self {
+        BreakableDelims {
+            single_line: DelimiterPair::new("(", ")"),
+            multi_line: DelimiterPair::new("(", ")"),
+        }
+    }
+
     pub fn single_line_open<'src>(&self) -> ConcreteLineToken<'src> {
         ConcreteLineToken::Delim {
             contents: self.single_line.open,

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2995,21 +2995,19 @@ fn format_array_pattern_node<'src>(
     });
 }
 
-/// Returns true if a node is inherently multiline (like case, begin, def, class, etc.)
-/// Note: Modifier forms (if/unless/while/until without `end`) are NOT multiline.
-fn is_multiline_node(node: &prism::Node) -> bool {
+/// Returns true if a node could potentially be rendered as multiline.
+fn is_multilinable_node(node: &prism::Node) -> bool {
     use prism::Node;
     match node {
         // Case and begin are always multiline
         Node::CaseNode { .. } | Node::CaseMatchNode { .. } | Node::BeginNode { .. } => true,
-        // If/unless are multiline only if they have an `end` keyword (not modifier form)
+        // `unless` may be converted to block form
+        Node::UnlessNode { .. } => true,
+        // If may be converted to block form (if it's not a ternary)
         Node::IfNode { .. } => {
             let if_node = node.as_if_node().unwrap();
-            if_node.end_keyword_loc().is_some()
-        }
-        Node::UnlessNode { .. } => {
-            let unless_node = node.as_unless_node().unwrap();
-            unless_node.end_keyword_loc().is_some()
+            // Ternary operators (no if_keyword_loc) are NOT multilinable
+            if_node.if_keyword_loc().is_some()
         }
         // While/until are multiline only if they have an `end` keyword (not modifier form)
         Node::WhileNode { .. } => {
@@ -3033,16 +3031,13 @@ fn format_parentheses_node<'src>(
     ps: &mut ParserState<'src>,
     parentheses_node: prism::ParenthesesNode<'src>,
 ) {
-    ps.emit_open_paren();
-
-    let is_multiline = if let Some(body) = parentheses_node.body() {
+    let is_multilinable = if let Some(body) = parentheses_node.body() {
         if let Some(statements_node) = body.as_statements_node() {
-            // Multiline if multiple statements OR if single statement is inherently multiline
             statements_node.body().len() > 1
                 || statements_node
                     .body()
                     .first()
-                    .is_some_and(|node| is_multiline_node(&node))
+                    .is_some_and(|node| is_multilinable_node(&node))
         } else {
             true
         }
@@ -3050,43 +3045,45 @@ fn format_parentheses_node<'src>(
         false
     };
 
-    if let Some(body) = parentheses_node.body() {
+    if is_multilinable {
         ps.with_start_of_line(false, |ps| {
-            if let Some(statements_node) = body.as_statements_node() {
-                let single_inline = statements_node.body().len() == 1
-                    && !statements_node
-                        .body()
-                        .first()
-                        .is_some_and(|node| is_multiline_node(&node));
-                if single_inline {
-                    ps.with_start_of_line(false, |ps| {
-                        format_node(ps, statements_node.body().first().unwrap())
-                    });
-                } else {
-                    ps.emit_newline();
-                    ps.new_block(|ps| {
-                        ps.with_start_of_line(true, |ps| {
+            ps.breakable_of(BreakableDelims::for_parens(), |ps| {
+                if let Some(body) = parentheses_node.body() {
+                    if let Some(statements_node) = body.as_statements_node() {
+                        let statements = statements_node.body();
+                        for (idx, stmt) in statements.iter().enumerate() {
+                            ps.emit_soft_indent();
+                            ps.with_start_of_line(false, |ps| {
+                                format_node(ps, stmt);
+                            });
+                            if idx < statements.len() - 1 {
+                                ps.emit_soft_newline();
+                            }
+                        }
+                    } else {
+                        // I'm *pretty* sure this should always be a StatementsNode, but this is here
+                        // just to be defensive
+                        ps.emit_soft_indent();
+                        ps.with_start_of_line(false, |ps| {
                             format_node(ps, body);
                         });
-                    });
+                    }
                 }
-            } else {
-                // I'm *pretty* sure this should always be a StatementsNode, but this is here
-                // just to be defensive
-                ps.emit_newline();
-                ps.new_block(|ps| {
-                    ps.with_start_of_line(true, |ps| {
-                        format_node(ps, body);
-                    });
-                });
-            }
+            });
         });
-    }
-
-    if is_multiline {
-        ps.emit_indent();
-        ps.emit_paren_expr_close();
     } else {
+        ps.emit_open_paren();
+        if let Some(body) = parentheses_node.body() {
+            ps.with_start_of_line(false, |ps| {
+                if let Some(statements_node) = body.as_statements_node() {
+                    if let Some(stmt) = statements_node.body().first() {
+                        format_node(ps, stmt);
+                    }
+                } else {
+                    format_node(ps, body);
+                }
+            });
+        }
         ps.emit_close_paren();
     }
 }

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -60,7 +60,6 @@ pub enum ConcreteLineToken<'src> {
     CloseCurlyBracket,
     OpenParen,
     CloseParen,
-    ParenExprClose,
     Op {
         op: &'src str,
     },
@@ -114,7 +113,7 @@ impl<'src> ConcreteLineToken<'src> {
             Self::OpenCurlyBracket => Cow::Borrowed("{"),
             Self::CloseCurlyBracket => Cow::Borrowed("}"),
             Self::OpenParen => Cow::Borrowed("("),
-            Self::CloseParen | Self::ParenExprClose => Cow::Borrowed(")"),
+            Self::CloseParen => Cow::Borrowed(")"),
             Self::Op { op } => Cow::Borrowed(op),
             Self::DoubleQuote => Cow::Borrowed("\""),
             Self::LTStringContent { content } => content,
@@ -148,8 +147,8 @@ impl<'src> ConcreteLineToken<'src> {
             DirectPart { part: contents } | LTStringContent { content: contents } => contents.len(),
             Comment { contents } | HeredocClose { symbol: contents } => contents.len(),
             HardNewLine | Comma | Space | Dot | OpenSquareBracket | CloseSquareBracket
-            | OpenCurlyBracket | CloseCurlyBracket | OpenParen | CloseParen | ParenExprClose
-            | SingleSlash | DoubleQuote => 1,
+            | OpenCurlyBracket | CloseCurlyBracket | OpenParen | CloseParen | SingleSlash
+            | DoubleQuote => 1,
             DoKeyword | CommaSpace | LonelyOperator | ColonColon => 2,
             DefKeyword | End => 3, // "def"/"..."/"end"
             ClassKeyword => 5,     // "class"
@@ -159,7 +158,7 @@ impl<'src> ConcreteLineToken<'src> {
 
     fn is_block_closing_token(&self) -> bool {
         match self {
-            Self::End | Self::ParenExprClose => true,
+            Self::End => true,
             Self::DirectPart { part } => *part == "}" || *part == "]" || *part == ")",
             Self::Delim { contents } => *contents == "}" || *contents == "]" || *contents == ")",
             _ => false,

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -559,10 +559,6 @@ impl<'src> ParserState<'src> {
         self.push_concrete_token(ConcreteLineToken::CloseParen);
     }
 
-    pub(crate) fn emit_paren_expr_close(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::ParenExprClose);
-    }
-
     pub(crate) fn emit_slash(&mut self) {
         self.push_concrete_token(ConcreteLineToken::SingleSlash);
     }


### PR DESCRIPTION
Closes #813 

#787 changed how we render paren expressions, making them sometimes render certain expression types across multiple lines. It had some special handling for if/unless nodes, but it didn't quite take into account the fact that if/unless can render in their block forms if they extend past the end of the line or if they are already on multiple lines. This meant that we sometimes had non-idempotent changes where the if/unless would switch to block form, which then on a second render would cause the parens to break to their multiline format.

This PR renders paren nodes as breakables (at least in the cases where we decided that they could render as such). The breakable machinery will handle rendering properly if the contents are on multiple lines, so it should have more consistent behavior and should work on the first run without requiring additional formats.