### PR TITLE
[chore] Bump some GH Action dep versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         override: true
         target: aarch64-unknown-linux-gnu
     - run: cargo test --release
-    - uses: actions/upload-artifact@v6
+    - uses: actions/upload-artifact@v7
       with:
         name: rubyfmt-artifact-${{ matrix.os }}
         path: target/release/rubyfmt-main

--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -48,7 +48,7 @@ jobs:
           override: true
           target: aarch64-unknown-linux-gnu
       - run: ./script/make_release
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: rubyfmt-release-artifact-${{ matrix.os }}
           path: rubyfmt-*.tar.gz
@@ -60,17 +60,17 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: rubyfmt-release-artifact-ubuntu-22.04-arm
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: rubyfmt-release-artifact-ubuntu-22.04
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: rubyfmt-release-artifact-macos-latest
       - name: Upload Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: rubyfmt-*.tar.gz
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           override: true
           target: aarch64-unknown-linux-gnu
       - run: ./script/make_release
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: rubyfmt-release-artifact-${{ matrix.os }}
           path: rubyfmt-*.tar.gz
@@ -41,17 +41,17 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: rubyfmt-release-artifact-ubuntu-22.04
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: rubyfmt-release-artifact-macos-latest
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: rubyfmt-release-artifact-ubuntu-22.04-arm
       - name: Ship It 🚢
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: rubyfmt-*.tar.gz


### PR DESCRIPTION
We're a few versions behind on some of these action dependencies. The changelogs look like they're unrelated to how we use them I think, and for the most part these are updates to the underlying Node runtime that should just get rid of some warnings.