### PR TITLE
Include Formatto extension reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ Rubyfmt is also supported by the (now-deprecated) [VSCode Ruby extension](https:
 }
 ```
 
+This is additionally supported by the [Formatto for VS Code](https://marketplace.visualstudio.com/items?itemName=damolinx.formatto) extension.  Use it as your project's formatter by adding this entry to your `.vscode/settings.json` after installing the extension: 
+
+```jsonc
+  {
+  "[ruby]": {
+    "editor.defaultFormatter": "damolinx.formatto"
+  },
+}
+```
+
+Check its [README](https://github.com/damolinx/vscode-formatto#readme) for additional configuration options.
+
 ### Neovim + null-ls
 
 The [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) plugin supports rubyfmt out of the box:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Rubyfmt is also supported by the (now-deprecated) [VSCode Ruby extension](https:
 This is additionally supported by the [Formatto for VS Code](https://marketplace.visualstudio.com/items?itemName=damolinx.formatto) extension.  Use it as your project's formatter by adding this entry to your `.vscode/settings.json` after installing the extension: 
 
 ```jsonc
-  {
+{
   "[ruby]": {
     "editor.defaultFormatter": "damolinx.formatto"
   },


### PR DESCRIPTION
Added instructions for using Formatto extension in VS Code.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
Include Formatto extension reference in README