### PR TITLE
[fix] Always render parens for capitalized methods with receivers

### DIFF
--- a/fixtures/small/constant_path_callers_actual.rb
+++ b/fixtures/small/constant_path_callers_actual.rb
@@ -1,0 +1,26 @@
+# Call nodes don't need to disambiguate blocks
+Case
+Case()
+Case { }
+Case() { }
+Case do; end
+Case() do; end
+Case(args) { }
+Case(args) do ;end
+
+# But ConstantReadNodes must disambiguate blocks
+Test::Case
+Test::Case()
+Test::Case { }
+Test::Case() { }
+Test::Case() do; end
+Test::Case(args) { }
+Test::Case(args) do ;end
+
+Test.Case
+Test.Case()
+Test.Case { }
+Test.Case() { }
+Test.Case() do; end
+Test.Case(args) { }
+Test.Case(args) do ;end

--- a/fixtures/small/constant_path_callers_expected.rb
+++ b/fixtures/small/constant_path_callers_expected.rb
@@ -1,0 +1,37 @@
+# Call nodes don't need to disambiguate blocks
+Case
+Case()
+Case { }
+Case { }
+Case do
+end
+
+Case do
+end
+
+Case(args) { }
+Case(args) do
+end
+
+# But ConstantReadNodes must disambiguate blocks
+Test::Case
+Test::Case()
+Test::Case() { }
+Test::Case() { }
+Test::Case() do
+end
+
+Test::Case(args) { }
+Test::Case(args) do
+end
+
+Test.Case()
+Test.Case()
+Test.Case() { }
+Test.Case() { }
+Test.Case() do
+end
+
+Test.Case(args) { }
+Test.Case(args) do
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1703,7 +1703,7 @@ fn use_parens_for_call_node<'src>(
     });
 
     if is_terminal_call && method_name.first().is_some_and(|c| c.is_ascii_uppercase()) {
-        if !has_arguments && call_node.block().is_some() {
+        if !has_arguments && call_node.block().is_some() && call_node.receiver().is_none() {
             return false;
         }
         return true;


### PR DESCRIPTION
Closes #869 

TL;DR for callers where the receiver is a `ConstantReadNode` (e.g. `Foo::Bar() { }`), parentheses are required for Prism to parse that call, so this adds a receiver check to ensure they're always left behind in this case.

---

Capitalized methods are a bit of a strange creature when it comes to how the parser handles them. On their own, they're essentially fine: a plane ol' `Foo` is a constant, and `Foo()`, `Foo { }`, `Foo do; end` or `Foo() { }` are all `CallNode`s. In all of those cases, Prism understands them to be calls as soon as it sees the parens or the block delimiters, so we can elide parens if there's nothing in them, as long as a block is present.

_However_, this isn't the same for capitalized methods where the receiver is a `ConstantReadNode`. In those cases, once Prism gets through the method name (e.g. `Foo::Bar`), it's ambiguous as to whether it's a constant or a call. For whatever reason, brace blocks actually do work fine here, and `Foo::Bar { }` is a totally valid call in Prism (not in parse.y!), but `Foo::Bar do; end` is _not_. For these, it's required that capitalized methods in constant reads use parens to force the parser to understand them as method calls, so `Foo::Bar() do; end` works.

Note: for the sake of consistency, I chose to just check for _any_ receiver and not care about the block type. In theory, we could still elide parens for block braces if we wanted to, but (1) I don't think older parser versions accept that, and (2) if we're required to have parens some of the time for this type of caller, I think it makes sense to just keep them all of the time.