### PR TITLE
Add support for multiple method modifiers

### DIFF
--- a/fixtures/small/chained_visibility_modifier_actual.rb
+++ b/fixtures/small/chained_visibility_modifier_actual.rb
@@ -1,0 +1,31 @@
+class Foo
+  memoize public def bar
+    42
+  end
+
+  memoize(
+    protected \
+    def bar; end
+  )
+
+  memoize \
+  private \
+  def baz(a, b, c)
+    a + b + c
+  end
+
+  memoize \
+  protected def with_body
+    "hello"
+  end
+
+  memoize module_function def class_util; end
+
+  memoize public def no_body; end
+
+  memoize final public private protected def all_the_modifiers!; end
+
+  memoize def simple
+    "no inner modifier"
+  end
+end

--- a/fixtures/small/chained_visibility_modifier_expected.rb
+++ b/fixtures/small/chained_visibility_modifier_expected.rb
@@ -1,0 +1,29 @@
+class Foo
+  memoize public def bar
+    42
+  end
+
+  memoize protected def bar
+  end
+
+  memoize private def baz(a, b, c)
+    a + b + c
+  end
+
+  memoize protected def with_body
+    "hello"
+  end
+
+  memoize module_function def class_util
+  end
+
+  memoize public def no_body
+  end
+
+  memoize final public private protected def all_the_modifiers!
+  end
+
+  memoize def simple
+    "no inner modifier"
+  end
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1657,6 +1657,25 @@ pub static GEMFILE_METHODS: [&[u8]; 4] = [b"gem", b"source", b"ruby", b"group"];
 pub static OPTIONALLY_PARENTHESIZED_METHODS: [&[u8]; 3] =
     [b"super", b"require", b"require_relative"];
 
+// Returns true if `node` is a DefNode or a modifier CallNode (no receiver, one DefNode argument)
+// that itself contains a def modifier node — e.g. `public def foo` or `memoize public def foo`.
+fn is_def_modifier_node(node: &prism::Node) -> bool {
+    if node.as_def_node().is_some() {
+        return true;
+    }
+
+    if let Some(call_node) = node.as_call_node()
+        && call_node.receiver().is_none()
+        && let Some(args) = call_node.arguments()
+        && args.arguments().len() == 1
+        && let Some(argument) = args.arguments().first()
+    {
+        return is_def_modifier_node(&argument);
+    }
+
+    false
+}
+
 fn use_parens_for_call_node<'src>(
     ps: &ParserState<'src>,
     call_node: &prism::CallNode<'src>,
@@ -1822,13 +1841,18 @@ fn format_call_node<'src>(
         if let Some(arguments) = call_node.arguments()
             && !has_only_empty_paren_arg
         {
-            // For callers where the only arg is a def node,
+            // For callers where the only arg is a def node (or a modifier wrapping one),
             // we assume that's a `public def` style modifier and don't use parens
             if arguments.arguments().len() == 1
-                && let Some(def_node) = arguments.arguments().first().unwrap().as_def_node()
+                && let Some(arg) = arguments.arguments().first()
+                && is_def_modifier_node(&arg)
             {
                 ps.emit_space();
-                format_def_node(ps, def_node);
+                if let Some(def_node) = arg.as_def_node() {
+                    format_def_node(ps, def_node);
+                } else {
+                    ps.with_start_of_line(false, |ps| format_node(ps, arg));
+                }
             } else if is_aref_write {
                 let arg_count = arguments.arguments().len();
 


### PR DESCRIPTION
Closes #859 

We currently support access modifiers (or any method that takes a `DefNode` as its sole argument) by rendering them inline with the definition, e.g.

```ruby
private def not_the_bees! = !bees
```

but we should also support arbitrarily many modifiers. This adds a check to recurse into the arguments of these single calls, and if all the calls are either (a) a `DefNode` or (b) another modifier whose argument is a `DefNode`, then we also treat those as modifiers. This allows us to do things like 

```ruby
memoize private def not_the_bees! = !bees
```