### PR TITLE
[fix] Keep parens on `raise` calls with arg forwarding

### DIFF
--- a/fixtures/small/raise_args_forwarding_actual.rb
+++ b/fixtures/small/raise_args_forwarding_actual.rb
@@ -1,0 +1,11 @@
+def a(...) = raise(...)
+
+def b(...) = raise(self, ...)
+
+def c(...)
+  raise(ArgumentError, ...)
+end
+
+class Error < StandardError
+  def self.call(...) = raise(self, ...)
+end

--- a/fixtures/small/raise_args_forwarding_expected.rb
+++ b/fixtures/small/raise_args_forwarding_expected.rb
@@ -1,0 +1,11 @@
+def a(...) = raise(...)
+
+def b(...) = raise(self, ...)
+
+def c(...)
+  raise(ArgumentError, ...)
+end
+
+class Error < StandardError
+  def self.call(...) = raise(self, ...)
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1745,10 +1745,9 @@ fn use_parens_for_call_node<'src>(
         }
 
         if let Some(arguments) = call_node.arguments()
-            && arguments
-                .arguments()
-                .iter()
-                .any(|arg| arg.as_splat_node().is_some())
+            && arguments.arguments().iter().any(|arg| {
+                arg.as_splat_node().is_some() || arg.as_forwarding_arguments_node().is_some()
+            })
         {
             return true;
         }


### PR DESCRIPTION
Closes #899 

We generally strip parens from `raise`, but there are exceptions where this produces invalid syntax. We already handle this exception for splats, but we also need to do it for the arg forwarding `...` syntax, since arg forwarding without parens is invalid.