### PR TITLE
Move keywords and delimiters to use `u8` slices

### DIFF
--- a/librubyfmt/src/delimiters.rs
+++ b/librubyfmt/src/delimiters.rs
@@ -2,12 +2,12 @@ use crate::line_tokens::ConcreteLineToken;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct DelimiterPair {
-    open: &'static str,
-    close: &'static str,
+    open: &'static [u8],
+    close: &'static [u8],
 }
 
 impl DelimiterPair {
-    fn new(open: &'static str, close: &'static str) -> Self {
+    fn new(open: &'static [u8], close: &'static [u8]) -> Self {
         DelimiterPair { open, close }
     }
 }
@@ -21,71 +21,71 @@ pub struct BreakableDelims {
 impl BreakableDelims {
     pub fn for_method_call() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new("(", ")"),
-            multi_line: DelimiterPair::new("(", ")"),
+            single_line: DelimiterPair::new(b"(", b")"),
+            multi_line: DelimiterPair::new(b"(", b")"),
         }
     }
 
     pub fn for_return_kw() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new(" ", ""),
-            multi_line: DelimiterPair::new(" [", "]"),
+            single_line: DelimiterPair::new(b" ", b""),
+            multi_line: DelimiterPair::new(b" [", b"]"),
         }
     }
 
     pub fn for_kw() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new(" ", ""),
-            multi_line: DelimiterPair::new("(", ")"),
+            single_line: DelimiterPair::new(b" ", b""),
+            multi_line: DelimiterPair::new(b"(", b")"),
         }
     }
 
     pub fn for_block_params() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new(" |", "|"),
-            multi_line: DelimiterPair::new(" |", "|"),
+            single_line: DelimiterPair::new(b" |", b"|"),
+            multi_line: DelimiterPair::new(b" |", b"|"),
         }
     }
 
     pub fn for_array() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new("[", "]"),
-            multi_line: DelimiterPair::new("[", "]"),
+            single_line: DelimiterPair::new(b"[", b"]"),
+            multi_line: DelimiterPair::new(b"[", b"]"),
         }
     }
 
     pub fn for_when() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new(" ", ""),
-            multi_line: DelimiterPair::new("", ""),
+            single_line: DelimiterPair::new(b" ", b""),
+            multi_line: DelimiterPair::new(b"", b""),
         }
     }
 
     pub fn for_hash() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new("{", "}"),
-            multi_line: DelimiterPair::new("{", "}"),
+            single_line: DelimiterPair::new(b"{", b"}"),
+            multi_line: DelimiterPair::new(b"{", b"}"),
         }
     }
 
     pub fn for_brace_block() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new("{", " }"),
-            multi_line: DelimiterPair::new("{", "}"),
+            single_line: DelimiterPair::new(b"{", b" }"),
+            multi_line: DelimiterPair::new(b"{", b"}"),
         }
     }
 
     pub fn for_binary_op() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new("", ""),
-            multi_line: DelimiterPair::new("", ""),
+            single_line: DelimiterPair::new(b"", b""),
+            multi_line: DelimiterPair::new(b"", b""),
         }
     }
 
     pub fn for_parens() -> Self {
         BreakableDelims {
-            single_line: DelimiterPair::new("(", ")"),
-            multi_line: DelimiterPair::new("(", ")"),
+            single_line: DelimiterPair::new(b"(", b")"),
+            multi_line: DelimiterPair::new(b"(", b")"),
         }
     }
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -507,7 +507,7 @@ fn format_begin_node<'src>(ps: &mut ParserState<'src>, begin_node: prism::BeginN
         // the body of a `def`
         ps.end_indent();
     } else {
-        ps.emit_keyword("begin");
+        ps.emit_keyword(b"begin");
     }
     ps.new_block(|ps| {
         // For implicit nodes, this newline was already emitted by the caller
@@ -1194,7 +1194,7 @@ fn format_ensure_node<'src>(ps: &mut ParserState<'src>, ensure_node: prism::Ensu
     // aren't always handled with `format_node`, which usually handles this
     ps.at_offset(ensure_node.location().start_offset());
 
-    ps.emit_keyword("ensure");
+    ps.emit_keyword(b"ensure");
     ps.new_block(|ps| {
         ps.emit_newline();
         if let Some(statements) = ensure_node.statements() {
@@ -1506,7 +1506,7 @@ fn format_else_node<'src>(ps: &mut ParserState<'src>, else_node: prism::ElseNode
     } else {
         // In a ternary
         ps.emit_space();
-        ps.emit_conditional_keyword(":");
+        ps.emit_conditional_keyword(b":");
         ps.emit_space();
         ps.with_start_of_line(false, |ps| {
             format_node(
@@ -3409,14 +3409,14 @@ fn format_float_node<'src>(ps: &mut ParserState<'src>, float_node: prism::FloatN
 }
 
 fn format_for_node<'src>(ps: &mut ParserState<'src>, for_node: prism::ForNode<'src>) {
-    ps.emit_keyword("for");
+    ps.emit_keyword(b"for");
     ps.emit_space();
 
     ps.with_start_of_line(false, |ps| {
         format_node(ps, for_node.index());
 
         ps.emit_space();
-        ps.emit_keyword("in");
+        ps.emit_keyword(b"in");
         ps.emit_space();
 
         format_node(ps, for_node.collection());
@@ -3660,7 +3660,7 @@ fn format_inline_conditional<'src>(
     ps: &mut ParserState<'src>,
     predicate: prism::Node<'src>,
     statements: Option<prism::StatementsNode<'src>>,
-    keyword: &'static str,
+    keyword: &'static [u8],
 ) {
     if let Some(statements) = statements {
         // There can only be a single statement in modifier form.
@@ -3732,7 +3732,7 @@ impl<'pr> Conditional<'pr> {
 
 fn format_conditional_node<'src>(
     ps: &mut ParserState<'src>,
-    conditional_keyword: &'static str,
+    conditional_keyword: &'static [u8],
     requires_end_keyword: bool,
     conditional: &Conditional<'src>,
 ) {
@@ -3806,7 +3806,7 @@ fn format_conditional_node<'src>(
 
 fn format_conditional_block_form<'src>(
     ps: &mut ParserState<'src>,
-    conditional_keyword: &'static str,
+    conditional_keyword: &'static [u8],
     predicate: prism::Node<'src>,
     statements: Option<prism::StatementsNode<'src>>,
     subsequent_or_else: Option<prism::Node<'src>>,
@@ -3845,7 +3845,11 @@ fn format_if_node<'src>(ps: &mut ParserState<'src>, if_node: prism::IfNode<'src>
     // different that we handle it in its own branch
     if let Some(if_loc) = if_node.if_keyword_loc() {
         let is_if_keyword = (if_loc.end_offset() - if_loc.start_offset()) == 2;
-        let conditional_keyword = if is_if_keyword { "if" } else { "elsif" };
+        let conditional_keyword = if is_if_keyword {
+            b"if" as &[u8]
+        } else {
+            b"elsif"
+        };
 
         format_conditional_node(
             ps,
@@ -4551,7 +4555,7 @@ fn format_post_execution_node<'src>(
     ps: &mut ParserState<'src>,
     post_execution_node: prism::PostExecutionNode<'src>,
 ) {
-    ps.emit_keyword("END");
+    ps.emit_keyword(b"END");
     ps.emit_space();
     ps.emit_open_curly_bracket();
 
@@ -4574,7 +4578,7 @@ fn format_pre_execution_node<'src>(
     ps: &mut ParserState<'src>,
     pre_execution_node: prism::PreExecutionNode<'src>,
 ) {
-    ps.emit_keyword("BEGIN");
+    ps.emit_keyword(b"BEGIN");
     ps.emit_space();
     ps.emit_open_curly_bracket();
 
@@ -4647,7 +4651,7 @@ fn format_rescue_node<'src>(ps: &mut ParserState<'src>, rescue_node: prism::Resc
     // aren't always handled with `format_node`, which usually handles this
     ps.at_offset(rescue_node.location().start_offset());
 
-    ps.emit_keyword("rescue");
+    ps.emit_keyword(b"rescue");
     let exceptions = rescue_node.exceptions();
     let reference = rescue_node.reference();
     if !exceptions.is_empty() {
@@ -4704,7 +4708,7 @@ fn format_rescue_node<'src>(ps: &mut ParserState<'src>, rescue_node: prism::Resc
 }
 
 fn format_retry_node(ps: &mut ParserState) {
-    ps.emit_keyword("retry");
+    ps.emit_keyword(b"retry");
 }
 
 fn format_return_node<'src>(ps: &mut ParserState<'src>, return_node: prism::ReturnNode<'src>) {
@@ -4810,11 +4814,11 @@ fn format_undef_node<'src>(ps: &mut ParserState<'src>, undef_node: prism::UndefN
 }
 
 fn format_unless_node<'src>(ps: &mut ParserState<'src>, unless_node: prism::UnlessNode<'src>) {
-    format_conditional_node(ps, "unless", true, &Conditional::Unless(unless_node));
+    format_conditional_node(ps, b"unless", true, &Conditional::Unless(unless_node));
 }
 
 fn format_until_node<'src>(ps: &mut ParserState<'src>, until_node: prism::UntilNode<'src>) {
-    format_conditional_node(ps, "until", true, &Conditional::Until(until_node));
+    format_conditional_node(ps, b"until", true, &Conditional::Until(until_node));
 }
 
 fn format_when_node<'src>(ps: &mut ParserState<'src>, when_node: prism::WhenNode<'src>) {
@@ -4852,7 +4856,7 @@ fn format_when_node<'src>(ps: &mut ParserState<'src>, when_node: prism::WhenNode
 }
 
 fn format_while_node<'src>(ps: &mut ParserState<'src>, while_node: prism::WhileNode<'src>) {
-    format_conditional_node(ps, "while", true, &Conditional::While(while_node));
+    format_conditional_node(ps, b"while", true, &Conditional::While(while_node));
 }
 
 fn format_x_string_node<'src>(ps: &mut ParserState<'src>, x_string_node: prism::XStringNode<'src>) {

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -33,14 +33,14 @@ pub enum ConcreteLineToken<'src> {
         depth: u32,
     },
     Keyword {
-        keyword: &'static str,
+        keyword: &'static [u8],
     },
     DefKeyword,
     ClassKeyword,
     ModuleKeyword,
     DoKeyword,
     ConditionalKeyword {
-        contents: &'static str,
+        contents: &'static [u8],
     },
     DirectPart {
         part: Cow<'src, [u8]>,
@@ -72,7 +72,7 @@ pub enum ConcreteLineToken<'src> {
         contents: Cow<'src, [u8]>,
     },
     Delim {
-        contents: &'static str,
+        contents: &'static [u8],
     },
     End,
     HeredocClose {
@@ -97,8 +97,8 @@ impl<'src> ConcreteLineToken<'src> {
         match self {
             Self::HardNewLine => Cow::Borrowed(b"\n"),
             Self::Indent { depth } => get_indent(depth as usize),
-            Self::Keyword { keyword } => Cow::Borrowed(keyword.as_bytes()),
-            Self::ConditionalKeyword { contents } => Cow::Borrowed(contents.as_bytes()),
+            Self::Keyword { keyword } => Cow::Borrowed(keyword),
+            Self::ConditionalKeyword { contents } => Cow::Borrowed(contents),
             Self::DoKeyword => Cow::Borrowed(b"do"),
             Self::ClassKeyword => Cow::Borrowed(b"class"),
             Self::DefKeyword => Cow::Borrowed(b"def"),
@@ -122,7 +122,7 @@ impl<'src> ConcreteLineToken<'src> {
             Self::LTStringContent { content } => content,
             Self::SingleSlash => Cow::Borrowed(b"\\"),
             Self::Comment { contents } => contents,
-            Self::Delim { contents } => Cow::Borrowed(contents.as_bytes()),
+            Self::Delim { contents } => Cow::Borrowed(contents),
             Self::End => Cow::Borrowed(b"end"),
             Self::HeredocClose { symbol } => Cow::Owned(symbol),
             Self::HeredocStart { symbol, .. } => Cow::Borrowed(symbol),
@@ -172,14 +172,16 @@ impl<'src> ConcreteLineToken<'src> {
             Self::DirectPart { part } => {
                 part.as_ref() == b"}" || part.as_ref() == b"]" || part.as_ref() == b")"
             }
-            Self::Delim { contents } => *contents == "}" || *contents == "]" || *contents == ")",
+            Self::Delim { contents } => *contents == b"}" || *contents == b"]" || *contents == b")",
             _ => false,
         }
     }
 
     fn is_conditional_spaced_token(&self) -> bool {
         match self {
-            Self::ConditionalKeyword { contents } => !(*contents == "else" || *contents == "elsif"),
+            Self::ConditionalKeyword { contents } => {
+                !(*contents == b"else" || *contents == b"elsif")
+            }
             Self::Dot | Self::LonelyOperator => false,
             Self::DirectPart { part } => part.as_ref() != b"&.",
             _ => true,

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -563,19 +563,19 @@ impl<'src> ParserState<'src> {
     }
 
     pub(crate) fn emit_rescue(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "rescue" });
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: b"rescue" });
     }
 
     pub(crate) fn emit_case_keyword(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "case" });
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: b"case" });
     }
 
     pub(crate) fn emit_when_keyword(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "when" });
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: b"when" });
     }
 
     pub(crate) fn emit_in_keyword(&mut self) {
-        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: "in" });
+        self.push_concrete_token(ConcreteLineToken::Keyword { keyword: b"in" });
     }
 
     pub(crate) fn emit_do_keyword(&mut self) {
@@ -591,7 +591,7 @@ impl<'src> ParserState<'src> {
     }
 
     pub(crate) fn emit_else(&mut self) {
-        self.emit_conditional_keyword("else");
+        self.emit_conditional_keyword(b"else");
     }
 
     pub(crate) fn emit_data(&mut self, data: &'src [u8]) {
@@ -702,11 +702,11 @@ impl<'src> ParserState<'src> {
         self.push_concrete_token(ConcreteLineToken::DefKeyword);
     }
 
-    pub(crate) fn emit_keyword(&mut self, keyword: &'static str) {
+    pub(crate) fn emit_keyword(&mut self, keyword: &'static [u8]) {
         self.push_concrete_token(ConcreteLineToken::Keyword { keyword });
     }
 
-    pub(crate) fn emit_conditional_keyword(&mut self, contents: &'static str) {
+    pub(crate) fn emit_conditional_keyword(&mut self, contents: &'static [u8]) {
         self.push_concrete_token(ConcreteLineToken::ConditionalKeyword { contents });
     }
 }
@@ -930,7 +930,7 @@ impl<'src> ParserState<'src> {
     /// Format a conditional modifier expression (e.g., `x if y` or `x unless y`).
     pub(crate) fn conditional_layout_of<FP, FS>(
         &mut self,
-        keyword: &'static str,
+        keyword: &'static [u8],
         format_predicate: FP,
         format_statement: FS,
     ) where

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -516,13 +516,13 @@ pub enum ConditionalLayoutPhase {
 pub struct ConditionalLayoutEntry<'src> {
     predicate_tokens: Vec<AbstractLineToken<'src>>,
     statement_tokens: Vec<AbstractLineToken<'src>>,
-    keyword: &'static str,
+    keyword: &'static [u8],
     indent_depth: u32,
     phase: ConditionalLayoutPhase,
 }
 
 impl<'src> ConditionalLayoutEntry<'src> {
-    pub fn new(keyword: &'static str, indent_depth: u32) -> Self {
+    pub fn new(keyword: &'static [u8], indent_depth: u32) -> Self {
         ConditionalLayoutEntry {
             predicate_tokens: Vec::new(),
             statement_tokens: Vec::new(),


### PR DESCRIPTION
For #832, everything else in the codebase was converted from strings to u8 slices/vecs, and the only holdouts are a few `'static str` types which we later have to convert into u8 anyways, so this converts all of them to be static byte arrays instead. This is pretty much entirely just for consistency with every other token type.