### PR TITLE
[fix] Preserve inline directive comments instead of moving them above

### DIFF
--- a/fixtures/small/inline_directive_comments_actual.rb
+++ b/fixtures/small/inline_directive_comments_actual.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# Basic rubocop:disable - must stay inline
+user.update_column(:role, "admin") # rubocop:disable Rails/SkipsModelValidations
+user.update_column(:verified, true)
+
+# rubocop:enable - must stay inline
+x = eval(input) # rubocop:enable Security/Eval
+
+# rubocop:todo - must stay inline
+x = 1 # rubocop:todo Style/FrozenStringLiteralComment
+
+# Multiple cops on one directive
+foo(bar) # rubocop:disable Style/Foo, Style/Bar
+
+# Directive with explanation text
+SolarPark.where(id: ids) # rubocop:disable Tenant/UnscopedModelAccess -- IDs pre-filtered by org
+
+# standard:disable - must stay inline
+def has_role?(name) # standard:disable Naming/PredicateMethod
+  roles.include?(name)
+end
+
+# standard:enable - must stay inline
+def valid? # standard:enable Naming/PredicateMethod
+  true
+end
+
+# steep:ignore - must stay inline
+result = untyped_method # steep:ignore
+
+# :reek: - must stay inline
+def complex_method(a, b, c, d, e) # :reek:LongParameterList
+  a + b + c + d + e
+end
+
+# Regular trailing comment - must still move above
+x = 42 # just a note
+y = 99 # another comment
+
+# Standalone directive comment on own line - stays on own line
+# rubocop:disable all
+def dangerous_method
+  eval("puts 1")
+end
+# rubocop:enable all
+
+# Directive inside a block
+[1, 2, 3].each do |i|
+  puts i # rubocop:disable Rails/Output
+end
+
+# Directive on method call with parens added by rubyfmt
+render html: content.html_safe # rubocop:disable Rails/OutputSafety
+
+# Directive inside conditional
+if condition
+  do_something # rubocop:disable CustomCop/Whatever
+else
+  do_other # rubocop:disable CustomCop/Other
+end
+
+# Indented directive in a class
+class MyClass
+  def foo
+    bar # rubocop:disable Style/Foo
+  end
+end
+
+# Multiple lines with directives and regular comments
+a = 1 # regular comment
+b = 2 # rubocop:disable Style/NumericLiterals
+c = 3 # another regular comment
+d = 4 # rubocop:enable Style/NumericLiterals
+
+# Heredoc with directive
+content = <<~HEREDOC # rubocop:disable Style/HeredocStyle
+  hello world
+HEREDOC
+
+# Multiline method call with directive on closing line
+result = very_long_method(
+  arg1,
+  arg2,
+  arg3
+) # rubocop:disable Metrics/ParameterLists
+
+# Constant assignment with directive
+CONST = "value" # rubocop:disable Style/MutableConstant
+
+# Case/when with directive
+case x
+when 1 # rubocop:disable Style/WhenThen
+  foo
+when 2
+  bar
+end
+
+# Rescue with directive
+begin
+  risky_op
+rescue StandardError # rubocop:disable Lint/RescueException
+  handle
+end
+
+# rubocop:push/pop directives
+# rubocop:push Metrics/ClassLength
+class VeryLongClass
+  x = 1 # rubocop:pop Metrics/ClassLength
+end

--- a/fixtures/small/inline_directive_comments_expected.rb
+++ b/fixtures/small/inline_directive_comments_expected.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+# Basic rubocop:disable - must stay inline
+user.update_column(:role, "admin") # rubocop:disable Rails/SkipsModelValidations
+user.update_column(:verified, true)
+
+# rubocop:enable - must stay inline
+x = eval(input) # rubocop:enable Security/Eval
+
+# rubocop:todo - must stay inline
+x = 1 # rubocop:todo Style/FrozenStringLiteralComment
+
+# Multiple cops on one directive
+foo(bar) # rubocop:disable Style/Foo, Style/Bar
+
+# Directive with explanation text
+SolarPark.where(id: ids) # rubocop:disable Tenant/UnscopedModelAccess -- IDs pre-filtered by org
+
+# standard:disable - must stay inline
+def has_role?(name) # standard:disable Naming/PredicateMethod
+  roles.include?(name)
+end
+
+# standard:enable - must stay inline
+def valid? # standard:enable Naming/PredicateMethod
+  true
+end
+
+# steep:ignore - must stay inline
+result = untyped_method # steep:ignore
+
+# :reek: - must stay inline
+def complex_method(a, b, c, d, e) # :reek:LongParameterList
+  a + b + c + d + e
+end
+
+# Regular trailing comment - must still move above
+# just a note
+x = 42
+# another comment
+y = 99
+
+# Standalone directive comment on own line - stays on own line
+# rubocop:disable all
+def dangerous_method
+  eval("puts 1")
+end
+# rubocop:enable all
+
+# Directive inside a block
+[1, 2, 3].each do |i|
+  puts(i) # rubocop:disable Rails/Output
+end
+
+# Directive on method call with parens added by rubyfmt
+render(html: content.html_safe) # rubocop:disable Rails/OutputSafety
+
+# Directive inside conditional
+if condition
+  do_something # rubocop:disable CustomCop/Whatever
+else
+  do_other # rubocop:disable CustomCop/Other
+end
+
+# Indented directive in a class
+class MyClass
+  def foo
+    bar # rubocop:disable Style/Foo
+  end
+end
+
+# Multiple lines with directives and regular comments
+# regular comment
+a = 1
+b = 2 # rubocop:disable Style/NumericLiterals
+# another regular comment
+c = 3
+d = 4 # rubocop:enable Style/NumericLiterals
+
+# Heredoc with directive
+content = <<~HEREDOC # rubocop:disable Style/HeredocStyle
+  hello world
+HEREDOC
+
+# Multiline method call with directive on closing line
+result = very_long_method(
+  arg1,
+  arg2,
+  arg3
+) # rubocop:disable Metrics/ParameterLists
+
+# Constant assignment with directive
+CONST = "value" # rubocop:disable Style/MutableConstant
+
+# Case/when with directive
+case x
+when 1 # rubocop:disable Style/WhenThen
+  foo
+when 2
+  bar
+end
+
+# Rescue with directive
+begin
+  risky_op
+rescue StandardError # rubocop:disable Lint/RescueException
+  handle
+end
+
+# rubocop:push/pop directives
+# rubocop:push Metrics/ClassLength
+class VeryLongClass
+  x = 1 # rubocop:pop Metrics/ClassLength
+end

--- a/fixtures/small/paren_expr_calls_expected.rb
+++ b/fixtures/small/paren_expr_calls_expected.rb
@@ -3,10 +3,9 @@ other_cool_method((a + b).round(4))
 
 # rubocop:disable PrisonGuard/PrivateModule
 (foo(
-  # rubocop:enable PrisonGuard/PrivateModule
   foo
 ))
-  .flatten
+  .flatten # rubocop:enable PrisonGuard/PrivateModule
 
 # rubocop:disable Style/Stuff
 (MyModel::InSomeNamespace

--- a/fixtures/small/paren_expr_calls_expected.rb
+++ b/fixtures/small/paren_expr_calls_expected.rb
@@ -3,9 +3,10 @@ other_cool_method((a + b).round(4))
 
 # rubocop:disable PrisonGuard/PrivateModule
 (foo(
+  # rubocop:enable PrisonGuard/PrivateModule
   foo
 ))
-  .flatten # rubocop:enable PrisonGuard/PrivateModule
+  .flatten
 
 # rubocop:disable Style/Stuff
 (MyModel::InSomeNamespace

--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -7,6 +7,28 @@ use crate::comment_block::CommentBlock;
 use crate::parser_state::line_difference_requires_newline;
 use crate::types::{LineNumber, SourceOffset};
 
+pub fn is_inline_directive(comment: &[u8]) -> bool {
+    let trimmed = if let Some(rest) = comment.strip_prefix(b"#") {
+        rest.trim_ascii_start()
+    } else {
+        return false;
+    };
+
+    const PATTERNS: &[&[u8]] = &[
+        b"rubocop:disable",
+        b"rubocop:enable",
+        b"rubocop:todo",
+        b"rubocop:push",
+        b"rubocop:pop",
+        b"standard:disable",
+        b"standard:enable",
+        b"steep:ignore",
+        b":reek:",
+    ];
+
+    PATTERNS.iter().any(|p| trimmed.starts_with(p))
+}
+
 /// A vector of offsets in the source code where lines start, which
 /// we use to detect what line a given offset is one.
 ///
@@ -94,20 +116,24 @@ impl FileComments {
 
         let line_index = LineIndex::from_vec(line_starts);
 
-        let mut file_comments = FileComments::default();
+        let mut file_comments = FileComments {
+            lines_with_ruby,
+            last_lineno: line_index.line_starts.len() as u64,
+            line_index,
+            ..Default::default()
+        };
+
         for comment in comments {
             file_comments.push_comment(
-                line_index.get_line_number(comment.location().start_offset()) as u64,
+                file_comments
+                    .line_index
+                    .get_line_number(comment.location().start_offset()) as u64,
                 comment.text().trim_ascii_end().to_vec(),
             );
             file_comments
                 .comment_start_offsets
                 .push(comment.location().start_offset());
         }
-
-        file_comments.lines_with_ruby = lines_with_ruby;
-        file_comments.last_lineno = line_index.line_starts.len() as u64;
-        file_comments.line_index = line_index;
         file_comments
     }
 
@@ -149,11 +175,13 @@ impl FileComments {
     /// each of those comment lines must be pushed before any other line, or
     /// the end of the block from the start of the file will be incorrectly calculated.
     fn push_comment(&mut self, line_number: u64, l: Vec<u8>) {
+        let on_code_line = self.line_has_ruby_code(line_number);
+
         match (
             &mut self.start_of_file_contiguous_comment_lines,
             line_number,
         ) {
-            (None, 1) => {
+            (None, 1) if !on_code_line => {
                 debug_assert!(
                     self.other_comments.is_empty(),
                     "If we have a start of file sled, it needs to come first,
@@ -162,14 +190,14 @@ impl FileComments {
                 self.start_of_file_contiguous_comment_lines =
                     Some(CommentBlock::new(1..2, vec![l.into()]));
             }
-            (Some(sled), _) if sled.following_line_number() == line_number => {
+            (Some(sled), _) if !on_code_line && sled.following_line_number() == line_number => {
                 sled.add_line(l.into());
             }
             _ => {
                 debug_assert!(
                     self.other_comments
                         .last()
-                        .is_none_or(|(last_line_number, _)| *last_line_number < line_number),
+                        .is_none_or(|(last_line_number, _)| *last_line_number <= line_number),
                     "Expected comments to be inserted in order"
                 );
 
@@ -213,6 +241,20 @@ impl FileComments {
         line_number: LineNumber,
         suppress_leading_blank: bool,
     ) -> Option<(CommentBlock, LineNumber)> {
+        self.extract_comments_to_line_with_directives(
+            starting_line_number,
+            line_number,
+            suppress_leading_blank,
+        )
+        .map(|(cb, ln, _)| (cb, ln))
+    }
+
+    pub fn extract_comments_to_line_with_directives(
+        &mut self,
+        starting_line_number: LineNumber,
+        line_number: LineNumber,
+        suppress_leading_blank: bool,
+    ) -> Option<(CommentBlock, LineNumber, Vec<Vec<u8>>)> {
         let lowest_line = self.other_comments.first().map(|(ln, _)| *ln)?;
         if lowest_line > line_number {
             return None;
@@ -224,6 +266,7 @@ impl FileComments {
 
         let mut comment_block_with_spaces = Vec::new();
         let mut last_line = None;
+        let mut inline_directives = Vec::new();
 
         if !suppress_leading_blank
             && line_difference_requires_newline(
@@ -234,7 +277,13 @@ impl FileComments {
             comment_block_with_spaces.push(b"".into());
         }
 
+        let lines_with_ruby = &self.lines_with_ruby;
         for (index, comment_contents) in self.other_comments.drain(..split_point) {
+            let on_code_line = lines_with_ruby.binary_search(&index).is_ok();
+            if on_code_line && is_inline_directive(&comment_contents) {
+                inline_directives.push(comment_contents);
+                continue;
+            }
             let comment_contents: Cow<'_, [u8]> = Cow::Owned(comment_contents);
             if let Some(last_line) = last_line
                 && line_difference_requires_newline(index, last_line)
@@ -246,6 +295,18 @@ impl FileComments {
             comment_block_with_spaces.push(comment_contents);
         }
 
+        if last_line.is_none() && inline_directives.is_empty() {
+            return None;
+        }
+
+        if last_line.is_none() {
+            return Some((
+                CommentBlock::new(line_number..line_number + 1, vec![]),
+                line_number,
+                inline_directives,
+            ));
+        }
+
         if line_number > last_line.unwrap() + 1 {
             last_line = Some(line_number);
             comment_block_with_spaces.push(b"".into());
@@ -254,7 +315,12 @@ impl FileComments {
         Some((
             CommentBlock::new(lowest_line..line_number + 1, comment_block_with_spaces),
             last_line.unwrap(),
+            inline_directives,
         ))
+    }
+
+    fn line_has_ruby_code(&self, line_number: LineNumber) -> bool {
+        !self.is_empty_line(line_number)
     }
 
     // Note: this is currently only used for Prism support, see the details

--- a/librubyfmt/src/file_comments.rs
+++ b/librubyfmt/src/file_comments.rs
@@ -295,26 +295,25 @@ impl FileComments {
             comment_block_with_spaces.push(comment_contents);
         }
 
-        if last_line.is_none() && inline_directives.is_empty() {
-            return None;
-        }
-
-        if last_line.is_none() {
+        let Some(mut last_line) = last_line else {
+            if inline_directives.is_empty() {
+                return None;
+            }
             return Some((
                 CommentBlock::new(line_number..line_number + 1, vec![]),
                 line_number,
                 inline_directives,
             ));
-        }
+        };
 
-        if line_number > last_line.unwrap() + 1 {
-            last_line = Some(line_number);
+        if line_number > last_line + 1 {
+            last_line = line_number;
             comment_block_with_spaces.push(b"".into());
         }
 
         Some((
             CommentBlock::new(lowest_line..line_number + 1, comment_block_with_spaces),
-            last_line.unwrap(),
+            last_line,
             inline_directives,
         ))
     }

--- a/librubyfmt/src/line_tokens.rs
+++ b/librubyfmt/src/line_tokens.rs
@@ -71,6 +71,9 @@ pub enum ConcreteLineToken<'src> {
     Comment {
         contents: Cow<'src, [u8]>,
     },
+    InlineComment {
+        contents: Cow<'src, [u8]>,
+    },
     Delim {
         contents: &'static [u8],
     },
@@ -122,6 +125,11 @@ impl<'src> ConcreteLineToken<'src> {
             Self::LTStringContent { content } => content,
             Self::SingleSlash => Cow::Borrowed(b"\\"),
             Self::Comment { contents } => contents,
+            Self::InlineComment { contents } => {
+                let mut result = b" ".to_vec();
+                result.extend_from_slice(&contents);
+                Cow::Owned(result)
+            }
             Self::Delim { contents } => Cow::Borrowed(contents),
             Self::End => Cow::Borrowed(b"end"),
             Self::HeredocClose { symbol } => Cow::Owned(symbol),
@@ -152,6 +160,7 @@ impl<'src> ConcreteLineToken<'src> {
             DirectPart { part } => part.len(),
             LTStringContent { content } => content.len(),
             Comment { contents } => contents.len(),
+            InlineComment { contents } => 1 + contents.len(),
             HeredocClose { symbol: contents } | RawHeredocContent { content: contents } => {
                 contents.len()
             }

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -74,6 +74,7 @@ pub struct ParserState<'src> {
     /// block. Used during call-chain element offset jumps, where a trailing-dot blank line in
     /// the source must not produce an invalid blank line before a leading-dot comment.
     suppress_blank_before_comment: bool,
+    pending_inline_comments: Vec<Vec<u8>>,
 }
 
 impl<'src> ParserState<'src> {
@@ -335,14 +336,19 @@ impl<'src> ParserState<'src> {
             be.push_line_number(line_number);
         }
 
-        if let Some((comments, last_comment_line)) = self.comments_hash.extract_comments_to_line(
-            self.current_orig_line_number,
-            line_number,
-            self.suppress_blank_before_comment,
-        ) {
-            self.push_comments(comments);
+        if let Some((comments, last_comment_line, inline_directives)) =
+            self.comments_hash.extract_comments_to_line_with_directives(
+                self.current_orig_line_number,
+                line_number,
+                self.suppress_blank_before_comment,
+            )
+        {
+            if comments.has_comments() {
+                self.push_comments(comments);
+            }
             self.current_orig_line_number =
                 std::cmp::max(self.current_orig_line_number, last_comment_line);
+            self.pending_inline_comments.extend(inline_directives);
         }
 
         debug!("lns: {} {}", line_number, self.current_orig_line_number);
@@ -415,6 +421,7 @@ impl<'src> ParserState<'src> {
 
     pub(crate) fn emit_newline(&mut self) {
         self.shift_comments();
+        self.flush_inline_comments();
         self.push_concrete_token(ConcreteLineToken::HardNewLine);
         self.render_heredocs(false);
         self.spaces_after_last_newline = self.current_spaces();
@@ -495,6 +502,14 @@ impl<'src> ParserState<'src> {
     pub(crate) fn shift_comments_at_index(&mut self, index: usize) {
         if let Some(new_comments) = self.comments_to_insert.take() {
             self.insert_concrete_tokens(index, new_comments.into_line_tokens());
+        }
+    }
+
+    fn flush_inline_comments(&mut self) {
+        for comment in std::mem::take(&mut self.pending_inline_comments) {
+            self.push_concrete_token(ConcreteLineToken::InlineComment {
+                contents: Cow::Owned(comment),
+            });
         }
     }
 
@@ -726,6 +741,7 @@ impl<'src> ParserState<'src> {
             scopes: vec![vec![]],
             inside_squiggly_heredoc: false,
             suppress_blank_before_comment: false,
+            pending_inline_comments: vec![],
         }
     }
 

--- a/librubyfmt/src/parser_state.rs
+++ b/librubyfmt/src/parser_state.rs
@@ -348,7 +348,20 @@ impl<'src> ParserState<'src> {
             }
             self.current_orig_line_number =
                 std::cmp::max(self.current_orig_line_number, last_comment_line);
-            self.pending_inline_comments.extend(inline_directives);
+            let inside_delimited_expr = self
+                .breakable_entry_stack
+                .last()
+                .is_some_and(|b| matches!(b, Breakable::DelimiterExpr(_)));
+            if inside_delimited_expr {
+                for directive in inline_directives {
+                    self.insert_comment_collection(CommentBlock::new(
+                        line_number..line_number + 1,
+                        vec![Cow::Owned(directive)],
+                    ));
+                }
+            } else {
+                self.pending_inline_comments.extend(inline_directives);
+            }
         }
 
         debug!("lns: {} {}", line_number, self.current_orig_line_number);


### PR DESCRIPTION
Closes #881

## Problem

Trailing linter directive comments were moved to their own line above the code, silently changing their semantics.

In RuboCop, placement determines scope ([docs](https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code)):
- **Trailing** `code # rubocop:disable Cop` → disables for **that line only** (via `DirectiveComment#single_line?`)
- **Standalone** `# rubocop:disable Cop` → disables **until matching `enable` or EOF**

rubyfmt was converting every trailing directive into a standalone one — silently widening the disable scope to the rest of the file. This is especially problematic for security-sensitive cops like `Rails/OutputSafety` and `Security/Eval`.

[→ See the bug on rubyfmt.run](https://rubyfmt.run/#Y2xhc3MgVXNlckNvbnRyb2xsZXIgPCBBcHBsaWNhdGlvbkNvbnRyb2xsZXIKICBkZWYgcHJvbW90ZQogICAgdXNlci51cGRhdGVfY29sdW1uKDpyb2xlLCAiYWRtaW4iKSAjIHJ1Ym9jb3A6ZGlzYWJsZSBSYWlscy9Ta2lwc01vZGVsVmFsaWRhdGlvbnMKICAgIHVzZXIudXBkYXRlX2NvbHVtbig6dmVyaWZpZWQsIHRydWUpCiAgZW5kCgogIGRlZiBzaG93CiAgICByZW5kZXIgaHRtbDogY29udGVudC5odG1sX3NhZmUgIyBydWJvY29wOmRpc2FibGUgUmFpbHMvT3V0cHV0U2FmZXR5CiAgZW5kCgogIGRlZiBoYXNfcm9sZT8obmFtZSkgIyBzdGFuZGFyZDpkaXNhYmxlIE5hbWluZy9QcmVkaWNhdGVNZXRob2QKICAgIHJvbGVzLmluY2x1ZGU/KG5hbWUpCiAgZW5kCgogIGRlZiBjb21wdXRlCiAgICByZXN1bHQgPSB1bnR5cGVkX21ldGhvZCAjIHN0ZWVwOmlnbm9yZQogICAgeCA9IDQyICMganVzdCBhIHJlZ3VsYXIgY29tbWVudAogIGVuZAplbmQ=)

## Solution

Detect known directive patterns and preserve them inline. Non-directive trailing comments continue to move above (rubyfmt's intended behavior).

**Before:**
```ruby
# rubocop:disable Rails/SkipsModelValidations  ← now file-scoped!
user.update_column(:role, "admin")
```

**After:**
```ruby
user.update_column(:role, "admin") # rubocop:disable Rails/SkipsModelValidations  ← line-scoped ✓
```

### Recognized patterns

`rubocop:disable/enable/todo/push/pop`, `standard:disable/enable`, `steep:ignore`, `:reek:`

## Implementation

The comment pipeline has three stages; this PR touches each one:

1. **Classification** (`file_comments.rs`): `is_inline_directive()` detects directive patterns. During comment extraction, directives on code lines are separated from regular comments. Also prevents trailing comments on code lines from entering the start-of-file comment sled.

2. **Token** (`line_tokens.rs`): New `InlineComment` variant renders as ` # contents` (space-prefixed, no trailing newline) — unlike `Comment` which always gets its own line.

3. **Emission** (`parser_state.rs`): Directives are buffered in `pending_inline_comments` and flushed before each `HardNewLine` in `emit_newline()`. Inside delimiter expressions (argument lists, arrays), directives fall back to the existing behavior (moved above) to avoid drifting to the closing bracket.

## Test plan

- [x] Added `fixtures/small/inline_directive_comments` covering: all 9 directive patterns, standalone vs trailing, mixed with regular comments, heredocs, multiline calls, conditionals, rescue, case/when, blocks, indented classes, constant assignments
- [x] Verified existing fixtures pass unchanged (including `paren_expr_calls`)
- [x] Verified idempotency
- [x] Full suite: 386 fixture + 46 CLI + 11 error + 3 stress tests
- [x] `cargo fmt` + `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)