### PR TITLE
[perf] Use faster check to early-return from `extract_comments_to_line`

### DIFF
--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -212,16 +212,16 @@ impl FileComments {
         line_number: LineNumber,
     ) -> Option<(CommentBlock, LineNumber)> {
         let lowest_line = self.other_comments.first().map(|(ln, _)| *ln)?;
-        let split_point = self
-            .other_comments
-            .partition_point(|(ln, _)| *ln <= line_number);
-
-        if split_point == 0 {
+        if lowest_line > line_number {
             return Some((
                 CommentBlock::new(lowest_line..line_number + 1, Vec::new()),
                 starting_line_number,
             ));
         }
+
+        let split_point = self
+            .other_comments
+            .partition_point(|(ln, _)| *ln <= line_number);
 
         let mut comment_block_with_spaces: Vec<String> = Vec::new();
         let mut last_line = None;


### PR DESCRIPTION
`extract_comments_to_line` is on a very hot path (being called by `on_line`, which gets called for ~every node in the tree), but a large portion on the time it should return early. Currently, we do a full binary search in the average case, but we can determine that the binary search will _definitely_ find nothing if the line number for the earliest comment is greater than the line number we care about, which guarantees we'll find nothing. This is a much faster check and delays a full binary search in the average case.

From profiling locally, this drops the total amount of time spent in `extract_comments_to_line` by half, reducing overall average runtime by ~1.5%.
