### PR TITLE
Finish support for non-UTF-8 source files

### DIFF
--- a/fixtures/small/euc_jp_encoding_actual.rb
+++ b/fixtures/small/euc_jp_encoding_actual.rb
@@ -1,0 +1,5 @@
+# encoding: EUC-JP
+
+def 挨拶(名前)
+  "こんにちは、#{名前}さん"
+end

--- a/fixtures/small/euc_jp_encoding_expected.rb
+++ b/fixtures/small/euc_jp_encoding_expected.rb
@@ -1,0 +1,5 @@
+# encoding: EUC-JP
+
+def 挨拶(名前)
+  "こんにちは、#{名前}さん"
+end

--- a/librubyfmt/src/comment_block.rs
+++ b/librubyfmt/src/comment_block.rs
@@ -64,9 +64,7 @@ impl CommentBlock {
             // Ignore empty vecs -- these represent blank lines between
             // groups of comments
             if !comment.is_empty() && !comment.starts_with(b"=begin") {
-                comment
-                    .to_mut()
-                    .splice(0..0, indent.iter().copied());
+                comment.to_mut().splice(0..0, indent.iter().copied());
             }
         }
         self

--- a/librubyfmt/src/comment_block.rs
+++ b/librubyfmt/src/comment_block.rs
@@ -66,7 +66,7 @@ impl CommentBlock {
             if !comment.is_empty() && !comment.starts_with(b"=begin") {
                 comment
                     .to_mut()
-                    .splice(0..0, indent.as_bytes().iter().copied());
+                    .splice(0..0, indent.iter().copied());
             }
         }
         self

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -7,7 +7,6 @@ use crate::{
     heredoc_string::HeredocKind,
     parser_state::{FormattingContext, HashType, ParserState},
     types::SourceOffset,
-    util::loc_to_str,
 };
 
 pub fn format_node<'src>(ps: &mut ParserState<'src>, node: prism::Node<'src>) {
@@ -660,9 +659,9 @@ fn format_string_node<'src>(ps: &mut ParserState<'src>, string_node: prism::Stri
 
     // `opening_loc()` is only `None` in the case of the inner parts of multiline strings
     // (e.g. the inner contents of a heredoc)
-    let opener = string_node.opening_loc().map(|s| loc_to_str(s).trim());
-    let closer = string_node.closing_loc().map(|s| loc_to_str(s).trim());
-    let is_heredoc = opener.map(|s| s.starts_with("<")).unwrap_or(false);
+    let opener = string_node.opening_loc().map(|s| s.as_slice().trim_ascii());
+    let closer = string_node.closing_loc().map(|s| s.as_slice().trim_ascii());
+    let is_heredoc = opener.map(|s| s.starts_with(b"<")).unwrap_or(false);
 
     if is_heredoc {
         format_heredoc(
@@ -681,21 +680,21 @@ fn format_string_node<'src>(ps: &mut ParserState<'src>, string_node: prism::Stri
 
         // If opener is nil, we must be in some kind of interpolated string context, which
         // means the contents must already be appropriately escaped -- hence we default to `true` here
-        let in_escaped_context = is_heredoc || opener.map(|s| s.starts_with("\"")).unwrap_or(true);
+        let in_escaped_context = is_heredoc || opener.map(|s| s.starts_with(b"\"")).unwrap_or(true);
         let string_content = if in_escaped_context {
-            Cow::Borrowed(loc_to_str(string_node.content_loc()))
+            Cow::Borrowed(string_node.content_loc().as_slice())
         } else {
             // For character literals (`?a`), there can be an opening loc without
             // a closing loc. In that case, fall back to a double quote, since
             // we render character literals as double-quoted string literals
-            let end_delim = if let Some(ref closer) = closer {
+            let end_delim = if let Some(closer) = closer {
                 closer
             } else {
-                "\""
+                b"\""
             };
 
             crate::string_escape::single_to_double_quoted(
-                loc_to_str(string_node.content_loc()),
+                string_node.content_loc().as_slice(),
                 opener.unwrap(),
                 end_delim,
             )
@@ -718,13 +717,13 @@ fn format_interpolated_string_node<'src>(
 ) {
     let opener = interpolated_string_node
         .opening_loc()
-        .map(|s| loc_to_str(s).trim());
+        .map(|s| s.as_slice().trim_ascii());
     let closer = interpolated_string_node
         .closing_loc()
-        .map(|s| loc_to_str(s).trim());
-    let is_heredoc = opener.map(|s| s.starts_with("<")).unwrap_or(false);
+        .map(|s| s.as_slice().trim_ascii());
+    let is_heredoc = opener.map(|s| s.starts_with(b"<")).unwrap_or(false);
     let needs_escape = opener
-        .map(|s| !s.starts_with("\"") && !is_heredoc)
+        .map(|s| !s.starts_with(b"\"") && !is_heredoc)
         .unwrap_or(false);
 
     // Prism actually handles string concatenation when using "\", so it treats
@@ -788,11 +787,10 @@ fn format_interpolated_string_node<'src>(
             }
 
             if needs_escape && let Some(string_node) = part.as_string_node() {
-                let content = loc_to_str(string_node.content_loc());
                 let escaped = crate::string_escape::single_to_double_quoted(
-                    content,
+                    string_node.content_loc().as_slice(),
                     opener.unwrap(),
-                    closer.unwrap_or("\""),
+                    closer.unwrap_or(b"\""),
                 );
                 ps.emit_string_content(escaped);
             } else {
@@ -859,14 +857,14 @@ impl<'src> HeredocNodeType<'src> {
 fn format_heredoc<'src>(
     ps: &mut ParserState<'src>,
     heredoc: HeredocNodeType<'src>,
-    heredoc_symbol: &'src str,
+    heredoc_symbol: &'src [u8],
 ) {
-    let heredoc_kind = HeredocKind::from_string(heredoc_symbol);
+    let heredoc_kind = HeredocKind::from_bytes(heredoc_symbol);
     ps.emit_heredoc_start(heredoc_symbol, heredoc_kind);
 
     let parts = heredoc.parts();
     ps.push_heredoc_content(
-        loc_to_str(heredoc.closing_loc()).trim(),
+        heredoc.closing_loc().as_slice().trim_ascii(),
         heredoc_kind,
         ps.get_line_number_for_offset(heredoc.closing_loc().start_offset()),
         |n: &mut ParserState<'src>| {
@@ -958,9 +956,10 @@ fn format_inner_string<'src>(
                 let part = part.as_string_node().unwrap();
                 // For heredocs, use raw `content_loc` to preserve escape sequences like `\n`
                 let mut contents = {
-                    let raw = loc_to_str(part.content_loc());
+                    let raw = part.content_loc().as_slice();
                     if common_indent > 0 {
-                        raw.split('\n')
+                        let lines = raw
+                            .split(|&b| b == b'\n')
                             .enumerate()
                             .map(|(line_idx, line)| {
                                 // Strip from lines at line boundaries
@@ -973,10 +972,17 @@ fn format_inner_string<'src>(
                                     line
                                 }
                             })
-                            .collect::<Vec<_>>()
-                            .join("\n")
+                            .collect::<Vec<&[u8]>>();
+                        let mut result = Vec::with_capacity(raw.len());
+                        for (i, line) in lines.iter().enumerate() {
+                            if i > 0 {
+                                result.push(b'\n');
+                            }
+                            result.extend_from_slice(line);
+                        }
+                        result
                     } else {
-                        raw.to_string()
+                        raw.to_vec()
                     }
                 };
 
@@ -993,17 +999,17 @@ fn format_inner_string<'src>(
                 //   EOD
                 let mut rendered_heredocs = false;
                 if ps.has_pending_heredocs()
-                    && !contents.starts_with('\n')
-                    && let Some(newline_idx) = contents.find('\n')
+                    && !contents.starts_with(b"\n")
+                    && let Some(newline_idx) = contents.iter().position(|&b| b == b'\n')
                 {
                     let before_newline = &contents[..newline_idx];
                     if !before_newline.is_empty() {
-                        ps.emit_string_content(before_newline.to_string());
+                        ps.emit_string_content(before_newline.to_vec());
                     }
                     ps.emit_hard_newline_in_heredoc();
                     // Use skip=false to ensure proper newline after heredoc close
                     ps.render_heredocs(false);
-                    contents = contents[newline_idx + 1..].to_string();
+                    contents = contents[newline_idx + 1..].to_vec();
                     rendered_heredocs = true;
                 }
 
@@ -1013,10 +1019,10 @@ fn format_inner_string<'src>(
                 prev_ended_with_newline = if rendered_heredocs && contents.is_empty() {
                     true
                 } else {
-                    contents.ends_with('\n')
+                    contents.ends_with(b"\n")
                 };
 
-                if peekable.peek().is_none() && contents.ends_with('\n') {
+                if peekable.peek().is_none() && contents.ends_with(b"\n") {
                     contents.pop();
                 }
 
@@ -1156,7 +1162,7 @@ fn format_embedded_statements_node<'src>(
     ps: &mut ParserState<'src>,
     embedded_statements_node: prism::EmbeddedStatementsNode<'src>,
 ) {
-    ps.emit_string_content("#{");
+    ps.emit_string_content(b"#{");
     if let Some(statements) = embedded_statements_node.statements() {
         ps.with_formatting_context(FormattingContext::StringEmbexpr, |ps| {
             let has_multiple_statements = statements.body().len() > 1;
@@ -1171,16 +1177,16 @@ fn format_embedded_statements_node<'src>(
             });
         });
     }
-    ps.emit_string_content("}");
+    ps.emit_string_content(b"}");
 }
 
 fn format_embedded_variable_node<'src>(
     ps: &mut ParserState<'src>,
     embedded_variable_node: prism::EmbeddedVariableNode<'src>,
 ) {
-    ps.emit_string_content("#{");
+    ps.emit_string_content(b"#{");
     format_node(ps, embedded_variable_node.variable());
-    ps.emit_string_content("}");
+    ps.emit_string_content(b"}");
 }
 
 fn format_ensure_node<'src>(ps: &mut ParserState<'src>, ensure_node: prism::EnsureNode<'src>) {
@@ -2326,13 +2332,13 @@ fn format_call_body<'src>(
             .and_then(|n| n.as_call_node())
             .filter(|c| c.is_attribute_write())
     {
-        let call_operator = attr_write.call_operator_loc().map(|loc| loc_to_str(loc));
+        let call_operator = attr_write.call_operator_loc().map(|loc| loc.as_slice());
         if let Some(call_operator) = call_operator {
             match call_operator {
-                "." => ps.emit_dot(),
-                "&." => ps.emit_lonely_operator(),
-                "::" => ps.emit_colon_colon(),
-                _ => ps.emit_ident(call_operator.as_bytes()),
+                b"." => ps.emit_dot(),
+                b"&." => ps.emit_lonely_operator(),
+                b"::" => ps.emit_colon_colon(),
+                _ => ps.emit_ident(call_operator),
             }
         }
 
@@ -2351,9 +2357,9 @@ fn format_call_body<'src>(
 
                 // `call_operator_loc` is the `.`/`::`/`&.` etc.
                 // it may be None in the case of arefs, e.g. foo[bar]
-                let call_operator = element.call_operator_loc().map(|loc| loc_to_str(loc));
+                let call_operator = element.call_operator_loc().map(|loc| loc.as_slice());
                 if let Some(call_operator) = call_operator {
-                    if call_operator != "::" {
+                    if call_operator != b"::" {
                         ps.emit_collapsing_newline();
                         ps.emit_soft_indent();
                     }
@@ -2362,10 +2368,10 @@ fn format_call_body<'src>(
                     // in single_line_string_length (which is used to determine whether to
                     // break the call chain or just the arguments)
                     match call_operator {
-                        "." => ps.emit_dot(),
-                        "&." => ps.emit_lonely_operator(),
-                        "::" => ps.emit_colon_colon(),
-                        _ => ps.emit_ident(call_operator.as_bytes()),
+                        b"." => ps.emit_dot(),
+                        b"&." => ps.emit_lonely_operator(),
+                        b"::" => ps.emit_colon_colon(),
+                        _ => ps.emit_ident(call_operator),
                     }
                 }
 
@@ -2580,21 +2586,20 @@ fn format_call_target_node<'src>(
 }
 
 fn format_symbol_node<'src>(ps: &mut ParserState<'src>, symbol_node: prism::SymbolNode<'src>) {
-    let opener = symbol_node.opening_loc().map(|s| loc_to_str(s));
-    let closer = symbol_node.closing_loc().map(|s| loc_to_str(s));
+    let opener = symbol_node.opening_loc().map(|s| s.as_slice());
+    let closer = symbol_node.closing_loc().map(|s| s.as_slice());
 
     // Check if this is a quoted symbol that needs normalization to double quotes
     // Symbols like :'"foo"' (single-quoted) should become :"\"foo\""
-    let is_single_quoted = opener.map(|s| s == ":'").unwrap_or(false);
+    let is_single_quoted = opener.map(|s| s == b":'").unwrap_or(false);
 
     if is_single_quoted {
         ps.emit_ident(b":");
         ps.emit_double_quote();
 
         if let Some(value_loc) = symbol_node.value_loc() {
-            let content = loc_to_str(value_loc);
             let escaped = crate::string_escape::single_to_double_quoted(
-                content,
+                value_loc.as_slice(),
                 opener.expect("We must have an opener to know we're single-quoted"),
                 closer.expect("We must have a closer when wrapped in single quotes"),
             );
@@ -2605,7 +2610,7 @@ fn format_symbol_node<'src>(ps: &mut ParserState<'src>, symbol_node: prism::Symb
     } else {
         // For other symbols, emit as-is
         if let Some(opening) = opener {
-            ps.emit_ident(opening.as_bytes());
+            ps.emit_ident(opening);
         }
         if let Some(value_loc) = symbol_node.value_loc() {
             ps.emit_ident(value_loc.as_slice());
@@ -2615,11 +2620,11 @@ fn format_symbol_node<'src>(ps: &mut ParserState<'src>, symbol_node: prism::Symb
             // String symbols, such as the key in `{ "a": b }` will have
             // a closing_str of `"\":"`, so we have to trim instead of
             // dropping the entire closing item.
-            if closing_str.ends_with(":") {
+            if closing_str.ends_with(b":") {
                 closing_str = &closing_str[..(closing_str.len() - 1)];
             }
             if !closing_str.is_empty() {
-                ps.emit_ident(closing_str.as_bytes());
+                ps.emit_ident(closing_str);
             }
         }
     }
@@ -2810,13 +2815,15 @@ fn format_block_local_variable_node<'src>(
 }
 
 fn format_array_node<'src>(ps: &mut ParserState<'src>, array_node: prism::ArrayNode<'src>) {
-    let opening = array_node.opening_loc().map(|loc| loc_to_str(loc).trim());
-    let is_word_array = opening.map(|s| s.starts_with("%")).unwrap_or(false);
+    let opening = array_node
+        .opening_loc()
+        .map(|loc| loc.as_slice().trim_ascii());
+    let is_word_array = opening.map(|s| s.starts_with(b"%")).unwrap_or(false);
 
-    let orig_delim = opening.and_then(|s| s.chars().nth(2)).unwrap_or('[');
+    let orig_delim = opening.and_then(|s| s.get(2).copied()).unwrap_or(b'[');
 
     if is_word_array {
-        ps.emit_ident(opening.unwrap().split_at(2).0.as_bytes());
+        ps.emit_ident(&opening.unwrap()[..2]);
     }
 
     if array_node.elements().is_empty() {
@@ -2875,7 +2882,7 @@ fn format_word_array_elements<'src>(
     ps: &mut ParserState<'src>,
     node_list: prism::NodeList<'src>,
     end_offset: SourceOffset,
-    orig_open_delim: char,
+    orig_open_delim: u8,
 ) {
     let args_count = node_list.len();
     let orig_close_delim = matching_delimiter(orig_open_delim);
@@ -2889,9 +2896,8 @@ fn format_word_array_elements<'src>(
                 if let Some(string_node) = expr.as_string_node() {
                     ps.at_offset(string_node.location().start_offset());
 
-                    let content = loc_to_str(string_node.content_loc());
                     let escaped = crate::string_escape::escape_word_array_content(
-                        content,
+                        string_node.content_loc().as_slice(),
                         orig_open_delim,
                         orig_close_delim,
                     );
@@ -2900,9 +2906,8 @@ fn format_word_array_elements<'src>(
                     ps.at_offset(symbol_node.location().start_offset());
 
                     if let Some(value_loc) = symbol_node.value_loc() {
-                        let content = loc_to_str(value_loc);
                         let escaped = crate::string_escape::escape_word_array_content(
-                            content,
+                            value_loc.as_slice(),
                             orig_open_delim,
                             orig_close_delim,
                         );
@@ -2940,12 +2945,12 @@ fn format_word_array_elements<'src>(
     );
 }
 
-fn matching_delimiter(open: char) -> char {
+fn matching_delimiter(open: u8) -> u8 {
     match open {
-        '[' => ']',
-        '(' => ')',
-        '{' => '}',
-        '<' => '>',
+        b'[' => b']',
+        b'(' => b')',
+        b'{' => b'}',
+        b'<' => b'>',
         // For non-paired delimiters (like ^, |, etc.), the closing is the same
         c => c,
     }
@@ -2954,8 +2959,8 @@ fn matching_delimiter(open: char) -> char {
 fn format_word_array_interpolated_parts<'src>(
     ps: &mut ParserState<'src>,
     parts: prism::NodeList<'src>,
-    orig_open_delim: char,
-    orig_close_delim: char,
+    orig_open_delim: u8,
+    orig_close_delim: u8,
 ) {
     for part in parts.iter() {
         let start_offset = part.location().start_offset();
@@ -2964,9 +2969,8 @@ fn format_word_array_interpolated_parts<'src>(
         ps.at_offset(start_offset);
 
         if let Some(string_node) = part.as_string_node() {
-            let content = loc_to_str(string_node.content_loc());
             let escaped = crate::string_escape::escape_word_array_content(
-                content,
+                string_node.content_loc().as_slice(),
                 orig_open_delim,
                 orig_close_delim,
             );
@@ -3617,9 +3621,9 @@ fn format_hash_pattern_node<'src>(
         });
     }
 
-    let opener = hash_pattern_node.opening_loc().map(|loc| loc_to_str(loc));
+    let opener = hash_pattern_node.opening_loc().map(|loc| loc.as_slice());
     let use_parens = hash_pattern_node.constant().is_some()
-        || opener.map(|s| s.starts_with("(")).unwrap_or(false);
+        || opener.map(|s| s.starts_with(b"(")).unwrap_or(false);
 
     let elements = hash_pattern_node.elements();
 
@@ -4321,7 +4325,7 @@ fn format_match_last_line_node<'src>(
     match_last_line_node: prism::MatchLastLineNode<'src>,
 ) {
     ps.emit_ident(match_last_line_node.opening_loc().as_slice());
-    ps.emit_string_content(loc_to_str(match_last_line_node.content_loc()));
+    ps.emit_string_content(match_last_line_node.content_loc().as_slice());
     ps.emit_ident(match_last_line_node.closing_loc().as_slice());
 }
 
@@ -4623,7 +4627,7 @@ fn format_regular_expression_node<'src>(
     regular_expression_node: prism::RegularExpressionNode<'src>,
 ) {
     ps.emit_ident(regular_expression_node.opening_loc().as_slice());
-    ps.emit_string_content(loc_to_str(regular_expression_node.content_loc()));
+    ps.emit_string_content(regular_expression_node.content_loc().as_slice());
     ps.emit_ident(regular_expression_node.closing_loc().as_slice());
 }
 
@@ -4855,7 +4859,7 @@ fn format_while_node<'src>(ps: &mut ParserState<'src>, while_node: prism::WhileN
 
 fn format_x_string_node<'src>(ps: &mut ParserState<'src>, x_string_node: prism::XStringNode<'src>) {
     ps.emit_ident(b"`");
-    ps.emit_string_content(loc_to_str(x_string_node.content_loc()));
+    ps.emit_string_content(x_string_node.content_loc().as_slice());
     ps.emit_ident(b"`");
 }
 

--- a/librubyfmt/src/heredoc_string.rs
+++ b/librubyfmt/src/heredoc_string.rs
@@ -11,10 +11,10 @@ pub enum HeredocKind {
 }
 
 impl HeredocKind {
-    pub fn from_string(kind_str: &str) -> Self {
-        if kind_str.contains('~') {
+    pub fn from_bytes(kind_bytes: &[u8]) -> Self {
+        if kind_bytes.contains(&b'~') {
             HeredocKind::Squiggly
-        } else if kind_str.contains('-') {
+        } else if kind_bytes.contains(&b'-') {
             HeredocKind::Dash
         } else {
             HeredocKind::Bare
@@ -35,15 +35,15 @@ impl HeredocKind {
 /// that should not be indented.
 #[derive(Debug, Clone)]
 pub enum HeredocSegment {
-    Normal(String),
+    Normal(Vec<u8>),
     /// Content from nested non-squiggly heredocs, should never receive squiggly indentation.
     /// This includes both the heredoc content and the closing identifier.
-    Raw(String),
+    Raw(Vec<u8>),
 }
 
 #[derive(Debug, Clone)]
 pub struct HeredocString<'src> {
-    symbol: Cow<'src, str>,
+    symbol: Cow<'src, [u8]>,
     pub kind: HeredocKind,
     pub segments: Vec<HeredocSegment>,
     pub indent: ColNumber,
@@ -51,7 +51,7 @@ pub struct HeredocString<'src> {
 
 impl<'src> HeredocString<'src> {
     pub fn new(
-        symbol: Cow<'src, str>,
+        symbol: Cow<'src, [u8]>,
         kind: HeredocKind,
         segments: Vec<HeredocSegment>,
         indent: ColNumber,
@@ -64,32 +64,33 @@ impl<'src> HeredocString<'src> {
         }
     }
 
-    pub fn render_as_string(self) -> String {
+    pub fn render_as_bytes(self) -> Vec<u8> {
         let indent = self.indent;
 
         if self.kind.is_squiggly() {
             // For squiggly heredocs, we need to apply indentation to Normal segments
             // but not to Raw segments (which come from nested non-squiggly heredocs).
-            let mut result = String::new();
+            let mut result = Vec::new();
             for segment in self.segments {
                 match segment {
                     HeredocSegment::Normal(content) => {
                         // Apply squiggly indentation to each line
-                        for (i, line) in content.split('\n').enumerate() {
+                        for (i, line) in content.split(|&b| b == b'\n').enumerate() {
                             if i > 0 {
-                                result.push('\n');
+                                result.push(b'\n');
                             }
-                            let indented = format!("{}{}", get_indent(indent as usize + 2), line);
-                            result.push_str(indented.trim_end());
+                            let mut indented = get_indent(indent as usize + 2).into_owned();
+                            indented.extend_from_slice(line);
+                            result.extend_from_slice(indented.trim_ascii_end());
                         }
                     }
                     HeredocSegment::Raw(content) => {
                         // No indentation for raw content (nested non-squiggly heredocs)
-                        for (i, line) in content.split('\n').enumerate() {
+                        for (i, line) in content.split(|&b| b == b'\n').enumerate() {
                             if i > 0 {
-                                result.push('\n');
+                                result.push(b'\n');
                             }
-                            result.push_str(line.trim_end());
+                            result.extend_from_slice(line.trim_ascii_end());
                         }
                     }
                 }
@@ -97,16 +98,16 @@ impl<'src> HeredocString<'src> {
             result
         } else {
             // For non-squiggly heredocs, just join segments and trim line endings
-            let mut result = String::new();
+            let mut result = Vec::new();
             for segment in self.segments {
                 let content = match segment {
                     HeredocSegment::Normal(s) | HeredocSegment::Raw(s) => s,
                 };
-                for (i, line) in content.split('\n').enumerate() {
+                for (i, line) in content.split(|&b| b == b'\n').enumerate() {
                     if i > 0 {
-                        result.push('\n');
+                        result.push(b'\n');
                     }
-                    result.push_str(line.trim_end());
+                    result.extend_from_slice(line.trim_ascii_end());
                 }
             }
             result
@@ -127,7 +128,11 @@ impl<'src> HeredocString<'src> {
     /// However, the closing symbol should *not* have
     /// quotes, so we must strip them from the symbol when
     /// rendering the closing symbol.
-    pub fn closing_symbol(&self) -> String {
-        self.symbol.replace(['\'', '"'], "")
+    pub fn closing_symbol(&self) -> Vec<u8> {
+        self.symbol
+            .iter()
+            .filter(|&&b| b != b'\'' && b != b'"')
+            .copied()
+            .collect()
     }
 }

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -16,7 +16,7 @@ pub fn clats_direct_part<'src>(
     })
 }
 
-pub fn clats_heredoc_close<'src>(symbol: String) -> ConcreteLineTokenAndTargets<'src> {
+pub fn clats_heredoc_close<'src>(symbol: Vec<u8>) -> ConcreteLineTokenAndTargets<'src> {
     ConcreteLineTokenAndTargets::ConcreteLineToken(ConcreteLineToken::HeredocClose { symbol })
 }
 
@@ -65,7 +65,7 @@ pub enum ConcreteLineToken<'src> {
     },
     DoubleQuote,
     LTStringContent {
-        content: Cow<'src, str>,
+        content: Cow<'src, [u8]>,
     },
     SingleSlash,
     Comment {
@@ -76,7 +76,7 @@ pub enum ConcreteLineToken<'src> {
     },
     End,
     HeredocClose {
-        symbol: String,
+        symbol: Vec<u8>,
     },
     // These are "magic" tokens. They have no concrete representation,
     // but they're meaningful inside of the render queue
@@ -85,10 +85,10 @@ pub enum ConcreteLineToken<'src> {
     EndCallChainIndent,
     HeredocStart {
         kind: HeredocKind,
-        symbol: &'src str,
+        symbol: &'src [u8],
     },
     RawHeredocContent {
-        content: String,
+        content: Vec<u8>,
     },
 }
 
@@ -96,10 +96,7 @@ impl<'src> ConcreteLineToken<'src> {
     pub fn into_ruby(self) -> Cow<'src, [u8]> {
         match self {
             Self::HardNewLine => Cow::Borrowed(b"\n"),
-            Self::Indent { depth } => match get_indent(depth as usize) {
-                Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
-                Cow::Owned(s) => Cow::Owned(s.into_bytes()),
-            },
+            Self::Indent { depth } => get_indent(depth as usize),
             Self::Keyword { keyword } => Cow::Borrowed(keyword.as_bytes()),
             Self::ConditionalKeyword { contents } => Cow::Borrowed(contents.as_bytes()),
             Self::DoKeyword => Cow::Borrowed(b"do"),
@@ -122,17 +119,14 @@ impl<'src> ConcreteLineToken<'src> {
             Self::CloseParen => Cow::Borrowed(b")"),
             Self::Op { op } => Cow::Borrowed(op),
             Self::DoubleQuote => Cow::Borrowed(b"\""),
-            Self::LTStringContent { content } => match content {
-                Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
-                Cow::Owned(s) => Cow::Owned(s.into_bytes()),
-            },
+            Self::LTStringContent { content } => content,
             Self::SingleSlash => Cow::Borrowed(b"\\"),
             Self::Comment { contents } => contents,
             Self::Delim { contents } => Cow::Borrowed(contents.as_bytes()),
             Self::End => Cow::Borrowed(b"end"),
-            Self::HeredocClose { symbol } => Cow::Owned(symbol.into()),
-            Self::HeredocStart { symbol, .. } => Cow::Borrowed(symbol.as_bytes()),
-            Self::RawHeredocContent { content } => Cow::Owned(content.into()),
+            Self::HeredocClose { symbol } => Cow::Owned(symbol),
+            Self::HeredocStart { symbol, .. } => Cow::Borrowed(symbol),
+            Self::RawHeredocContent { content } => Cow::Owned(content),
             // no-op, this is purely semantic information
             // for the render queue
             Self::AfterCallChain | Self::BeginCallChainIndent | Self::EndCallChainIndent => {
@@ -355,9 +349,9 @@ impl<'src> AbstractLineToken<'src> {
                 let kind = hds.kind;
                 let symbol = hds.closing_symbol();
 
-                let s = hds.render_as_string();
+                let s = hds.render_as_bytes();
                 if !s.is_empty() {
-                    out.push(clats_direct_part(s.into_bytes()));
+                    out.push(clats_direct_part(s));
                     out.push(cltats_hard_newline());
                 }
                 if !kind.is_bare() {

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -11,7 +11,6 @@ use crate::types::{ColNumber, LineNumber, SourceOffset};
 use log::debug;
 use std::borrow::Cow;
 use std::io::{self, Write};
-use std::str;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FormattingContext {
@@ -90,7 +89,7 @@ impl<'src> ParserState<'src> {
     }
     pub(crate) fn push_heredoc_content<F>(
         &mut self,
-        symbol: impl Into<Cow<'src, str>>,
+        symbol: impl Into<Cow<'src, [u8]>>,
         kind: HeredocKind,
         end_line: LineNumber,
         formatting_func: F,
@@ -121,11 +120,11 @@ impl<'src> ParserState<'src> {
         ));
     }
 
-    pub(crate) fn emit_heredoc_start(&mut self, symbol: &'src str, kind: HeredocKind) {
+    pub(crate) fn emit_heredoc_start(&mut self, symbol: &'src [u8], kind: HeredocKind) {
         self.push_concrete_token(ConcreteLineToken::HeredocStart { kind, symbol });
     }
 
-    pub(crate) fn emit_heredoc_close(&mut self, symbol: String) {
+    pub(crate) fn emit_heredoc_close(&mut self, symbol: Vec<u8>) {
         self.push_concrete_token(ConcreteLineToken::HeredocClose { symbol });
     }
 
@@ -390,9 +389,9 @@ impl<'src> ParserState<'src> {
         self.push_concrete_token(ConcreteLineToken::DoubleQuote);
     }
 
-    pub(crate) fn emit_string_content(&mut self, s: impl Into<Cow<'src, str>>) {
+    pub(crate) fn emit_string_content(&mut self, s: impl Into<Cow<'src, [u8]>>) {
         let content = s.into();
-        let newline_count = content.matches('\n').count() as u64;
+        let newline_count = content.iter().filter(|&&b| b == b'\n').count() as u64;
         self.current_orig_line_number += newline_count;
         for be in self.breakable_entry_stack.iter_mut().rev() {
             be.push_line_number(self.current_orig_line_number);
@@ -653,7 +652,7 @@ impl<'src> ParserState<'src> {
             let kind = next_heredoc.kind;
             let symbol = next_heredoc.closing_symbol();
             let space_count = next_heredoc.indent;
-            let string_contents = next_heredoc.render_as_string();
+            let string_contents = next_heredoc.render_as_bytes();
 
             // When inside a squiggly heredoc context and this is a non-squiggly heredoc,
             // emit RawHeredocContent tokens so the content won't receive squiggly indentation.
@@ -666,7 +665,7 @@ impl<'src> ParserState<'src> {
                     });
                 } else {
                     self.push_concrete_token(ConcreteLineToken::DirectPart {
-                        part: Cow::Owned(string_contents.into_bytes()),
+                        part: Cow::Owned(string_contents),
                     });
                 }
                 self.emit_newline();
@@ -675,14 +674,13 @@ impl<'src> ParserState<'src> {
             if emit_as_raw {
                 // For bare/dash heredocs inside squiggly context, emit the close as raw content
                 let close_content = if kind.is_bare() {
-                    symbol.replace('\'', "")
+                    symbol
                 } else {
                     // Dash heredocs can have indented close
-                    format!(
-                        "{}{}",
-                        crate::util::get_indent(space_count as usize),
-                        symbol.replace('\'', "")
-                    )
+                    let indent = crate::util::get_indent(space_count as usize);
+                    let mut content = indent.into_owned();
+                    content.extend_from_slice(&symbol);
+                    content
                 };
                 self.push_concrete_token(ConcreteLineToken::RawHeredocContent {
                     content: close_content,
@@ -691,7 +689,7 @@ impl<'src> ParserState<'src> {
                 if !kind.is_bare() {
                     self.push_concrete_token(ConcreteLineToken::Indent { depth: space_count });
                 }
-                self.emit_heredoc_close(symbol.replace('\'', ""));
+                self.emit_heredoc_close(symbol);
             }
 
             if !skip {
@@ -820,9 +818,9 @@ impl<'src> ParserState<'src> {
         let final_tokens = rqw.into_tokens();
 
         let mut segments = Vec::new();
-        let mut current_normal = String::new();
+        let mut current_normal = Vec::new();
 
-        fn flush_normal(current: &mut String, segments: &mut Vec<HeredocSegment>) {
+        fn flush_normal(current: &mut Vec<u8>, segments: &mut Vec<HeredocSegment>) {
             if !current.is_empty() {
                 segments.push(HeredocSegment::Normal(std::mem::take(current)));
             }
@@ -835,9 +833,7 @@ impl<'src> ParserState<'src> {
                 segments.push(HeredocSegment::Raw(content));
             } else {
                 // Accumulate into normal content
-                current_normal
-                    // TODO(@reese): Use &[u8] here when string internals are updated
-                    .push_str(std::str::from_utf8(&token.into_ruby()).unwrap());
+                current_normal.extend_from_slice(&token.into_ruby());
             }
         }
 

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -66,7 +66,7 @@ impl<'src> RenderQueueWriter<'src> {
                 }) => {
                     if !contents.is_empty() {
                         let indent = get_indent(accum.additional_indent as usize * 2);
-                        let mut new_contents = indent.as_bytes().to_vec();
+                        let mut new_contents = indent.into_owned();
                         new_contents.extend_from_slice(contents);
                         next_token = ConcreteLineTokenAndTargets::ConcreteLineToken(
                             ConcreteLineToken::Comment {
@@ -83,7 +83,7 @@ impl<'src> RenderQueueWriter<'src> {
                         .unwrap_or(false)
                     {
                         let indent = get_indent(accum.additional_indent as usize * 2);
-                        let indent_bytes = indent.as_bytes();
+                        let indent_bytes = indent.as_ref();
                         let mut new_contents = Vec::new();
                         let parts = part.split(|&b| b == b'\n');
 
@@ -108,11 +108,9 @@ impl<'src> RenderQueueWriter<'src> {
                     // Bare heredocs (e.g. <<FOO) must have the closing ident completely unindented, so
                     // ignore them in this case
                     if current_heredoc_kind.map(|k| !k.is_bare()).unwrap_or(false) {
-                        let new_contents: String = format!(
-                            "{}{}",
-                            get_indent(accum.additional_indent as usize * 2),
-                            symbol
-                        );
+                        let indent = get_indent(accum.additional_indent as usize * 2);
+                        let mut new_contents = indent.into_owned();
+                        new_contents.extend_from_slice(symbol);
                         next_token = clats_heredoc_close(new_contents);
                     }
                     current_heredoc_kind = None;

--- a/librubyfmt/src/string_escape.rs
+++ b/librubyfmt/src/string_escape.rs
@@ -1,46 +1,46 @@
 use std::borrow::Cow;
 
 pub fn single_to_double_quoted<'src>(
-    content: &'src str,
-    start_delim: &'src str,
-    end_delim: &'src str,
-) -> Cow<'src, str> {
-    if start_delim == "'" || start_delim.starts_with("%q") {
+    content: &'src [u8],
+    start_delim: &'src [u8],
+    end_delim: &'src [u8],
+) -> Cow<'src, [u8]> {
+    if start_delim == b"'" || start_delim.starts_with(b"%q") {
         escape_string(
             content,
-            start_delim.chars().last().unwrap(),
-            end_delim.chars().last().unwrap(),
+            *start_delim.last().unwrap(),
+            *end_delim.last().unwrap(),
         )
         .into()
     } else {
-        let start_delim_char = start_delim.chars().last().unwrap();
-        let end_delim_char = end_delim.chars().last().unwrap();
-        convert_percent_literal_escapes(content, start_delim_char, end_delim_char)
+        let start_delim_byte = *start_delim.last().unwrap();
+        let end_delim_byte = *end_delim.last().unwrap();
+        convert_percent_literal_escapes(content, start_delim_byte, end_delim_byte)
     }
 }
 
 /// Converts escape sequences in a percent-literal string's content so they are
 /// valid inside a double-quoted string.
 fn convert_percent_literal_escapes(
-    content: &str,
-    start_delim: char,
-    end_delim: char,
-) -> Cow<'_, str> {
+    content: &[u8],
+    start_delim: u8,
+    end_delim: u8,
+) -> Cow<'_, [u8]> {
     let first_change_pos = {
         let mut pos = None;
-        let mut chars = content.char_indices().peekable();
-        while let Some((i, c)) = chars.next() {
-            if c == '"' {
+        let mut bytes = content.iter().copied().enumerate().peekable();
+        while let Some((i, c)) = bytes.next() {
+            if c == b'"' {
                 pos = Some(i);
                 break;
-            } else if c == '\\'
-                && let Some(&(_, next)) = chars.peek()
+            } else if c == b'\\'
+                && let Some(&(_, next)) = bytes.peek()
             {
                 if next == start_delim || next == end_delim {
                     pos = Some(i);
                     break;
                 }
-                chars.next(); // skip next char — treat \X as a unit
+                bytes.next(); // skip next byte — treat \X as a unit
             }
         }
         pos
@@ -50,27 +50,27 @@ fn convert_percent_literal_escapes(
         return Cow::Borrowed(content); // No changes
     };
 
-    let mut output = content[..start].to_string();
-    let mut chars = content[start..].chars().peekable();
+    let mut output = content[..start].to_vec();
+    let mut bytes = content[start..].iter().copied().peekable();
 
-    while let Some(c) = chars.next() {
-        if c == '\\' {
-            if let Some(&next) = chars.peek() {
+    while let Some(c) = bytes.next() {
+        if c == b'\\' {
+            if let Some(&next) = bytes.peek() {
                 if next == start_delim || next == end_delim {
                     // Drop the delimiter escape: \( → (
                     output.push(next);
-                    chars.next();
+                    bytes.next();
                 } else {
                     // Write back the original with no changes
-                    output.push('\\');
+                    output.push(b'\\');
                     output.push(next);
-                    chars.next();
+                    bytes.next();
                 }
             } else {
-                output.push('\\');
+                output.push(b'\\');
             }
-        } else if c == '"' {
-            output.push_str("\\\"");
+        } else if c == b'"' {
+            output.extend_from_slice(b"\\\"");
         } else {
             output.push(c);
         }
@@ -82,43 +82,43 @@ fn convert_percent_literal_escapes(
 /// Escapes content for word arrays when converting to bracket delimiters.
 /// This handles unescaping the original delimiter and escaping [ and ] (since they're the new delimiters)
 pub fn escape_word_array_content(
-    content: &str,
-    orig_open_delim: char,
-    orig_close_delim: char,
-) -> String {
+    content: &[u8],
+    orig_open_delim: u8,
+    orig_close_delim: u8,
+) -> Vec<u8> {
     // Output is always [] delimited
-    const TARGET_OPEN: char = '[';
-    const TARGET_CLOSE: char = ']';
+    const TARGET_OPEN: u8 = b'[';
+    const TARGET_CLOSE: u8 = b']';
 
-    let mut chars = content.chars().peekable();
-    let mut output = String::new();
+    let mut bytes = content.iter().copied().peekable();
+    let mut output = Vec::new();
 
-    while let Some(c) = chars.next() {
-        if c == '\\' {
-            if let Some(&next) = chars.peek() {
-                if next == '\\' {
+    while let Some(c) = bytes.next() {
+        if c == b'\\' {
+            if let Some(&next) = bytes.peek() {
+                if next == b'\\' {
                     // Escaped backslash, keep both
-                    output.push('\\');
-                    output.push('\\');
+                    output.push(b'\\');
+                    output.push(b'\\');
                 } else if next == orig_open_delim || next == orig_close_delim {
                     // Original delimiter was escaped - unescape unless it's also a target delimiter
                     if next == TARGET_OPEN || next == TARGET_CLOSE {
-                        output.push('\\');
+                        output.push(b'\\');
                     }
                     output.push(next);
                 } else if next == TARGET_OPEN || next == TARGET_CLOSE {
                     // Already escaped target delimiter, keep it
-                    output.push('\\');
+                    output.push(b'\\');
                     output.push(next);
                 } else {
-                    output.push('\\');
+                    output.push(b'\\');
                     output.push(next);
                 }
-                chars.next();
+                bytes.next();
             }
         } else if c == TARGET_OPEN || c == TARGET_CLOSE {
             // Unescaped target delimiter needs escaping
-            output.push('\\');
+            output.push(b'\\');
             output.push(c);
         } else {
             output.push(c);
@@ -128,77 +128,77 @@ pub fn escape_word_array_content(
     output
 }
 
-fn escape_string(content: &str, opening_delim: char, closing_delim: char) -> String {
-    if opening_delim == '"' {
-        return content.to_string();
+fn escape_string(content: &[u8], opening_delim: u8, closing_delim: u8) -> Vec<u8> {
+    if opening_delim == b'"' {
+        return content.to_vec();
     }
 
-    let mut chars = content.chars().peekable();
-    let mut output = String::new();
+    let mut bytes = content.iter().copied().peekable();
+    let mut output = Vec::new();
 
-    while let Some(c) = chars.next() {
+    while let Some(c) = bytes.next() {
         match c {
-            '"' => {
-                output.push('\\');
+            b'"' => {
+                output.push(b'\\');
             }
-            '\\' => {
-                if let Some(&next_char) = chars.peek() {
+            b'\\' => {
+                if let Some(&next_char) = bytes.peek() {
                     match next_char {
-                        '\'' => {
+                        b'\'' => {
                             // String#inspect strips the leading backslash from \', despite it being a valid
                             // escape character in double-quoted strings as well. Leaving the behavior the same
                             // for consistency with the previous behavior.
-                            output.push('\'');
-                            chars.next();
+                            output.push(b'\'');
+                            bytes.next();
                             continue;
                         }
                         // '\\' is considered an escape sequence in both single and double quoted strings
                         // and thus we don't need to "double-escape" it to "\\\\"
-                        '\\' => {
-                            output.push_str("\\\\");
-                            chars.next();
+                        b'\\' => {
+                            output.extend_from_slice(b"\\\\");
+                            bytes.next();
                             continue;
                         }
                         // '\"' is a slash char and a double-quote char, not an escaped double-quote,
                         // so here we print an escaped slash character and then an escaped quote character: `"\\\""`
-                        '"' => {
-                            output.push_str("\\\\\\\"");
-                            chars.next();
+                        b'"' => {
+                            output.extend_from_slice(b"\\\\\\\"");
+                            bytes.next();
                             continue;
                         }
-                        delim_char
-                            if (delim_char == opening_delim || delim_char == closing_delim)
+                        delim_byte
+                            if (delim_byte == opening_delim || delim_byte == closing_delim)
                                 // We only care about the "non-standard" delimiters like %() etc.
                                 // For single-quoted strings, these characters should *not* be treated as escape sequences.
-                                && opening_delim != '\'' =>
+                                && opening_delim != b'\'' =>
                         {
                             // In percent-strings, the opening and closing delimiters can be escaped to prevent terminating the string.
-                            output.push(delim_char);
-                            chars.next();
+                            output.push(delim_byte);
+                            bytes.next();
                             continue;
                         }
-                        // For everything else, this is not an escape sequnce, so we need to
+                        // For everything else, this is not an escape sequence, so we need to
                         // escape the slash and then print the next character.
                         _ => {
-                            output.push('\\');
-                            output.push('\\');
+                            output.push(b'\\');
+                            output.push(b'\\');
                             output.push(next_char);
-                            chars.next();
+                            bytes.next();
                             continue;
                         }
                     }
                 }
             }
-            '#' => {
-                if let Some(&next_char) = chars.peek() {
+            b'#' => {
+                if let Some(&next_char) = bytes.peek() {
                     match next_char {
                         // These are shorthands for embedded variables when double-quoted,
                         // e.g. "#@foo", "#$GLOBAL", and "#{1}", so they must be escaped
-                        '$' | '@' | '{' => {
-                            output.push('\\');
+                        b'$' | b'@' | b'{' => {
+                            output.push(b'\\');
                             output.push(c);
                             output.push(next_char);
-                            chars.next();
+                            bytes.next();
                             continue;
                         }
                         _ => {}

--- a/librubyfmt/src/util.rs
+++ b/librubyfmt/src/util.rs
@@ -1,26 +1,16 @@
 use std::borrow::Cow;
 
-use ruby_prism::Location;
-
 /// Maximum indent depth we cache without allocation.
 const MAX_CACHED_INDENT: usize = 128;
-/// A pre-allocated string of spaces for efficient indentation
-const SPACES: &str = unsafe { std::str::from_utf8_unchecked(&[b' '; MAX_CACHED_INDENT]) };
+/// A pre-allocated array of spaces for efficient indentation
+const SPACES: &[u8] = &[b' '; MAX_CACHED_INDENT];
 
-/// Returns a string of `depth` spaces. For common indent depths (<= 128),
+/// Returns a byte slice of `depth` spaces. For common indent depths (<= 128),
 /// this returns a static slice and only allocates for huge indents.
-pub fn get_indent(depth: usize) -> Cow<'static, str> {
+pub fn get_indent(depth: usize) -> Cow<'static, [u8]> {
     if depth <= MAX_CACHED_INDENT {
         Cow::Borrowed(&SPACES[..depth])
     } else {
-        Cow::Owned(" ".repeat(depth))
+        Cow::Owned(vec![b' '; depth])
     }
-}
-
-fn u8_to_str(arr: &[u8]) -> &str {
-    std::str::from_utf8(arr).unwrap()
-}
-
-pub fn loc_to_str(loc: Location<'_>) -> &str {
-    u8_to_str(loc.as_slice())
 }

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -1,7 +1,7 @@
 use libtest_mimic::{Arguments, Trial};
 use std::{
     collections::HashMap,
-    fs::{self, read_to_string},
+    fs::{self, read},
     io,
     path::{Path, PathBuf},
 };
@@ -43,7 +43,7 @@ impl Fixture {
                 );
             };
 
-            let expected_text = read_to_string(&expected)?;
+            let expected_text = read(&expected)?;
 
             // Test if the formatting works as expected
             let mut cmd = Command::cargo_bin("rubyfmt-main").unwrap();


### PR DESCRIPTION
Closes #832 

This updates all of the string conversion internals to operate on `Vec<u8>` instead of `String`. This is a bit of a big change, but it's all intertwined and is easiest to change all at once, and the change is generally mechanical. This also gets rid of the last usages of `loc_to_str` and `u8_to_str` and removes them both.