### PR TITLE
Remove fancy-regex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,21 +119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,17 +376,6 @@ name = "escape8259"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
-
-[[package]]
-name = "fancy-regex"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "fastrand"
@@ -793,7 +767,6 @@ dependencies = [
 name = "rubyfmt"
 version = "0.12.0"
 dependencies = [
- "fancy-regex",
  "log",
  "memchr",
  "ruby-prism",

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fancy-regex = "0.14.0"
 log = { version = "0.4.8", features = ["max_level_debug", "release_max_level_warn"] }
 memchr = "2.7"
 simplelog = "0.12"

--- a/librubyfmt/src/string_escape.rs
+++ b/librubyfmt/src/string_escape.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-use fancy_regex::Regex;
-
 pub fn single_to_double_quoted<'src>(
     content: &'src str,
     start_delim: &'src str,
@@ -15,38 +13,70 @@ pub fn single_to_double_quoted<'src>(
         )
         .into()
     } else {
-        // For percent literals, we only care about the delimiter
-        // e.g. for `%<` we're looking for the `<`
-        let start_delim = if let Some(stripped) = start_delim.strip_prefix('%') {
-            stripped
-        } else {
-            start_delim
-        };
-
-        let regexp = Regex::new(&format!(
-            r#"(?<!\\)(\\\\)*(\"|\\{}|\\{})"#,
-            fancy_regex::escape(start_delim),
-            fancy_regex::escape(end_delim)
-        ))
-        .unwrap();
-
-        regexp.replace_all(content, |captures: &fancy_regex::Captures| {
-            // first capture is the entire match
-            let val = captures.get(0).unwrap();
-            let val_str = val.as_str();
-            if val_str.ends_with("\"") {
-                // Ends with a quote, which we transform to `\"`
-                format!("{}\\\"", &val_str[0..(val_str.len() - 1)])
-            } else {
-                // drop unnecessary escape
-                format!(
-                    "{}{}",
-                    &val_str[0..(val_str.len() - 2)],
-                    val_str.chars().last().unwrap()
-                )
-            }
-        })
+        let start_delim_char = start_delim.chars().last().unwrap();
+        let end_delim_char = end_delim.chars().last().unwrap();
+        convert_percent_literal_escapes(content, start_delim_char, end_delim_char)
     }
+}
+
+/// Converts escape sequences in a percent-literal string's content so they are
+/// valid inside a double-quoted string.
+fn convert_percent_literal_escapes(
+    content: &str,
+    start_delim: char,
+    end_delim: char,
+) -> Cow<'_, str> {
+    let first_change_pos = {
+        let mut pos = None;
+        let mut chars = content.char_indices().peekable();
+        while let Some((i, c)) = chars.next() {
+            if c == '"' {
+                pos = Some(i);
+                break;
+            } else if c == '\\'
+                && let Some(&(_, next)) = chars.peek()
+            {
+                if next == start_delim || next == end_delim {
+                    pos = Some(i);
+                    break;
+                }
+                chars.next(); // skip next char — treat \X as a unit
+            }
+        }
+        pos
+    };
+
+    let Some(start) = first_change_pos else {
+        return Cow::Borrowed(content); // No changes
+    };
+
+    let mut output = content[..start].to_string();
+    let mut chars = content[start..].chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(&next) = chars.peek() {
+                if next == start_delim || next == end_delim {
+                    // Drop the delimiter escape: \( → (
+                    output.push(next);
+                    chars.next();
+                } else {
+                    // Write back the original with no changes
+                    output.push('\\');
+                    output.push(next);
+                    chars.next();
+                }
+            } else {
+                output.push('\\');
+            }
+        } else if c == '"' {
+            output.push_str("\\\"");
+        } else {
+            output.push(c);
+        }
+    }
+
+    Cow::Owned(output)
 }
 
 /// Escapes content for word arrays when converting to bracket delimiters.


### PR DESCRIPTION
Currently, any time we convert a string to use double quotes, we compile and run a regex for every string. Benchmarking the large test fixtures, `Regex::new` alone takes up more than 2% of the overall runtime, with `single_to_double_quoted` taking up 3.5%. We could cache these or precompile the most common ones, but honestly using a regex here is overkill -- we're basically just checking for slashes followed by one of the delimiters, which we could do by iterating over the characters instead.

Replacing the `fancy-regex` usage with a manual implementation shows `single_to_double_quoted` going from 3.5% -> 0.5% in my benchmarking, plus it's one fewer dependency.

(This is also part of #832, since `fancy-regex` takes UTF-8 strings.)