### PR TITLE
Remove duplicate caching in CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,6 @@ jobs:
           toolchain: 1.93.0
           components: clippy
           override: true
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo clippy --all --all-features -- -D warnings
 
   lint:
@@ -69,12 +63,6 @@ jobs:
         toolchain: 1.93.0
         override: true
         target: aarch64-unknown-linux-gnu
-    - uses: actions/cache@v5
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: ${{ runner.os }}-cargo-2-${{ hashFiles('**/Cargo.lock') }}
     - run: cargo test --release
     - uses: actions/upload-artifact@v6
       with:


### PR DESCRIPTION
`actions-rust-lang/setup-rust-toolchain` already has its own caching (which is enabled by default), so currently we're just maintaining two caches for no benefit. You can see the duplicate caching in the post-job actions on all of our [action runs](https://github.com/fables-tales/rubyfmt/actions/runs/21365715296/job/61496793025), this should just drop it down to a single cache.