### PR TITLE
Make `format_buffer` return a `Vec<u8>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,9 +907,12 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "similar"
-version = "2.2.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "simplelog"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ ctrlc = { version = "3.2", features = ["termination"] }
 ignore = "0.4.18"
 regex = "1.11.1"
 rubyfmt = { path = "./librubyfmt" }
-similar = "2.1.0"
+similar = { version = "2.7.0", features = ["bytes"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/librubyfmt/src/lib.rs
+++ b/librubyfmt/src/lib.rs
@@ -61,7 +61,7 @@ pub enum FormatError {
     DiffDetected = 5,
 }
 
-pub fn format_buffer(buf: &str) -> Result<String, RichFormatError> {
+pub fn format_buffer(buf: &str) -> Result<Vec<u8>, RichFormatError> {
     let out_data = vec![];
     let mut output = Cursor::new(out_data);
 
@@ -80,7 +80,7 @@ pub fn format_buffer(buf: &str) -> Result<String, RichFormatError> {
     )?;
 
     output.flush().expect("flushing to a vec should never fail");
-    Ok(String::from_utf8(output.into_inner()).expect("we never write invalid UTF-8"))
+    Ok(output.into_inner())
 }
 
 pub fn toplevel_format_program_with_prism<W: Write>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ fn rubyfmt_string(
         ..
     }: &CommandlineOpts,
     buffer: &str,
-) -> Result<Option<String>, rubyfmt::RichFormatError> {
+) -> Result<Option<Vec<u8>>, rubyfmt::RichFormatError> {
     if header_opt_in || header_opt_out {
         // Only look at the first 500 bytes for the magic header.
         // This is for performance
@@ -282,7 +282,7 @@ fn iterate_input_files(opts: &CommandlineOpts, f: &dyn Fn((&Path, &String))) {
             if is_path_ignored(path, opts.include_gitignored) {
                 // Print unchanged output for ignored files unless we're in check mode
                 if !opts.check {
-                    puts_stdout(&buffer);
+                    puts_stdout(&buffer.as_bytes());
                 }
                 return;
             }
@@ -350,7 +350,7 @@ fn iterate_input_files(opts: &CommandlineOpts, f: &dyn Fn((&Path, &String))) {
     }
 }
 
-type FormattingFunc<'a> = &'a dyn Fn((&Path, &String, Option<String>));
+type FormattingFunc<'a> = &'a dyn Fn((&Path, &String, Option<Vec<u8>>));
 
 fn iterate_formatted(opts: &CommandlineOpts, f: FormattingFunc) {
     iterate_input_files(
@@ -365,9 +365,9 @@ fn iterate_formatted(opts: &CommandlineOpts, f: FormattingFunc) {
     );
 }
 
-fn puts_stdout(input: &String) {
+fn puts_stdout(input: &[u8]) {
     io::stdout()
-        .write_all(input.as_bytes())
+        .write_all(input)
         .expect("Could not write to stdout");
     io::stdout().flush().expect("flush works");
 }
@@ -392,7 +392,7 @@ fn main() {
                 &|(file_path, before)| match rubyfmt_string(&opts, before) {
                     Ok(None) => {}
                     Ok(Some(fmtted)) => {
-                        let diff = TextDiff::from_lines(before, &fmtted);
+                        let diff = TextDiff::from_lines(before.as_bytes(), &fmtted);
                         let path_string = file_path.to_str().unwrap();
                         text_diffs.lock().unwrap().push(format!(
                             "{}",
@@ -416,7 +416,7 @@ fn main() {
 
             for diff in all_diffs.iter() {
                 if !diff.is_empty() {
-                    puts_stdout(diff);
+                    puts_stdout(diff.as_bytes());
                     diffs_reported += 1
                 }
             }
@@ -434,12 +434,12 @@ fn main() {
             iterate_formatted(&opts, &|(file_path, before, after)| match after {
                 None => {}
                 Some(fmtted) => {
-                    if fmtted.ne(before) {
+                    if fmtted.ne(before.as_bytes()) {
                         let file_write = OpenOptions::new()
                             .write(true)
                             .truncate(true)
                             .open(file_path)
-                            .and_then(|mut file| file.write_all(fmtted.as_bytes()));
+                            .and_then(|mut file| file.write_all(&fmtted));
 
                         match file_write {
                             Ok(_) => {}
@@ -455,7 +455,7 @@ fn main() {
 
         _ => iterate_formatted(&opts, &|(_, before, after)| match after {
             Some(fmtted) => puts_stdout(&fmtted),
-            None => puts_stdout(before),
+            None => puts_stdout(before.as_bytes()),
         }),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,7 @@ fn iterate_input_files(opts: &CommandlineOpts, f: &dyn Fn((&Path, &String))) {
             if is_path_ignored(path, opts.include_gitignored) {
                 // Print unchanged output for ignored files unless we're in check mode
                 if !opts.check {
-                    puts_stdout(&buffer.as_bytes());
+                    puts_stdout(buffer.as_bytes());
                 }
                 return;
             }


### PR DESCRIPTION
`format_buffer` currently returns a `String` and assumes that we always return valid UTF-8. With the changes I'm making for #832, this will no longer be the case, since Ruby source is not always UTF-8 encoded.