### PR TITLE
[fix] Prevent additional blank lines in multiline sends

### DIFF
--- a/fixtures/small/chain_blank_line_actual.rb
+++ b/fixtures/small/chain_blank_line_actual.rb
@@ -1,0 +1,11 @@
+foo
+  .bar.
+
+  baz
+
+
+  foo
+    .bar.
+
+    # Some more info about baz
+    baz

--- a/fixtures/small/chain_blank_line_expected.rb
+++ b/fixtures/small/chain_blank_line_expected.rb
@@ -1,0 +1,8 @@
+foo
+  .bar
+  .baz
+
+foo
+  .bar
+  # Some more info about baz
+  .baz

--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -211,6 +211,7 @@ impl FileComments {
         &mut self,
         starting_line_number: LineNumber,
         line_number: LineNumber,
+        suppress_leading_blank: bool,
     ) -> Option<(CommentBlock, LineNumber)> {
         let lowest_line = self.other_comments.first().map(|(ln, _)| *ln)?;
         if lowest_line > line_number {
@@ -224,10 +225,12 @@ impl FileComments {
         let mut comment_block_with_spaces = Vec::new();
         let mut last_line = None;
 
-        if line_difference_requires_newline(
-            self.other_comments.first().unwrap().0,
-            starting_line_number,
-        ) {
+        if !suppress_leading_blank
+            && line_difference_requires_newline(
+                self.other_comments.first().unwrap().0,
+                starting_line_number,
+            )
+        {
             comment_block_with_spaces.push(b"".into());
         }
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2396,7 +2396,10 @@ fn format_call_body<'src>(
                     }
                 }
 
-                ps.at_offset(start_loc_for_call_node_in_chain(&element));
+                // Blank lines between leading-dot chain elements produce invalid Ruby.
+                ps.with_user_newlines_disabled(|ps| {
+                    ps.at_offset(start_loc_for_call_node_in_chain(&element));
+                });
                 ps.shift_comments();
 
                 let skip_value =

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -70,6 +70,10 @@ pub struct ParserState<'src> {
     /// Whether we're currently rendering inside a squiggly heredoc's content.
     /// Used to mark nested non-squiggly heredocs so they don't get incorrect indentation.
     inside_squiggly_heredoc: bool,
+    /// When true, strip blank lines that would otherwise be prepended to an extracted comment
+    /// block. Used during call-chain element offset jumps, where a trailing-dot blank line in
+    /// the source must not produce an invalid blank line before a leading-dot comment.
+    suppress_blank_before_comment: bool,
 }
 
 impl<'src> ParserState<'src> {
@@ -106,9 +110,11 @@ impl<'src> ParserState<'src> {
         // Update line number and clear out any comments we might have rendered in e.g. an embexpr
         //
         // (Ignore this comment extraction, we've already rendered them elsewhere)
-        let _ = self
-            .comments_hash
-            .extract_comments_to_line(self.current_orig_line_number, end_line);
+        let _ = self.comments_hash.extract_comments_to_line(
+            self.current_orig_line_number,
+            end_line,
+            false,
+        );
         self.current_orig_line_number = end_line;
 
         let segments = next_ps.render_to_segments();
@@ -329,10 +335,11 @@ impl<'src> ParserState<'src> {
             be.push_line_number(line_number);
         }
 
-        if let Some((comments, last_comment_line)) = self
-            .comments_hash
-            .extract_comments_to_line(self.current_orig_line_number, line_number)
-        {
+        if let Some((comments, last_comment_line)) = self.comments_hash.extract_comments_to_line(
+            self.current_orig_line_number,
+            line_number,
+            self.suppress_blank_before_comment,
+        ) {
             self.push_comments(comments);
             self.current_orig_line_number =
                 std::cmp::max(self.current_orig_line_number, last_comment_line);
@@ -718,6 +725,7 @@ impl<'src> ParserState<'src> {
             spaces_after_last_newline: 0,
             scopes: vec![vec![]],
             inside_squiggly_heredoc: false,
+            suppress_blank_before_comment: false,
         }
     }
 
@@ -773,6 +781,21 @@ impl<'src> ParserState<'src> {
 
     pub(crate) fn disable_user_newlines(&mut self) {
         self.insert_user_newlines = false;
+    }
+
+    pub(crate) fn with_user_newlines_disabled<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut ParserState<'src>),
+    {
+        let saved_newlines = self.insert_user_newlines;
+        let saved_blank = self.suppress_blank_before_comment;
+        self.insert_user_newlines = false;
+        self.suppress_blank_before_comment = true;
+
+        f(self);
+
+        self.insert_user_newlines = saved_newlines;
+        self.suppress_blank_before_comment = saved_blank;
     }
 
     pub(crate) fn last_token_is_a_newline(&self) -> bool {


### PR DESCRIPTION
Closes #865

Call-chains with blank lines between the calls (using a trailing dot) can potentially be rendered with user-whitespace still inserted. This shouldn't happen -- in the middle of a call chain, we should be suppressing user-newlines to ensure that the output is syntactically valid.