### PR TITLE
Fix empty comment handling

### DIFF
--- a/librubyfmt/src/comment_block.rs
+++ b/librubyfmt/src/comment_block.rs
@@ -25,11 +25,30 @@ impl CommentBlock {
     }
 
     pub fn into_line_tokens<'src>(self) -> impl Iterator<Item = ConcreteLineToken<'src>> {
-        self.comments.into_iter().flat_map(|c| {
-            [
-                ConcreteLineToken::Comment { contents: c },
-                ConcreteLineToken::HardNewLine,
-            ]
+        let comments = self.comments;
+        let len = comments.len();
+
+        comments.into_iter().enumerate().flat_map(move |(i, c)| {
+            if c.is_empty() {
+                // Empty strings represent blank lines
+                // If this is a trailing empty comment (at the end), keep it as an empty Comment token
+                // to bypass the HardNewLine deduplication logic. Otherwise convert to just HardNewLine.
+                if i == len - 1 {
+                    // Trailing empty - keep as empty comment to preserve blank lines
+                    vec![
+                        ConcreteLineToken::Comment { contents: c },
+                        ConcreteLineToken::HardNewLine,
+                    ]
+                } else {
+                    // Between comments - convert to just HardNewLine
+                    vec![ConcreteLineToken::HardNewLine]
+                }
+            } else {
+                vec![
+                    ConcreteLineToken::Comment { contents: c },
+                    ConcreteLineToken::HardNewLine,
+                ]
+            }
         })
     }
 

--- a/librubyfmt/src/intermediary.rs
+++ b/librubyfmt/src/intermediary.rs
@@ -34,20 +34,6 @@ impl<'src> Intermediary<'src> {
         self.tokens.len()
     }
 
-    // Pops off excessive whitespace for `require` calls followed
-    // by comments. In the intermediary, this looks like
-    // a `require` call followed by
-    // - HardNewline
-    // - HardNewline
-    // - Comment { contents: "" }
-    // - HardNewline
-    // so this method actually pops off the extra empty comment whitespace
-    pub fn pop_require_comment_whitespace(&mut self) {
-        self.tokens.pop();
-        self.tokens.pop();
-        self.index_of_last_hard_newline = self.tokens.len() - 1;
-    }
-
     pub fn pop_heredoc_mistake(&mut self) {
         self.tokens.remove(self.tokens.len() - 1);
         self.tokens.remove(self.tokens.len() - 1);
@@ -134,39 +120,6 @@ impl<'src> Intermediary<'src> {
                 if *name == "require" && self.tokens.last().map(|t| t.is_indent()).unwrap_or(false)
                 {
                     self.current_line_metadata.set_has_require();
-                }
-            }
-            ConcreteLineToken::Comment { .. } => {
-                if matches!(
-                    self.last::<4>(),
-                    Some([
-                        _,
-                        _,
-                        ConcreteLineToken::HardNewLine,
-                        ConcreteLineToken::HardNewLine
-                    ])
-                ) {
-                    let mut module_or_class_before_newline = false;
-                    let mut past_first_two_newlines = 0;
-                    for tok in self.tokens.iter().rev() {
-                        if tok == &ConcreteLineToken::HardNewLine {
-                            if past_first_two_newlines < 2 {
-                                past_first_two_newlines += 1;
-                            } else {
-                                break;
-                            }
-                        }
-                        if tok == &ConcreteLineToken::ModuleKeyword
-                            || tok == &ConcreteLineToken::ClassKeyword
-                        {
-                            module_or_class_before_newline = true;
-                        }
-                    }
-
-                    if module_or_class_before_newline {
-                        self.tokens.pop();
-                        self.index_of_last_hard_newline = self.tokens.len() - 1;
-                    }
                 }
             }
             _ => {}

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -158,13 +158,6 @@ impl<'src> RenderQueueWriter<'src> {
                 accum.insert_trailing_blankline(BlanklineReason::ComesAfterEnd);
             }
 
-            if let Some([HardNewLine, HardNewLine, Comment { contents }, HardNewLine]) =
-                accum.last::<4>()
-                && contents.is_empty()
-            {
-                accum.pop_require_comment_whitespace();
-            }
-
             if let Some(
                 [
                     ConcreteLineToken::End,


### PR DESCRIPTION
`render_as` is pretty slow, largely due to the pattern matching required for a whole lot of band-aid fixes to what really should be fixed elsewhere. I'd like to remove most of these by just fixing the busted logic instead of applying band-aids, which hopefully will speed up `render_as` as a nice side effect.

---

In the line winding machinery, we try and maintain user-inserted newlines between comments and nodes. I don't recall why we don't use newlines, but for whatever reason we use empty `Comment` nodes (e.g. `Comment { comment: "" }`). The `into_line_comments` machinery was [_supposed_ to](https://github.com/fables-tales/rubyfmt/blob/cadd3d90081d37efbb7ffbc60cdda371624e1cf2/librubyfmt/src/comment_block.rs#L39-L40) ignore these but didn't, causing us to add additional hard newlines in between these empty comments. This updates the logic in `into_line_comments` to ignore all but the trailing empty comment lines (which are the ones actually used for spacing) and then removes the old cleanup logic.