### PR TITLE
Refactor heredoc handling for complex use cases

### DIFF
--- a/fixtures/small/pathological_heredocs_actual.rb
+++ b/fixtures/small/pathological_heredocs_actual.rb
@@ -35,3 +35,57 @@ ASSIGNED_MESSAGE = lambda do |assignee|
     Otherwise, it's probably in your best interest not to write things like this.
   END
 end
+
+<<EOD
+part 1 of heredoc #{"not a heredoc" + <<EOM} after brace before newline
+contents of EOM
+EOM
+contents of EOD
+EOD
+
+# Multiple heredocs on same line
+<<OUTER
+first #{<<A} middle #{<<B} last
+content A
+A
+content B
+B
+OUTER
+
+# Heredoc-only interpolation with text after
+<<OUTER
+#{<<INNER} after
+inner content
+INNER
+more outer
+OUTER
+
+# Heredoc with escape sequences preserved
+<<EOD
+line with escape \n in middle
+another line
+EOD
+
+# Nested heredoc with escape sequence in interpolation
+<<OUTER
+prefix #{"text\n" + <<INNER} after
+inner content
+INNER
+more outer
+OUTER
+
+# Squiggly heredoc with nested bare heredoc
+<<~OUTER
+  prefix #{<<INNER} after
+inner content
+INNER
+  more outer
+OUTER
+
+# Squiggly heredoc with nested squiggly heredoc
+<<~OUTER
+  prefix #{<<~INNER} after
+  inner content
+  INNER
+  more outer
+OUTER

--- a/fixtures/small/pathological_heredocs_expected.rb
+++ b/fixtures/small/pathological_heredocs_expected.rb
@@ -40,3 +40,58 @@ ASSIGNED_MESSAGE = lambda do |assignee|
     .join
     .strip
 end
+
+<<EOD
+part 1 of heredoc #{"not a heredoc" + <<EOM} after brace before newline
+contents of EOM
+EOM
+contents of EOD
+EOD
+
+# Multiple heredocs on same line
+<<OUTER
+first #{<<A} middle #{<<B} last
+content A
+A
+content B
+B
+
+OUTER
+
+# Heredoc-only interpolation with text after
+<<OUTER
+#{<<INNER} after
+inner content
+INNER
+more outer
+OUTER
+
+# Heredoc with escape sequences preserved
+<<EOD
+line with escape \n in middle
+another line
+EOD
+
+# Nested heredoc with escape sequence in interpolation
+<<OUTER
+prefix #{"text\n" + <<INNER} after
+inner content
+INNER
+more outer
+OUTER
+
+# Squiggly heredoc with nested bare heredoc
+<<~OUTER
+  prefix #{<<INNER} after
+inner content
+INNER
+  more outer
+OUTER
+
+# Squiggly heredoc with nested squiggly heredoc
+<<~OUTER
+  prefix #{<<~INNER} after
+    inner content
+  INNER
+  more outer
+OUTER

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -980,14 +980,50 @@ fn format_inner_string<'src>(
                     }
                 };
 
-                prev_ended_with_newline = contents.ends_with('\n');
+                // If there are pending heredocs and the content contains a newline
+                // (but doesn't start with one), we need to split the content at the
+                // first newline, emit the part before, then a HardNewLine, then
+                // render the heredocs (with a proper newline after
+                // heredoc close), then emit the rest. This handles cases like:
+                //   <<EOD
+                //   text #{<<INNER} after brace
+                //   inner content
+                //   INNER
+                //   more outer content
+                //   EOD
+                let mut rendered_heredocs = false;
+                if ps.has_pending_heredocs()
+                    && !contents.starts_with('\n')
+                    && let Some(newline_idx) = contents.find('\n')
+                {
+                    let before_newline = &contents[..newline_idx];
+                    if !before_newline.is_empty() {
+                        ps.emit_string_content(before_newline.to_string());
+                    }
+                    ps.emit_hard_newline_in_heredoc();
+                    // Use skip=false to ensure proper newline after heredoc close
+                    ps.render_heredocs(false);
+                    contents = contents[newline_idx + 1..].to_string();
+                    rendered_heredocs = true;
+                }
+
+                // If we rendered heredocs, they end with a newline (since skip=false),
+                // so the next StringNode should have its first line treated as starting
+                // at a line boundary for common_indent stripping purposes.
+                prev_ended_with_newline = if rendered_heredocs && contents.is_empty() {
+                    true
+                } else {
+                    contents.ends_with('\n')
+                };
 
                 if peekable.peek().is_none() && contents.ends_with('\n') {
                     contents.pop();
                 }
 
                 ps.at_offset(part.location().end_offset());
-                ps.emit_string_content(contents);
+                if !contents.is_empty() {
+                    ps.emit_string_content(contents);
+                }
             }
             prism::Node::InterpolatedStringNode { .. } => {
                 ps.at_offset(part.location().start_offset());

--- a/librubyfmt/src/heredoc_string.rs
+++ b/librubyfmt/src/heredoc_string.rs
@@ -30,42 +30,86 @@ impl HeredocKind {
     }
 }
 
+/// A segment of heredoc content. Used to distinguish between content that should
+/// receive squiggly indentation and content from nested non-squiggly heredocs
+/// that should not be indented.
+#[derive(Debug, Clone)]
+pub enum HeredocSegment {
+    Normal(String),
+    /// Content from nested non-squiggly heredocs, should never receive squiggly indentation.
+    /// This includes both the heredoc content and the closing identifier.
+    Raw(String),
+}
+
 #[derive(Debug, Clone)]
 pub struct HeredocString<'src> {
     symbol: Cow<'src, str>,
     pub kind: HeredocKind,
-    pub buf: Vec<u8>,
+    pub segments: Vec<HeredocSegment>,
     pub indent: ColNumber,
 }
 
 impl<'src> HeredocString<'src> {
-    pub fn new(symbol: Cow<'src, str>, kind: HeredocKind, buf: Vec<u8>, indent: ColNumber) -> Self {
+    pub fn new(
+        symbol: Cow<'src, str>,
+        kind: HeredocKind,
+        segments: Vec<HeredocSegment>,
+        indent: ColNumber,
+    ) -> Self {
         HeredocString {
             symbol,
             kind,
-            buf,
+            segments,
             indent,
         }
     }
 
     pub fn render_as_string(self) -> String {
         let indent = self.indent;
-        let string = String::from_utf8(self.buf).expect("heredoc is utf8");
 
         if self.kind.is_squiggly() {
-            string
-                .split('\n')
-                .map(|l| {
-                    String::from(format!("{}{}", get_indent(indent as usize + 2), l).trim_end())
-                })
-                .collect::<Vec<String>>()
-                .join("\n")
+            // For squiggly heredocs, we need to apply indentation to Normal segments
+            // but not to Raw segments (which come from nested non-squiggly heredocs).
+            let mut result = String::new();
+            for segment in self.segments {
+                match segment {
+                    HeredocSegment::Normal(content) => {
+                        // Apply squiggly indentation to each line
+                        for (i, line) in content.split('\n').enumerate() {
+                            if i > 0 {
+                                result.push('\n');
+                            }
+                            let indented = format!("{}{}", get_indent(indent as usize + 2), line);
+                            result.push_str(indented.trim_end());
+                        }
+                    }
+                    HeredocSegment::Raw(content) => {
+                        // No indentation for raw content (nested non-squiggly heredocs)
+                        for (i, line) in content.split('\n').enumerate() {
+                            if i > 0 {
+                                result.push('\n');
+                            }
+                            result.push_str(line.trim_end());
+                        }
+                    }
+                }
+            }
+            result
         } else {
-            string
-                .split('\n')
-                .map(|l| l.trim_end())
-                .collect::<Vec<&str>>()
-                .join("\n")
+            // For non-squiggly heredocs, just join segments and trim line endings
+            let mut result = String::new();
+            for segment in self.segments {
+                let content = match segment {
+                    HeredocSegment::Normal(s) | HeredocSegment::Raw(s) => s,
+                };
+                for (i, line) in content.split('\n').enumerate() {
+                    if i > 0 {
+                        result.push('\n');
+                    }
+                    result.push_str(line.trim_end());
+                }
+            }
+            result
         }
     }
 

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -88,6 +88,9 @@ pub enum ConcreteLineToken<'src> {
         kind: HeredocKind,
         symbol: &'src str,
     },
+    RawHeredocContent {
+        content: String,
+    },
 }
 
 impl<'src> ConcreteLineToken<'src> {
@@ -124,6 +127,7 @@ impl<'src> ConcreteLineToken<'src> {
             Self::End => Cow::Borrowed("end"),
             Self::HeredocClose { symbol } => Cow::Owned(symbol),
             Self::HeredocStart { symbol, .. } => Cow::Borrowed(symbol),
+            Self::RawHeredocContent { content } => Cow::Owned(content),
             // no-op, this is purely semantic information
             // for the render queue
             Self::AfterCallChain | Self::BeginCallChainIndent | Self::EndCallChainIndent => {
@@ -146,7 +150,9 @@ impl<'src> ConcreteLineToken<'src> {
             Keyword { keyword: contents } | ConditionalKeyword { contents } => contents.len(),
             Op { op } | MethodName { name: op } => op.len(),
             DirectPart { part: contents } | LTStringContent { content: contents } => contents.len(),
-            Comment { contents } | HeredocClose { symbol: contents } => contents.len(),
+            Comment { contents }
+            | HeredocClose { symbol: contents }
+            | RawHeredocContent { content: contents } => contents.len(),
             HardNewLine | Comma | Space | Dot | OpenSquareBracket | CloseSquareBracket
             | OpenCurlyBracket | CloseCurlyBracket | OpenParen | CloseParen | ParenExprClose
             | SingleSlash | DoubleQuote => 1,

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -1,7 +1,7 @@
 use crate::comment_block::{CommentBlock, Merge};
 use crate::delimiters::BreakableDelims;
 use crate::file_comments::FileComments;
-use crate::heredoc_string::{HeredocKind, HeredocString};
+use crate::heredoc_string::{HeredocKind, HeredocSegment, HeredocString};
 use crate::line_tokens::*;
 use crate::render_queue_writer::{MAX_LINE_LENGTH, RenderQueueWriter};
 use crate::render_targets::{BaseQueue, Breakable, BreakableCallChainEntry, BreakableEntry};
@@ -66,6 +66,9 @@ pub struct ParserState<'src> {
     insert_user_newlines: bool,
     spaces_after_last_newline: ColNumber,
     scopes: Vec<Vec<Cow<'src, str>>>,
+    /// Whether we're currently rendering inside a squiggly heredoc's content.
+    /// Used to mark nested non-squiggly heredocs so they don't get incorrect indentation.
+    inside_squiggly_heredoc: bool,
 }
 
 impl<'src> ParserState<'src> {
@@ -99,7 +102,9 @@ impl<'src> ParserState<'src> {
     ) where
         F: FnOnce(&mut ParserState<'src>),
     {
-        let mut next_ps = ParserState::render_with_blank_state(self, formatting_func);
+        let mut next_ps = ParserState::new_with_reset_indentation(self);
+        next_ps.inside_squiggly_heredoc = kind.is_squiggly() || self.inside_squiggly_heredoc;
+        formatting_func(&mut next_ps);
 
         self.heredoc_strings
             .extend(next_ps.heredoc_strings.drain(0..));
@@ -112,11 +117,11 @@ impl<'src> ParserState<'src> {
             .extract_comments_to_line(self.current_orig_line_number, end_line);
         self.current_orig_line_number = end_line;
 
-        let data = next_ps.render_to_buffer();
+        let segments = next_ps.render_to_segments();
         self.heredoc_strings.push(HeredocString::new(
             symbol.into(),
             kind,
-            data,
+            segments,
             self.current_spaces(),
         ));
     }
@@ -438,6 +443,12 @@ impl<'src> ParserState<'src> {
         self.spaces_after_last_newline = self.current_spaces();
     }
 
+    /// Emit a hard newline token without triggering heredoc rendering.
+    /// Used when we need to manually control when heredocs are rendered.
+    pub(crate) fn emit_hard_newline_in_heredoc(&mut self) {
+        self.push_concrete_token(ConcreteLineToken::HardNewLine);
+    }
+
     pub(crate) fn wind_dumping_comments_until_line(&mut self, line_number: LineNumber) {
         self.wind_dumping_comments(Some(line_number))
     }
@@ -660,7 +671,11 @@ impl<'src> ParserState<'src> {
     }
 
     pub(crate) fn render_heredocs(&mut self, skip: bool) {
-        while let Some(next_heredoc) = self.heredoc_strings.pop() {
+        // Drain to process heredocs in declaration order (FIFO).
+        // When multiple heredocs are declared on the same line (e.g., #{<<A} middle #{<<B}),
+        // they are pushed in order [A, B], so we iterate in that order to render A before B.
+        let heredocs: Vec<_> = self.heredoc_strings.drain(..).collect();
+        for next_heredoc in heredocs {
             let want_newline = !self.last_token_is_a_newline();
             if want_newline {
                 self.push_concrete_token(ConcreteLineToken::HardNewLine);
@@ -671,18 +686,45 @@ impl<'src> ParserState<'src> {
             let space_count = next_heredoc.indent;
             let string_contents = next_heredoc.render_as_string();
 
+            // When inside a squiggly heredoc context and this is a non-squiggly heredoc,
+            // emit RawHeredocContent tokens so the content won't receive squiggly indentation.
+            let emit_as_raw = self.inside_squiggly_heredoc && !kind.is_squiggly();
+
             if !string_contents.is_empty() {
-                self.push_concrete_token(ConcreteLineToken::DirectPart {
-                    part: Cow::Owned(string_contents),
-                });
+                if emit_as_raw {
+                    self.push_concrete_token(ConcreteLineToken::RawHeredocContent {
+                        content: string_contents,
+                    });
+                } else {
+                    self.push_concrete_token(ConcreteLineToken::DirectPart {
+                        part: Cow::Owned(string_contents),
+                    });
+                }
                 self.emit_newline();
             }
-            if !kind.is_bare() {
-                self.push_concrete_token(ConcreteLineToken::Indent { depth: space_count })
+
+            if emit_as_raw {
+                // For bare/dash heredocs inside squiggly context, emit the close as raw content
+                let close_content = if kind.is_bare() {
+                    symbol.replace('\'', "")
+                } else {
+                    // Dash heredocs can have indented close
+                    format!(
+                        "{}{}",
+                        crate::util::get_indent(space_count as usize),
+                        symbol.replace('\'', "")
+                    )
+                };
+                self.push_concrete_token(ConcreteLineToken::RawHeredocContent {
+                    content: close_content,
+                });
             } else {
-                self.push_concrete_token(ConcreteLineToken::Indent { depth: 0 });
+                if !kind.is_bare() {
+                    self.push_concrete_token(ConcreteLineToken::Indent { depth: space_count });
+                }
+                self.emit_heredoc_close(symbol.replace('\'', ""));
             }
-            self.emit_heredoc_close(symbol.replace('\'', ""));
+
             if !skip {
                 self.emit_newline();
             }
@@ -718,6 +760,7 @@ impl<'src> ParserState<'src> {
             insert_user_newlines: true,
             spaces_after_last_newline: 0,
             scopes: vec![vec![]],
+            inside_squiggly_heredoc: false,
         }
     }
 
@@ -812,6 +855,43 @@ impl<'src> ParserState<'src> {
         bufio.into_inner()
     }
 
+    /// Convert the render queue to heredoc segments. This separates content into
+    /// Normal segments (which should receive squiggly indentation) and Raw segments
+    /// (content from nested non-squiggly heredocs that should not be indented).
+    pub(crate) fn render_to_segments(self) -> Vec<HeredocSegment> {
+        // First, render to get the final token stream (resolving breakable entries)
+        let rqw = RenderQueueWriter::new(self.consume_to_render_queue());
+        let final_tokens = rqw.into_tokens();
+
+        let mut segments = Vec::new();
+        let mut current_normal = String::new();
+
+        fn flush_normal(current: &mut String, segments: &mut Vec<HeredocSegment>) {
+            if !current.is_empty() {
+                segments.push(HeredocSegment::Normal(std::mem::take(current)));
+            }
+        }
+
+        for token in final_tokens {
+            if let ConcreteLineToken::RawHeredocContent { content } = token {
+                // Flush accumulated normal content, then add raw segment
+                flush_normal(&mut current_normal, &mut segments);
+                segments.push(HeredocSegment::Raw(content));
+            } else {
+                // Accumulate into normal content
+                current_normal.push_str(&token.into_ruby());
+            }
+        }
+
+        // Flush any remaining normal content
+        flush_normal(&mut current_normal, &mut segments);
+        segments
+    }
+
+    pub(crate) fn has_pending_heredocs(&self) -> bool {
+        !self.heredoc_strings.is_empty()
+    }
+
     pub(crate) fn write<W: Write>(self, writer: &mut W) -> io::Result<()> {
         let rqw = RenderQueueWriter::new(self.consume_to_render_queue());
         rqw.write(writer)
@@ -891,15 +971,6 @@ impl<'src> ParserState<'src> {
             Some(be) => be.push(t),
             None => self.render_queue.push(Self::dangerously_convert(t)),
         }
-    }
-
-    pub(crate) fn render_with_blank_state<F>(ps: &mut ParserState<'src>, f: F) -> ParserState<'src>
-    where
-        F: FnOnce(&mut ParserState<'src>),
-    {
-        let mut next_ps = ParserState::new_with_reset_indentation(ps);
-        f(&mut next_ps);
-        next_ps
     }
 }
 

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -31,6 +31,14 @@ impl<'src> RenderQueueWriter<'src> {
         Self::write_final_tokens(writer, accum.into_tokens())
     }
 
+    /// Convert the render queue to final tokens without writing them.
+    /// This is used for extracting heredoc segments.
+    pub fn into_tokens(self) -> Vec<ConcreteLineToken<'src>> {
+        let mut accum = Intermediary::new();
+        Self::render_as(&mut accum, self.tokens);
+        accum.into_tokens()
+    }
+
     fn render_as(accum: &mut Intermediary<'src>, tokens: Vec<ConcreteLineTokenAndTargets<'src>>) {
         use ConcreteLineToken::*;
         let token_len = tokens.len();


### PR DESCRIPTION
Closes #286 
Closes #361 

There's a few cases where we don't currently handle heredocs properly. They're extreme cases, few of which I hope are written on any regular basis, but they're good stress tests (and rightfully belong in a fixture called `pathological_heredocs`). Generally, these cases involve nested heredocs, as well as the case where string content exists on the same line as a nested heredoc.

This PR breaks up heredocs into "segments," which themselves may be considered "Normal" which require no special handling, as well as "raw" heredocs, which we use to skip over our indentation logic. Raw heredoc segments apply in few cases, but they matter for nested ones where one heredoc type (say, squiggly) may be nested inside another (bare) where the indentation rules differ. This change also then wires up the render queue to handle this, and segments are also used to properly track newlines and insertion for things like content after a new interpolated heredoc.