### PR TITLE
[fix] Properly multiline multi-statement blocks in string embexprs

### DIFF
--- a/fixtures/small/multi_statement_brace_block_in_embexpr_actual.rb
+++ b/fixtures/small/multi_statement_brace_block_in_embexpr_actual.rb
@@ -1,0 +1,32 @@
+"value: #{proc { a; b }.call}"
+
+"value: #{-> { a; b }.call}"
+
+"value: #{lambda { a; b }.call}"
+
+"value: #{foo { a; b }.call}"
+
+"value: #{proc { a; b; c }.call}"
+
+class Foo
+  def bar
+    "value: #{proc { a; b }.call}"
+  end
+
+  def baz
+    if condition
+      "nested: #{lambda { x; y; z }.call}"
+    end
+  end
+end
+
+"value: #{proc {
+  a # first
+  b # second
+}.call}"
+
+"value: #{proc {
+  # leading comment
+  a
+  b
+}.call}"

--- a/fixtures/small/multi_statement_brace_block_in_embexpr_expected.rb
+++ b/fixtures/small/multi_statement_brace_block_in_embexpr_expected.rb
@@ -1,0 +1,57 @@
+"value: #{proc {
+  a
+  b
+}.call}"
+
+"value: #{-> {
+  a
+  b
+}.call}"
+
+"value: #{lambda {
+  a
+  b
+}.call}"
+
+"value: #{foo {
+  a
+  b
+}.call}"
+
+"value: #{proc {
+  a
+  b
+  c
+}.call}"
+
+class Foo
+  def bar
+    "value: #{proc {
+      a
+      b
+    }.call}"
+  end
+
+  def baz
+    if condition
+      "nested: #{lambda {
+        x
+        y
+        z
+      }.call}"
+    end
+  end
+end
+
+"value: #{proc {
+  # first
+  a
+  # second
+  b
+}.call}"
+
+"value: #{proc {
+  # leading comment
+  a
+  b
+}.call}"

--- a/librubyfmt/src/render_queue_writer.rs
+++ b/librubyfmt/src/render_queue_writer.rs
@@ -198,9 +198,12 @@ impl<'src> RenderQueueWriter<'src> {
     fn format_breakable_entry(accum: &mut Intermediary<'src>, be: BreakableEntry<'src>) {
         // We generally will force expressions embedded in strings to be on a single line,
         // but if that expression has a heredoc nested in it, we should let it render across lines
-        // so that the collapsing newlines render properly.
-        let force_single_line =
-            !be.any_collapsing_newline_has_heredoc_content() && be.in_string_embexpr();
+        // so that the collapsing newlines render properly. Similarly, if the entry already
+        // contains hard newlines (e.g. a multi-statement brace block), forcing single-line
+        // would leave dangling newlines and squash statements together.
+        let force_single_line = be.in_string_embexpr()
+            && !be.any_collapsing_newline_has_heredoc_content()
+            && !be.contains_hard_newline();
 
         let mut tokens = Vec::new();
         if !force_single_line

--- a/librubyfmt/src/render_targets.rs
+++ b/librubyfmt/src/render_targets.rs
@@ -185,7 +185,7 @@ impl<'src> BreakableEntry<'src> {
         self.in_string_embexpr
     }
 
-    fn contains_hard_newline(&self) -> bool {
+    pub fn contains_hard_newline(&self) -> bool {
         self.tokens.iter().any(tokens_contain_hard_newline)
     }
 


### PR DESCRIPTION
Closes #877 

Normally, we force breakables onto a single line when they're inside of string embexprs. However, doing that for multi-statement blocks renders invalid Ruby, so we need to make sure they stay multilined.