### PR TITLE
Bump to `v0.13.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "rubyfmt"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "log",
  "memchr",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "rubyfmt-main"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "rubyfmt-main"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Fable Tales <penelopedotzone@gmail.com>"]
 edition = "2024"
 

--- a/librubyfmt/Cargo.toml
+++ b/librubyfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rubyfmt"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Fable Tales <penelopedotzone@gmail.com>"]
 edition = "2024"
 


### PR DESCRIPTION
We've made a [lot of small fixes](https://github.com/fables-tales/rubyfmt/compare/v0.12.0...v0.12.49-0) over the last few months (enough to [land the Prism rewrite at Stripe](https://github.com/fables-tales/rubyfmt/pull/846#issuecomment-4107066583) (!)), plus even more (!) performance improvements.

I was going to wait for Prism 2.0 to come out (arena allocation!) to do another release, but I'm slightly impatient and that can come in its own release, I think in the meantime it'd be great to get all of these various and sundry bug fixes out into the wild.