### PR TITLE
[fix] Preserve `then` delimiter for `when` clauses with endless ranges

### DIFF
--- a/fixtures/small/when_endless_range_actual.rb
+++ b/fixtures/small/when_endless_range_actual.rb
@@ -1,0 +1,38 @@
+case x
+when 0.9.. then "very strong"
+when 0.7.. then "strong"
+when 0.5.. then "moderate"
+end
+
+case x
+when 1.. then "positive"
+end
+
+case x
+when ..0 then "non-positive"
+end
+
+case x
+when 0..10 then "small"
+end
+
+case x
+when 0.9.., :special then "a"
+end
+
+case x
+when 0.9.. then
+  "very strong"
+end
+
+case x
+when 1... then "exclusive endless"
+end
+
+case x
+when :special, 0.9.. then "a"
+end
+
+case x
+when (0.9..) then "parenthesized endless"
+end

--- a/fixtures/small/when_endless_range_expected.rb
+++ b/fixtures/small/when_endless_range_expected.rb
@@ -1,0 +1,48 @@
+case x
+when 0.9.. then
+  "very strong"
+when 0.7.. then
+  "strong"
+when 0.5.. then
+  "moderate"
+end
+
+case x
+when 1.. then
+  "positive"
+end
+
+case x
+when ..0
+  "non-positive"
+end
+
+case x
+when 0..10
+  "small"
+end
+
+case x
+when 0.9.., :special
+  "a"
+end
+
+case x
+when 0.9.. then
+  "very strong"
+end
+
+case x
+when 1... then
+  "exclusive endless"
+end
+
+case x
+when :special, 0.9.. then
+  "a"
+end
+
+case x
+when (0.9..)
+  "parenthesized endless"
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4862,6 +4862,14 @@ fn format_when_node<'src>(ps: &mut ParserState<'src>, when_node: prism::WhenNode
         });
     });
 
+    // Ruby treats `..` at end-of-line as a line continuation operator.
+    // When the last condition is an endless range, we must emit `then`
+    // to prevent a SyntaxError.
+    if when_conditions_end_with_endless_range(&when_node) {
+        ps.emit_space();
+        ps.emit_keyword(b"then");
+    }
+
     ps.new_block(|ps| {
         ps.with_start_of_line(true, |ps| {
             ps.emit_newline();
@@ -4870,6 +4878,14 @@ fn format_when_node<'src>(ps: &mut ParserState<'src>, when_node: prism::WhenNode
             }
         });
     });
+}
+
+fn when_conditions_end_with_endless_range(when_node: &prism::WhenNode) -> bool {
+    when_node
+        .conditions()
+        .last()
+        .and_then(|c| c.as_range_node())
+        .is_some_and(|r| r.right().is_none())
 }
 
 fn format_while_node<'src>(ps: &mut ParserState<'src>, while_node: prism::WhileNode<'src>) {


### PR DESCRIPTION
Fixes #878

## Problem

[→ Reproduce on rubyfmt.run](https://rubyfmt.run/#Y2FzZSB4CndoZW4gMC45Li4gdGhlbiAidmVyeSBzdHJvbmciCndoZW4gMC43Li4gdGhlbiAic3Ryb25nIgp3aGVuIDAuNS4uIHRoZW4gIm1vZGVyYXRlIgplbmQKCmNhc2UgeAp3aGVuIDEuLiB0aGVuICJwb3NpdGl2ZSIKZW5kCgpjYXNlIHgKd2hlbiAuLjAgdGhlbiAibm9uLXBvc2l0aXZlIgplbmQKCmNhc2UgeAp3aGVuIDAuLjEwIHRoZW4gInNtYWxsIgplbmQ=)

Ruby treats `..` at end-of-line as a line continuation operator. When rubyfmt expands `when` clauses with endless ranges to multiline, the stripped `then` leaves `..` at EOL → SyntaxError.

```ruby
# Input
case x
when 0.9.. then "very strong"
when 0.7.. then "strong"
end

# Before (broken — SyntaxError)
case x
when 0.9..
  "very strong"
when 0.7..
  "strong"
end

# After (valid Ruby)
case x
when 0.9.. then
  "very strong"
when 0.7.. then
  "strong"
end
```

## Fix

After formatting `when` conditions, check if the last condition is an endless range (`RangeNode` with no `right()`). If so, emit `then` to disambiguate.

Only endless ranges need this — beginless (`..0`), bounded (`0..10`), and parenthesized (`(0.9..)`) ranges are unambiguous at EOL.

```rust
fn when_conditions_end_with_endless_range(when_node: &prism::WhenNode) -> bool {
    when_node
        .conditions()
        .last()
        .and_then(|c| c.as_range_node())
        .is_some_and(|r| r.right().is_none())
}
```

## Test coverage

New fixture `when_endless_range` covers:
- `..` (inclusive) and `...` (exclusive) endless ranges → `then` emitted
- Beginless range (`..0`) → no `then`
- Bounded range (`0..10`) → no `then`
- Parenthesized endless (`(0.9..)`) → no `then` (parens disambiguate)
- Endless range not last in conditions list (`0.9.., :special`) → no `then`
- Idempotency: re-formatting produces identical output

All existing tests pass.