### PR TITLE
[chore] Update rust version in CI to `1.93.0`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
           override: true
           cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
           components: clippy
           override: true
       - uses: actions/cache@v5
@@ -60,13 +60,13 @@ jobs:
     - if: runner.os == 'macOS'
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: 1.91.1
+        toolchain: 1.93.0
         target: aarch64-apple-darwin
         override: true
     - if: runner.os != 'macOS'
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: 1.91.1
+        toolchain: 1.93.0
         override: true
         target: aarch64-unknown-linux-gnu
     - uses: actions/cache@v5

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -38,13 +38,13 @@ jobs:
       - if: runner.os == 'macOS'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
           target: aarch64-apple-darwin
           override: true
       - if: runner.os != 'macOS'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
           override: true
           target: aarch64-unknown-linux-gnu
       - run: ./script/make_release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,13 +22,13 @@ jobs:
       - if: runner.os == 'macOS'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
           target: aarch64-apple-darwin
           override: true
       - if: runner.os != 'macOS'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
           override: true
           target: aarch64-unknown-linux-gnu
       - run: ./script/make_release


### PR DESCRIPTION
On the tin -- this is the current stable version of Rust, so just keeping us up-to-date 🧹 