### PR TITLE
Remove unused clippy allow

### DIFF
--- a/librubyfmt/src/lib.rs
+++ b/librubyfmt/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(warnings, missing_copy_implementations)]
-#![allow(clippy::upper_case_acronyms, clippy::enum_variant_names)]
 
 use std::io::{Cursor, Write};
 


### PR DESCRIPTION
On the tin -- I think this is a remnant from when Ripper/Ruby struct names used non-standard naming conventions, but that's no longer needed.