### PR TITLE
Simplifies installation into vim with a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,20 @@ See the [null-ls documentation](https://github.com/jose-elias-alvarez/null-ls.nv
 
 ### Vim
 
-1. Run `cargo build --release`
-2. Add `source /path/to/rubyfmt.vim` to your `~/.vimrc`
-3. Add `let g:rubyfmt_path = /path/to/target/release/rubyfmt-main` beneath the source line
+vim-plug:
+
+```vim
+Plug 'fables-tales/rubyfmt', { 'rtp': 'editor_plugins/vim' }
+```
+
+Native packages:
+
+```sh
+git clone https://github.com/fables-tales/rubyfmt ~/.rubyfmt
+ln -s ~/.rubyfmt/editor_plugins/vim ~/.vim/pack/rubyfmt/start/rubyfmt
+```
+
+Set `g:rubyfmt_path` if `rubyfmt` is not on your `$PATH`.
 
 ### RubyMine (and JetBrains IDEs)
 

--- a/editor_plugins/vim/autoload/rubyfmt.vim
+++ b/editor_plugins/vim/autoload/rubyfmt.vim
@@ -1,8 +1,6 @@
 let s:cpo_save = &cpo
 set cpo&vim
 
-let g:rubyfmt_path = '/Users/penelope/dev/rubyfmt/target/release/rubyfmt-main'
-
 function! rubyfmt#format() abort
   let l:bin_args = [g:rubyfmt_path, '-i']
   let l:curw = winsaveview()
@@ -68,11 +66,6 @@ endfunction
 function! rubyfmt#show_errors(errors) abort
   echom a:errors
 endfunction
-
-if !exists("s:rubyfmt_ac_set")
-  let s:rubyfmt_ac_set=1
-  autocmd FileType ruby autocmd! BufWritePre <buffer> call rubyfmt#format()
-endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/editor_plugins/vim/plugin/rubyfmt.vim
+++ b/editor_plugins/vim/plugin/rubyfmt.vim
@@ -1,0 +1,21 @@
+if exists('g:loaded_rubyfmt')
+  finish
+endif
+let g:loaded_rubyfmt = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" Path to the rubyfmt binary. Defaults to whatever is on $PATH; override in
+" your vimrc, e.g. let g:rubyfmt_path = '/path/to/target/release/rubyfmt-main'
+if !exists('g:rubyfmt_path')
+  let g:rubyfmt_path = 'rubyfmt'
+endif
+
+if !exists("s:rubyfmt_ac_set")
+  let s:rubyfmt_ac_set=1
+  autocmd FileType ruby autocmd! BufWritePre <buffer> call rubyfmt#format()
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
Hi there! 

I've tweaked the vim integration a small amount just to allow it to be installed from the git repo instead of needing to clone locally. I've updated the readme instructions as well. Now, pointing this at my fork, I'm able to install the rubyfmt vim extension without manually sourcing the config and overriding the path. 

I'm able to:

- `brew install rubyfmt`
- and add this to my vim-plugin list: `Plug 'robacarp/rubyfmt', { 'rtp': 'editor_plugins/vim', 'branch': 'vim-plugin' }`

And I have a working configuration. Hopefully this contribution is welcome, I believe it'll make using the tool much easier for vim-natives. 