### PR TITLE
[chore] Bump ruby-prism to 1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,9 +770,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ruby-prism"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c950685ad401193788a593f2d7be6d2cb16ec722cbc1aa6c85f16375e59b2db"
+checksum = "3b302f00359d0b5423a600314935ca5f994484e15da2db5345631d28c6e029d6"
 dependencies = [
  "ruby-prism-sys",
  "serde",
@@ -781,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "ruby-prism-sys"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de44d9a3c0456612160a31294485b2acaf6ffeb49e165c7a0bf4a70655c20b1b"
+checksum = "9f85fd9571455bdca2b3bf0b2f543cd13ac39d5de0026a8eb2deb94ffd264f00"
 dependencies = [
  "bindgen",
  "cc",

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -11,7 +11,7 @@ fancy-regex = "0.14.0"
 log = { version = "0.4.8", features = ["max_level_debug", "release_max_level_warn"] }
 memchr = "2.7"
 simplelog = "0.12"
-ruby-prism="1.8.0"
+ruby-prism="1.9.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6.1", features = ["disable_initial_exec_tls"], optional=true }


### PR DESCRIPTION
On the tin. I don't think this release has any major changes on the Rust side, but this keeps us up to date 🧹 