### PR TITLE
[fix] Render comments for word arrays outside of breakables

### DIFF
--- a/fixtures/small/word_array_trailing_comment_actual.rb
+++ b/fixtures/small/word_array_trailing_comment_actual.rb
@@ -1,0 +1,21 @@
+a = %w[
+  b
+] #c
+
+d = %w[
+  e
+  f
+] # trailing
+
+g = %i[
+  h
+  i
+] # symbol trailing
+
+j = %W[
+  k
+] # cap-W trailing
+
+l = %I[
+  m
+] # cap-I trailing

--- a/fixtures/small/word_array_trailing_comment_actual.rb
+++ b/fixtures/small/word_array_trailing_comment_actual.rb
@@ -9,6 +9,7 @@ d = %w[
 
 g = %i[
   h
+  # this looks like a comment but isn't
   i
 ] # symbol trailing
 

--- a/fixtures/small/word_array_trailing_comment_expected.rb
+++ b/fixtures/small/word_array_trailing_comment_expected.rb
@@ -1,0 +1,26 @@
+#c
+a = %w[
+  b
+]
+
+# trailing
+d = %w[
+  e
+  f
+]
+
+# symbol trailing
+g = %i[
+  h
+  i
+]
+
+# cap-W trailing
+j = %W[
+  k
+]
+
+# cap-I trailing
+l = %I[
+  m
+]

--- a/fixtures/small/word_array_trailing_comment_expected.rb
+++ b/fixtures/small/word_array_trailing_comment_expected.rb
@@ -12,6 +12,14 @@ d = %w[
 # symbol trailing
 g = %i[
   h
+  #
+  this
+  looks
+  like
+  a
+  comment
+  but
+  isn't
   i
 ]
 

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -2943,9 +2943,11 @@ fn format_array_node<'src>(ps: &mut ParserState<'src>, array_node: prism::ArrayN
                     array_node.location().end_offset(),
                     orig_delim,
                 );
-                ps.wind_dumping_comments_until_offset(array_node.location().end_offset());
             });
         });
+        // Wind outside the breakable so that a comment on the same line as the
+        // closing bracket shifts above the array instead of being absorbed into its body.
+        ps.wind_dumping_comments_until_offset(array_node.location().end_offset());
     } else {
         ps.with_start_of_line(false, |ps| {
             if array_node.opening_loc().is_none() {


### PR DESCRIPTION
Closes #905 

We previously called `wind_dumping_comments_until_offset` inside the breakable for word arrays, but this would render trailing comments inside the array itself, which changes the runtime behavior. Instead, we should call `wind_dumping_comments_until_offset` _after_ the breakable so that trailing comments go above the _entire_ array, which won't modify the contents of that array.