### PR TITLE
Add unit tests for string escape logic

### DIFF
--- a/librubyfmt/src/string_escape.rs
+++ b/librubyfmt/src/string_escape.rs
@@ -115,6 +115,8 @@ pub fn escape_word_array_content(
                     output.push(next);
                 }
                 bytes.next();
+            } else {
+                output.push(b'\\');
             }
         } else if c == TARGET_OPEN || c == TARGET_CLOSE {
             // Unescaped target delimiter needs escaping
@@ -211,4 +213,230 @@ fn escape_string(content: &[u8], opening_delim: u8, closing_delim: u8) -> Vec<u8
     }
 
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- escape_string with single-quoted strings ---
+
+    #[test]
+    fn single_quoted_empty() {
+        assert_eq!(single_to_double_quoted(b"", b"'", b"'").as_ref(), b"");
+    }
+
+    #[test]
+    fn single_quoted_plain_content() {
+        assert_eq!(
+            single_to_double_quoted(b"hello", b"'", b"'").as_ref(),
+            b"hello"
+        );
+    }
+
+    #[test]
+    fn single_quoted_escapes_double_quote() {
+        assert_eq!(
+            single_to_double_quoted(b"say \"hi\"", b"'", b"'").as_ref(),
+            b"say \\\"hi\\\""
+        );
+    }
+
+    #[test]
+    fn single_quoted_strips_backslash_before_single_quote() {
+        // \' is valid in single-quoted strings but meaningless in double-quoted; strip it
+        assert_eq!(single_to_double_quoted(b"\\'", b"'", b"'").as_ref(), b"'");
+    }
+
+    #[test]
+    fn single_quoted_preserves_escaped_backslash() {
+        assert_eq!(
+            single_to_double_quoted(b"\\\\", b"'", b"'").as_ref(),
+            b"\\\\"
+        );
+    }
+
+    #[test]
+    fn single_quoted_backslash_before_double_quote() {
+        // '\"' is a literal backslash + double-quote (not an escape sequence in single-quoted).
+        // In double-quoted, that must be \\\" (escaped backslash, then escaped quote).
+        assert_eq!(
+            single_to_double_quoted(b"\\\"", b"'", b"'").as_ref(),
+            b"\\\\\\\""
+        );
+    }
+
+    #[test]
+    fn single_quoted_doubles_backslash_before_unknown_escape() {
+        // '\n' in single-quoted is a literal backslash + n (not a newline).
+        // In double-quoted, \n would be a newline, so the backslash must be doubled.
+        assert_eq!(
+            single_to_double_quoted(b"\\n", b"'", b"'").as_ref(),
+            b"\\\\n"
+        );
+    }
+
+    #[test]
+    fn single_quoted_escapes_hash_dollar_interpolation() {
+        // '#$foo' in double-quoted would interpolate $foo — escape the #
+        assert_eq!(
+            single_to_double_quoted(b"#$foo", b"'", b"'").as_ref(),
+            b"\\#$foo"
+        );
+    }
+
+    #[test]
+    fn single_quoted_escapes_hash_at_interpolation() {
+        assert_eq!(
+            single_to_double_quoted(b"#@foo", b"'", b"'").as_ref(),
+            b"\\#@foo"
+        );
+    }
+
+    #[test]
+    fn single_quoted_escapes_hash_brace_interpolation() {
+        assert_eq!(
+            single_to_double_quoted(b"#{foo}", b"'", b"'").as_ref(),
+            b"\\#{foo}"
+        );
+    }
+
+    #[test]
+    fn single_quoted_hash_before_regular_char_not_escaped() {
+        assert_eq!(
+            single_to_double_quoted(b"#foo", b"'", b"'").as_ref(),
+            b"#foo"
+        );
+    }
+
+    // --- escape_string with %q(...) strings ---
+
+    #[test]
+    fn percent_q_unescapes_open_delimiter() {
+        // \( was escaping the %q( delimiter; in double-quoted it's just (
+        assert_eq!(single_to_double_quoted(b"\\(", b"%q(", b")").as_ref(), b"(");
+    }
+
+    #[test]
+    fn percent_q_unescapes_close_delimiter() {
+        assert_eq!(single_to_double_quoted(b"\\)", b"%q(", b")").as_ref(), b")");
+    }
+
+    #[test]
+    fn percent_q_escapes_double_quote() {
+        assert_eq!(
+            single_to_double_quoted(b"\"", b"%q(", b")").as_ref(),
+            b"\\\""
+        );
+    }
+
+    // --- convert_percent_literal_escapes with %Q(...) strings ---
+
+    #[test]
+    fn percent_q_upper_no_changes_returns_borrowed() {
+        // No " and no escaped delimiters: should return the original slice
+        let result = single_to_double_quoted(b"hello world", b"%Q(", b")");
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(result.as_ref(), b"hello world");
+    }
+
+    #[test]
+    fn percent_q_upper_double_quote_triggers_owned() {
+        let result = single_to_double_quoted(b"say \"hi\"", b"%Q(", b")");
+        assert!(matches!(result, Cow::Owned(_)));
+        assert_eq!(result.as_ref(), b"say \\\"hi\\\"");
+    }
+
+    #[test]
+    fn percent_q_upper_unescapes_open_delimiter() {
+        assert_eq!(single_to_double_quoted(b"\\(", b"%Q(", b")").as_ref(), b"(");
+    }
+
+    #[test]
+    fn percent_q_upper_unescapes_close_delimiter() {
+        assert_eq!(single_to_double_quoted(b"\\)", b"%Q(", b")").as_ref(), b")");
+    }
+
+    #[test]
+    fn percent_q_upper_preserves_other_backslash_sequences() {
+        let result = single_to_double_quoted(b"\\n", b"%Q(", b")");
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(result.as_ref(), b"\\n");
+    }
+
+    #[test]
+    fn percent_q_upper_preserves_escaped_backslash() {
+        let result = single_to_double_quoted(b"\\\\", b"%Q(", b")");
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(result.as_ref(), b"\\\\");
+    }
+
+    #[test]
+    fn percent_q_upper_trailing_backslash_preserved() {
+        let result = single_to_double_quoted(b"foo\\", b"%Q(", b")");
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(result.as_ref(), b"foo\\");
+    }
+
+    // --- escape_word_array_content ---
+
+    #[test]
+    fn word_array_plain_content() {
+        assert_eq!(escape_word_array_content(b"hello", b'(', b')'), b"hello");
+    }
+
+    #[test]
+    fn word_array_escapes_open_bracket() {
+        assert_eq!(escape_word_array_content(b"[", b'(', b')'), b"\\[");
+    }
+
+    #[test]
+    fn word_array_escapes_close_bracket() {
+        assert_eq!(escape_word_array_content(b"]", b'(', b')'), b"\\]");
+    }
+
+    #[test]
+    fn word_array_unescapes_original_open_delim() {
+        // \( was needed to escape the %w( delimiter; in %w[...] it's just (
+        assert_eq!(escape_word_array_content(b"\\(", b'(', b')'), b"(");
+    }
+
+    #[test]
+    fn word_array_unescapes_original_close_delim() {
+        assert_eq!(escape_word_array_content(b"\\)", b'(', b')'), b")");
+    }
+
+    #[test]
+    fn word_array_preserves_escaped_backslash() {
+        assert_eq!(escape_word_array_content(b"\\\\", b'(', b')'), b"\\\\");
+    }
+
+    #[test]
+    fn word_array_keeps_already_escaped_open_bracket() {
+        assert_eq!(escape_word_array_content(b"\\[", b'(', b')'), b"\\[");
+    }
+
+    #[test]
+    fn word_array_keeps_already_escaped_close_bracket() {
+        assert_eq!(escape_word_array_content(b"\\]", b'(', b')'), b"\\]");
+    }
+
+    #[test]
+    fn word_array_preserves_other_backslash_sequences() {
+        assert_eq!(escape_word_array_content(b"\\n", b'(', b')'), b"\\n");
+    }
+
+    #[test]
+    fn word_array_orig_delim_is_target_stays_escaped() {
+        // When orig delim is [ (same as the target), \[ must remain \[ rather than being unescaped
+        assert_eq!(escape_word_array_content(b"\\[", b'[', b']'), b"\\[");
+    }
+
+    #[test]
+    fn word_array_trailing_backslash_preserved() {
+        // Technically this probably isn't reachable in valid Ruby code,
+        // e.g. `%w(foo\)` is not valid, but we have it here defensively to
+        // prevent accidentally dropping a slash in an edge case
+        assert_eq!(escape_word_array_content(b"foo\\", b'(', b')'), b"foo\\");
+    }
 }


### PR DESCRIPTION
`rubyfmt` is almost entirely tested with fixtures. This is mostly fine, but there's a few isolated bits of logic that could use some unit testing. String escaping is the most obvious one -- it's bytes in to bytes out and has quite specific rules that are easy to test in isolation. (Heredocs and some of the comment bits also could use them, but strings are probably the highest value for now.)

This does add one `else` branch to the actual production code purely as a defense mechanism/future-proof that I saw in unit tests, but I'm fairly confident it's never reachable in real Ruby code (see the `word_array_trailing_backslash_preserved` test). It covers a trailing slash in a `%w` array, which in real usages (`%w[\]`) would escape the closing delimiter and be invalid, so that `else` is unreachable, but as far as `escape_word_array_content` is concerned it does the right thing if it ever were to get in that state.