### PR TITLE
Remove no-op `push_line_number`

### DIFF
--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -286,8 +286,7 @@ impl<'src> ParserState<'src> {
         F: FnOnce(&mut ParserState<'src>),
     {
         self.shift_comments();
-        let mut be = BreakableCallChainEntry::new(&self.formatting_context, is_user_multilined);
-        be.push_line_number(self.current_orig_line_number);
+        let be = BreakableCallChainEntry::new(&self.formatting_context, is_user_multilined);
         self.breakable_entry_stack.push(Breakable::CallChain(be));
 
         f(self);

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -367,11 +367,6 @@ impl<'src> BreakableCallChainEntry<'src> {
         insert_at(idx, &mut self.tokens, tokens)
     }
 
-    pub fn push_line_number(&mut self, _number: LineNumber) {
-        // No-op, BreakableCallChainEntry has custom multilining logic
-        // that doesn't depend on the source line numbers
-    }
-
     /// Removes `BeginCallChainIndent` and `EndCallChainIndent`, which is only really
     /// necessary when rendering a call chain as single-line. This prevents unnecessariliy
     /// increasing the indentation for a trailing block in e.g. `thing.each do; /* block */; end`
@@ -434,9 +429,9 @@ impl<'src> Breakable<'src> {
     pub fn push_line_number(&mut self, number: LineNumber) {
         match self {
             Breakable::DelimiterExpr(be) => be.push_line_number(number),
-            Breakable::CallChain(bcce) => bcce.push_line_number(number),
-            Breakable::InlineConditional(_) => {
-                // No-op for conditional layout - line numbers are tracked by nested breakables
+            Breakable::CallChain(_) | Breakable::InlineConditional(_) => {
+                // `InlineConditional` line numbers are tracked by nested breakables,
+                // and `CallChain` has its own multilining logic
             }
         }
     }


### PR DESCRIPTION
`push_line_number` used to be required as part of implementing a trait interface, but that was removed a while back, so `push_line_number` is no longer needed for `BreakableCallChainEntry` usages.