### PR TITLE
[perf] Use slices instead of `HashSet` for reserved method name checks

### DIFF
--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashSet, sync::LazyLock};
+use std::borrow::Cow;
 
 use ruby_prism as prism;
 
@@ -1632,18 +1632,12 @@ fn format_block_argument_node<'src>(
     }
 }
 
-pub static RSPEC_METHODS: LazyLock<HashSet<&'static str>> =
-    LazyLock::new(|| vec!["it", "describe"].into_iter().collect());
+pub static RSPEC_METHODS: [&'static str; 2] = ["it", "describe"];
 
-pub static GEMFILE_METHODS: LazyLock<HashSet<&'static str>> =
-    LazyLock::new(|| vec!["gem", "source", "ruby", "group"].into_iter().collect());
+pub static GEMFILE_METHODS: [&'static str; 4] = ["gem", "source", "ruby", "group"];
 
-pub static OPTIONALLY_PARENTHESIZED_METHODS: LazyLock<HashSet<&'static str>> =
-    LazyLock::new(|| {
-        vec!["super", "require", "require_relative"]
-            .into_iter()
-            .collect::<HashSet<_>>()
-    });
+pub static OPTIONALLY_PARENTHESIZED_METHODS: [&'static str; 3] =
+    ["super", "require", "require_relative"];
 
 fn use_parens_for_call_node<'src>(
     ps: &ParserState<'src>,
@@ -1712,8 +1706,8 @@ fn use_parens_for_call_node<'src>(
         return false;
     }
 
-    if OPTIONALLY_PARENTHESIZED_METHODS.contains(method_name)
-        || GEMFILE_METHODS.contains(method_name)
+    if OPTIONALLY_PARENTHESIZED_METHODS.contains(&method_name)
+        || GEMFILE_METHODS.contains(&method_name)
     {
         return original_used_parens;
     }
@@ -1733,7 +1727,7 @@ fn use_parens_for_call_node<'src>(
         return true;
     }
 
-    if RSPEC_METHODS.contains(method_name)
+    if RSPEC_METHODS.contains(&method_name)
         && call_node.receiver().is_none()
         // Only elide parens for blocks, not block params (`&blk`)
         && call_node

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1632,12 +1632,11 @@ fn format_block_argument_node<'src>(
     }
 }
 
-pub static RSPEC_METHODS: [&'static str; 2] = ["it", "describe"];
+pub static RSPEC_METHODS: [&str; 2] = ["it", "describe"];
 
-pub static GEMFILE_METHODS: [&'static str; 4] = ["gem", "source", "ruby", "group"];
+pub static GEMFILE_METHODS: [&str; 4] = ["gem", "source", "ruby", "group"];
 
-pub static OPTIONALLY_PARENTHESIZED_METHODS: [&'static str; 3] =
-    ["super", "require", "require_relative"];
+pub static OPTIONALLY_PARENTHESIZED_METHODS: [&str; 3] = ["super", "require", "require_relative"];
 
 fn use_parens_for_call_node<'src>(
     ps: &ParserState<'src>,


### PR DESCRIPTION
At first glance, `HashSet` made sense for fast checking of set membership, but for sets that are only ever 2-4 items, array iteration is significantly faster than the hashing overhead required for `HashSet::contains`. On my machine, `contains` on a slice of 2-4 items is about 10-12x faster than HashSets of the equivalent size.