### PR TITLE
Remove unneeded heredoc checks in render queue

### DIFF
--- a/librubyfmt/src/intermediary.rs
+++ b/librubyfmt/src/intermediary.rs
@@ -34,21 +34,9 @@ impl<'src> Intermediary<'src> {
         self.tokens.len()
     }
 
-    pub fn pop_heredoc_mistake(&mut self) {
-        self.tokens.remove(self.tokens.len() - 1);
-        self.tokens.remove(self.tokens.len() - 1);
-        self.index_of_last_hard_newline = self.tokens.len() - 1;
-    }
-
     pub fn fix_heredoc_duplicate_indent_mistake(&mut self) {
         // Remove duplicate indent
         self.tokens.remove(self.tokens.len() - 3);
-    }
-
-    pub fn fix_heredoc_arg_newline_mistake(&mut self) {
-        // Remove duplicate newline
-        self.tokens.remove(self.tokens.len() - 1);
-        self.index_of_last_hard_newline = self.tokens.len() - 1;
     }
 
     pub fn last<const N: usize>(&self) -> Option<&[ConcreteLineToken<'src>; N]> {

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -135,18 +135,6 @@ impl<'src> RenderQueueWriter<'src> {
 
             if let Some(
                 [
-                    ConcreteLineToken::HeredocClose { .. },
-                    ConcreteLineToken::HardNewLine,
-                    ConcreteLineToken::Indent { .. },
-                    ConcreteLineToken::HardNewLine,
-                ],
-            ) = accum.last::<4>()
-            {
-                accum.pop_heredoc_mistake();
-            }
-
-            if let Some(
-                [
                     ConcreteLineToken::End,
                     ConcreteLineToken::HardNewLine,
                     ConcreteLineToken::Indent { .. },
@@ -209,21 +197,6 @@ impl<'src> RenderQueueWriter<'src> {
             ) = accum.last::<5>()
             {
                 accum.fix_heredoc_duplicate_indent_mistake();
-            }
-
-            if let Some(
-                [
-                    ConcreteLineToken::HeredocClose { .. },
-                    ConcreteLineToken::HardNewLine,
-                    ConcreteLineToken::Indent { .. },
-                    ConcreteLineToken::Delim { .. },
-                    ConcreteLineToken::Comma,
-                    ConcreteLineToken::HardNewLine,
-                    ConcreteLineToken::HardNewLine,
-                ],
-            ) = accum.last::<7>()
-            {
-                accum.fix_heredoc_arg_newline_mistake();
             }
         }
     }


### PR DESCRIPTION
I believe #818 (accidentally -- er, I mean _totally according to plan_) fixed the root cause of these heredoc checks in the render queue (added ages ago in 46e08ebde71f5e816bdde0065c5100f33ee638a7). The relevant part of the change is [this](https://github.com/fables-tales/rubyfmt/pull/818/changes#diff-c8621eb40386281f14cc1e81bfd0e0c3b5a0033ba35639a7e55c7b482113c942L683-R724), which stopped emitting a 0-depth `Indent` node for bare heredocs. The 0-depth indent caused all sorts of problems with later machinery changes (like the call-chain indent adjustments that happen in the render queue) so we had to add these hacks, but now that they're gone, we can 🔪 them.