### PR TITLE
[perf] Skip more no-op calls in on_line

### DIFF
--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -213,10 +213,7 @@ impl FileComments {
     ) -> Option<(CommentBlock, LineNumber)> {
         let lowest_line = self.other_comments.first().map(|(ln, _)| *ln)?;
         if lowest_line > line_number {
-            return Some((
-                CommentBlock::new(lowest_line..line_number + 1, Vec::new()),
-                starting_line_number,
-            ));
+            return None;
         }
 
         let split_point = self


### PR DESCRIPTION
`extract_comments_to_line` returns an `Option`, but it previously was always returning `Some` with an empty vec of comments. This cause a whole chain of calls that did nothing -- [pushing an empty vec of comments](https://github.com/fables-tales/rubyfmt/blob/6db201ab96cfab3bfed2ff1f7994dad36983a5c0/librubyfmt/src/parser_state.rs#L366), running [checks](https://github.com/fables-tales/rubyfmt/blob/6db201ab96cfab3bfed2ff1f7994dad36983a5c0/librubyfmt/src/parser_state.rs#L783) on it, then iterating over the (again, empty) vec to [apply spaces](https://github.com/fables-tales/rubyfmt/blob/6db201ab96cfab3bfed2ff1f7994dad36983a5c0/librubyfmt/src/parser_state.rs#L408-L409), etc.

This instead just returns `None` in the empty case, which skips all of that. Given that we call on_line potentially multiple times per node in the AST, it's very hot, and skipping all of this trivial work and Vec allocation cuts about 1/3 of its overall runtime off (which means shaving ~2.5% of overall runtime).