### PR TITLE
Clean up redundant Cow usage in variables scopes

### DIFF
--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -75,11 +75,7 @@ pub struct ParserState<'src> {
 
 impl<'src> ParserState<'src> {
     pub(crate) fn scope_has_variable(&self, s: &str) -> bool {
-        self.scopes
-            .last()
-            .expect("it's never empty")
-            .iter()
-            .any(|e| *e == s)
+        self.scopes.last().expect("it's never empty").contains(&s)
     }
     pub(crate) fn new_scope<F>(&mut self, f: F)
     where
@@ -90,10 +86,7 @@ impl<'src> ParserState<'src> {
         self.scopes.pop();
     }
     pub(crate) fn bind_variable(&mut self, s: &'src str) {
-        self.scopes
-            .last_mut()
-            .expect("it's never empty")
-            .push(s.into());
+        self.scopes.last_mut().expect("it's never empty").push(s);
     }
     pub(crate) fn push_heredoc_content<F>(
         &mut self,

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -67,7 +67,7 @@ pub struct ParserState<'src> {
     formatting_context: Vec<FormattingContext>,
     insert_user_newlines: bool,
     spaces_after_last_newline: ColNumber,
-    scopes: Vec<Vec<Cow<'src, str>>>,
+    scopes: Vec<Vec<&'src str>>,
     /// Whether we're currently rendering inside a squiggly heredoc's content.
     /// Used to mark nested non-squiggly heredocs so they don't get incorrect indentation.
     inside_squiggly_heredoc: bool,
@@ -79,7 +79,7 @@ impl<'src> ParserState<'src> {
             .last()
             .expect("it's never empty")
             .iter()
-            .any(|e| e == s)
+            .any(|e| *e == s)
     }
     pub(crate) fn new_scope<F>(&mut self, f: F)
     where
@@ -89,7 +89,7 @@ impl<'src> ParserState<'src> {
         f(self);
         self.scopes.pop();
     }
-    pub(crate) fn bind_variable(&mut self, s: impl Into<Cow<'src, str>>) {
+    pub(crate) fn bind_variable(&mut self, s: &'src str) {
         self.scopes
             .last_mut()
             .expect("it's never empty")


### PR DESCRIPTION
This `Cow` usage is a vestigial change from supporting both `String` and `&str` when Ripper was still around, so we can 🔪 it
