### PR TITLE
[fix] Render implicit nodes in hash rocket conversions

### DIFF
--- a/fixtures/small/hash_mixed_shorthand_and_rocket_actual.rb
+++ b/fixtures/small/hash_mixed_shorthand_and_rocket_actual.rb
@@ -1,0 +1,15 @@
+x = 1
+y = :key
+
+single_line = { x:, y => 2 }
+
+multi_line = {
+  x:,
+  y => 2
+}
+
+leading_rocket = { y => 2, x: }
+
+with_other_pairs = { a: 1, x:, y => 2 }
+
+with_splats = { x:, y => 2, **z}

--- a/fixtures/small/hash_mixed_shorthand_and_rocket_actual.rb
+++ b/fixtures/small/hash_mixed_shorthand_and_rocket_actual.rb
@@ -13,3 +13,5 @@ leading_rocket = { y => 2, x: }
 with_other_pairs = { a: 1, x:, y => 2 }
 
 with_splats = { x:, y => 2, **z}
+
+only_shorthands = {x:, y:}

--- a/fixtures/small/hash_mixed_shorthand_and_rocket_expected.rb
+++ b/fixtures/small/hash_mixed_shorthand_and_rocket_expected.rb
@@ -1,0 +1,15 @@
+x = 1
+y = :key
+
+single_line = {:x => x, y => 2}
+
+multi_line = {
+  :x => x,
+  y => 2
+}
+
+leading_rocket = {y => 2, :x => x}
+
+with_other_pairs = {:a => 1, :x => x, y => 2}
+
+with_splats = {:x => x, y => 2, **z}

--- a/fixtures/small/hash_mixed_shorthand_and_rocket_expected.rb
+++ b/fixtures/small/hash_mixed_shorthand_and_rocket_expected.rb
@@ -13,3 +13,5 @@ leading_rocket = {y => 2, :x => x}
 with_other_pairs = {:a => 1, :x => x, y => 2}
 
 with_splats = {:x => x, y => 2, **z}
+
+only_shorthands = {x:, y:}

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2686,9 +2686,11 @@ fn format_assoc_node<'src>(ps: &mut ParserState<'src>, assoc_node: prism::AssocN
 
         let value = assoc_node.value();
         if let Some(implicit) = value.as_implicit_node() {
-            // A mixed hash forces hash rocket form, so we have to expand the
-            // shorthand `x:` into the equivalent `:x => x` rather than
-            // emitting nothing for the implicit value.
+            // If there's an implicit node here, that means we're in a hash shorthand
+            // mixed with hash rockets, e.g. `{ key:, bar => baz }`.
+            // If `as_symbol` is false, we're forcing conversions to hash rockets,
+            // but in this case we've already rendered the `key =>` and have to re-render the
+            // key as the value so that `key:` transforms into syntactically-valid `:key => key`
             if !as_symbol {
                 ps.emit_space();
                 format_node(ps, implicit.value());

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2683,11 +2683,20 @@ fn format_assoc_node<'src>(ps: &mut ParserState<'src>, assoc_node: prism::AssocN
             ps.emit_space();
             ps.emit_ident(b"=>");
         }
-        // For assoc nodes, skip the space so it renders as `{ a:, b:, c: }`
-        if assoc_node.value().as_implicit_node().is_none() {
+
+        let value = assoc_node.value();
+        if let Some(implicit) = value.as_implicit_node() {
+            // A mixed hash forces hash rocket form, so we have to expand the
+            // shorthand `x:` into the equivalent `:x => x` rather than
+            // emitting nothing for the implicit value.
+            if !as_symbol {
+                ps.emit_space();
+                format_node(ps, implicit.value());
+            }
+        } else {
             ps.emit_space();
+            format_node(ps, value);
         }
-        format_node(ps, assoc_node.value());
     });
 }
 


### PR DESCRIPTION
Closes #884 

For hashes that use the hash rocket syntax, the general style is to try and make all the keys match, so if any key uses hash rockets, all the keys will be converted to hash rockets for uniformity. In the case of implicit nodes, there's no AST node for the value, so when they're mixed with hash rockets (e.g. `{ foo:, bar => baz }`) we need to also re-render the value for that key after the rocket.