### PR TITLE
[fix] Format singleton class receiver expression instead of hardcoding self

### DIFF
--- a/fixtures/small/singleton_class_expression_actual.rb
+++ b/fixtures/small/singleton_class_expression_actual.rb
@@ -1,0 +1,31 @@
+class << self
+  def foo; end
+end
+
+class << receiver
+  def foo; :bar; end
+end
+
+class << @ivar
+  def foo; end
+end
+
+class << @@cvar
+  def foo; end
+end
+
+class << $global
+  def foo; end
+end
+
+class << Foo
+  def foo; end
+end
+
+class << SomeModule::CONST
+  def foo; end
+end
+
+class << foo.bar
+  def foo; end
+end

--- a/fixtures/small/singleton_class_expression_expected.rb
+++ b/fixtures/small/singleton_class_expression_expected.rb
@@ -1,0 +1,40 @@
+class << self
+  def foo
+  end
+end
+
+class << receiver
+  def foo
+    :bar
+  end
+end
+
+class << @ivar
+  def foo
+  end
+end
+
+class << @@cvar
+  def foo
+  end
+end
+
+class << $global
+  def foo
+  end
+end
+
+class << Foo
+  def foo
+  end
+end
+
+class << SomeModule::CONST
+  def foo
+  end
+end
+
+class << foo.bar
+  def foo
+  end
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4765,7 +4765,9 @@ fn format_singleton_class_node<'src>(
     ps.emit_space();
     ps.emit_ident(b"<<");
     ps.emit_space();
-    ps.emit_ident(b"self");
+    ps.with_start_of_line(false, |ps| {
+        format_node(ps, singleton_class_node.expression())
+    });
 
     ps.new_block(|ps| {
         ps.with_start_of_line(true, |ps| {


### PR DESCRIPTION
## Summary

- `format_singleton_class_node` emitted a hardcoded `self` identifier regardless of the actual receiver expression, silently rewriting `class << obj` to `class << self`
- Now formats the AST expression node directly using `format_node`, preserving whatever receiver the user wrote
- Added fixture test covering local variables, `self`, constants, and instance variables as receivers

Fixes #874

## Examples

Before (broken):
```ruby
class << receiver; self; end      # becomes: class << self\n  self\nend
class << obj; self; end           # becomes: class << self\n  self\nend
class << some_object              # becomes: class << self
  def foo; :bar; end              #            def foo; :bar; end
end                               #          end
```

After (correct):
```ruby
class << receiver
  self
end

class << obj
  self
end

class << some_object
  def foo
    :bar
  end
end
```

## Test plan

- [x] Added `fixtures/small/singleton_class_expression_actual.rb` / `_expected.rb` covering 6 receiver variants
- [x] Verified test fails without the fix (all receivers become `self`)
- [x] Verified test passes with the fix
- [x] Full test suite passes (383 fixture + 46 CLI + 11 error handling + 3 stress tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)