### PR TITLE
Update `CONTRIBUTING.MD`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
-# Setup
+# Contributing
 
-1. make sure you have a recent-ish rust/cargo toolchain
-2. ensure you have at least ruby 2.6 installed
+## Requirements
+
+Make sure you have a recent-ish Rust/Cargo toolchain. You can [check what version is used in CI](https://github.com/search?q=repo%3Afables-tales%2Frubyfmt%20toolchain%3A&type=code), but most recent versions should work fine.
 
 # Day to day tasks
 
@@ -12,10 +13,6 @@
 in particular `cargo test --test fixtures_test` is what I use for ongoing
 development when I'm testing a new feature, which I usually start by committing
 a new fixture.
-
-## Doing what CI does:
-
-`./script/ci`
 
 ## Autoformatting
 


### PR DESCRIPTION
This file still referenced a required Ruby version (which we don't use anymore) as well as `./scripts/ci`, which no longer exists. (I think that script is essentially just `cargo test && cargo fmt && cargo clippy`, all of which are listed already.)