### PR TITLE
[fix] Properly multiline multi-statement `ParenthesesNode` expressions

### DIFF
--- a/fixtures/small/paren_multi_stmt_actual.rb
+++ b/fixtures/small/paren_multi_stmt_actual.rb
@@ -1,0 +1,5 @@
+(true; true)
+
+cond1 &&
+  (pattern_match_me => { foo: }; true) &&
+  cond3

--- a/fixtures/small/paren_multi_stmt_expected.rb
+++ b/fixtures/small/paren_multi_stmt_expected.rb
@@ -1,0 +1,11 @@
+(
+  true
+  true
+)
+
+cond1 &&
+  (
+    pattern_match_me => {foo:}
+    true
+  ) &&
+  cond3

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -3126,7 +3126,7 @@ fn format_parentheses_node<'src>(
                                 format_node(ps, stmt);
                             });
                             if idx < statements.len() - 1 {
-                                ps.emit_soft_newline();
+                                ps.emit_newline();
                             }
                         }
                     } else {


### PR DESCRIPTION
Closes #864 

On the tin -- I could've _sworn_ we had tests for this, but apparently not! `ParenthesesNode`s which have multiple statements in them (e.g. `(foo; bar)`) are supposed to be always rendered separately on multiple lines. (I believe that's the style we've approved in the past, but feel free to chime in if I'm misremembering.)