### PR TITLE
Remove debug symbols from release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,3 @@ harness = false
 [[bench]]
 name = "formatting"
 harness = false
-
-[profile.release]
-debug = true


### PR DESCRIPTION
On the tin. I don't recall why this was added in #731, since it's not like the benchmarking job requires debug symbols, and we don't do anything like emit backtraces in release builds which would otherwise require debug symbols, so at the moment all this does is make Linux binaries about 4x larger than they otherwise should be.

Removing this should get the Linux release artifacts from 17-20MB down to something closer to what the Mac binaries are, which is about 5MB.