### PR TITLE
[fix] Properly indent `case`/`in` statements

### DIFF
--- a/fixtures/small/prism/case_match_nested_actual.rb
+++ b/fixtures/small/prism/case_match_nested_actual.rb
@@ -1,0 +1,23 @@
+module App
+  config = {db: {user: 'admin', password: 'abc123'}}
+
+  case config
+  in {db: {user:}}
+    puts "Connect with user '#{user}'"
+  in {connection: {username: }}
+    puts "Connect with user '#{username}'"
+  else
+    puts "Unrecognized structure of config"
+  end
+end
+
+class Foo
+  def bar(value)
+    case value
+    in 1
+      "one"
+    in 2
+      "two"
+    end
+  end
+end

--- a/fixtures/small/prism/case_match_nested_expected.rb
+++ b/fixtures/small/prism/case_match_nested_expected.rb
@@ -1,0 +1,23 @@
+module App
+  config = {db: {user: "admin", password: "abc123"}}
+
+  case config
+  in {db: {user:}}
+    puts "Connect with user '#{user}'"
+  in {connection: {username:}}
+    puts "Connect with user '#{username}'"
+  else
+    puts "Unrecognized structure of config"
+  end
+end
+
+class Foo
+  def bar(value)
+    case value
+    in 1
+      "one"
+    in 2
+      "two"
+    end
+  end
+end

--- a/fixtures/small/prism/case_match_trailing_comments_actual.rb
+++ b/fixtures/small/prism/case_match_trailing_comments_actual.rb
@@ -1,0 +1,11 @@
+case 1
+in 2 # Two
+in 3 # Three
+end
+
+case value
+in :a # comment a
+  do_a
+in :b # comment b
+  do_b
+end

--- a/fixtures/small/prism/case_match_trailing_comments_expected.rb
+++ b/fixtures/small/prism/case_match_trailing_comments_expected.rb
@@ -1,0 +1,15 @@
+case 1
+# Two
+in 2
+  # Three
+in 3
+end
+
+case value
+# comment a
+in :a
+  do_a
+  # comment b
+in :b
+  do_b
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -588,6 +588,11 @@ fn format_case_match_node<'src>(
     ps.emit_newline();
     ps.with_start_of_line(true, |ps| {
         for condition in case_match_node.conditions().iter() {
+            // We keep start_of_line false and handle indentation here
+            // so that format_node's trailing emit_newline doesn't insert
+            // a blank line between consecutive `in` clauses.
+            ps.at_offset(condition.location().start_offset());
+            ps.emit_indent();
             ps.with_start_of_line(false, |ps| format_node(ps, condition));
         }
 


### PR DESCRIPTION
Closes #885
Closes #886

We format `in` nodes as `with_start_of_line(false, ...` since they generally handle their own newlines as part of formatting the branch bodies. However, we still need to properly indent them each time manually (since we're skipping the indentation bits in `format_node`) so they start at the right indentation level.