### PR TITLE
[fix] Dedup parens for capitalized calls with only block args

### DIFF
--- a/fixtures/small/constant_path_callers_actual.rb
+++ b/fixtures/small/constant_path_callers_actual.rb
@@ -24,3 +24,10 @@ Test.Case() { }
 Test.Case() do; end
 Test.Case(args) { }
 Test.Case(args) do ;end
+
+Case(&blk)
+Case(args, &blk)
+Test::Case(&blk)
+Test::Case(args, &blk)
+Test.Case(&blk)
+Test.Case(args, &blk)

--- a/fixtures/small/constant_path_callers_expected.rb
+++ b/fixtures/small/constant_path_callers_expected.rb
@@ -35,3 +35,10 @@ end
 Test.Case(args) { }
 Test.Case(args) do
 end
+
+Case(&blk)
+Case(args, &blk)
+Test::Case(&blk)
+Test::Case(args, &blk)
+Test.Case(&blk)
+Test.Case(args, &blk)

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1708,6 +1708,16 @@ fn use_parens_for_call_node<'src>(
     });
 
     if is_terminal_call && method_name.first().is_some_and(|c| c.is_ascii_uppercase()) {
+        // The block-argument render path emits its own parens around `(&blk)`, so we can skip them
+        // if they're the only arg
+        let has_block_arg_only = !has_arguments
+            && call_node
+                .block()
+                .and_then(|b| b.as_block_argument_node())
+                .is_some();
+        if has_block_arg_only {
+            return false;
+        }
         if !has_arguments && call_node.block().is_some() && call_node.receiver().is_none() {
             return false;
         }


### PR DESCRIPTION
Closes #890
(and fixing something introduced in #870)

On the tin -- block arguments in Prism are confusingly separate from the rest of the argument list, so we also need to handle cases where they're the only caller. Lone block args [have their own paren handling](https://github.com/fables-tales/rubyfmt/blob/3310e525448511cd02045bc2fd05feaa0ecbdbee/librubyfmt/src/format_prism.rs#L2036-L2045), so we should "elide" them in `use_parens_for_call_node` so that they're not rendered twice.