### PR TITLE
Bump `prerelease` levels instead of `prepatch` in `preview-release` GH action

### DIFF
--- a/.github/workflows/preview-release.yaml
+++ b/.github/workflows/preview-release.yaml
@@ -16,7 +16,7 @@ jobs:
         id: bump-semver
         with:
           current_version: ${{ steps.get-latest-tag.outputs.tag }}
-          level: prepatch
+          level: prerelease
       - uses: actions-ecosystem/action-push-tag@v1
         with:
           tag: ${{ steps.bump-semver.outputs.new_version }}


### PR DESCRIPTION
This is something minor that has annoyed me for a long time: in the `preview-release` action, we currently bump using the `prepatch` level, which always increments the `patch` semver level. This makes it really annoying to properly release a true patch bump, since every commit is bumping the patch. For example, I would love to do a patch release right now for some small fixes, but that would require us to bump from `0.13.0` to `0.13.8`, since we've been bumping the patch version this whole time.

Instead, we should be using `prerelease`, which will bump from e.g. `0.13.0-1` to `0.13.0-2`, and when we do make a release, say `0.13.1`, it bumps to `0.13.2-0`, which importantly does not prevent us from releasing `0.13.2` itself.