### PR TITLE
[fix] Handle inline comments after `rescue \`

### DIFF
--- a/fixtures/small/rescue_inline_comment_actual.rb
+++ b/fixtures/small/rescue_inline_comment_actual.rb
@@ -1,0 +1,19 @@
+begin
+rescue Foo # comment
+end
+
+begin
+rescue Foo,
+       Bar # comment
+end
+
+begin
+rescue \
+    Foo # comment
+end
+
+begin
+rescue \
+    Foo,
+    Bar # comment
+end

--- a/fixtures/small/rescue_inline_comment_expected.rb
+++ b/fixtures/small/rescue_inline_comment_expected.rb
@@ -1,0 +1,21 @@
+begin
+  # comment
+rescue Foo
+end
+
+begin
+rescue Foo,
+  # comment
+  Bar
+end
+
+begin
+  # comment
+rescue Foo
+end
+
+begin
+rescue Foo,
+  # comment
+  Bar
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4728,6 +4728,7 @@ fn format_rescue_node<'src>(ps: &mut ParserState<'src>, rescue_node: prism::Resc
     let exceptions = rescue_node.exceptions();
     let reference = rescue_node.reference();
     if !exceptions.is_empty() {
+        // Preemptively extract inline comments so they land before rescue, not inside the breakable.
         ps.at_offset(exceptions.first().unwrap().location().start_offset());
         ps.with_start_of_line(false, |ps| {
             ps.inline_breakable_of(BreakableDelims::for_binary_op(), |ps| {

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4728,6 +4728,7 @@ fn format_rescue_node<'src>(ps: &mut ParserState<'src>, rescue_node: prism::Resc
     let exceptions = rescue_node.exceptions();
     let reference = rescue_node.reference();
     if !exceptions.is_empty() {
+        ps.at_offset(exceptions.iter().next().unwrap().location().start_offset());
         ps.with_start_of_line(false, |ps| {
             ps.inline_breakable_of(BreakableDelims::for_binary_op(), |ps| {
                 let exceptions_count = exceptions.len();

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -4728,7 +4728,7 @@ fn format_rescue_node<'src>(ps: &mut ParserState<'src>, rescue_node: prism::Resc
     let exceptions = rescue_node.exceptions();
     let reference = rescue_node.reference();
     if !exceptions.is_empty() {
-        ps.at_offset(exceptions.iter().next().unwrap().location().start_offset());
+        ps.at_offset(exceptions.first().unwrap().location().start_offset());
         ps.with_start_of_line(false, |ps| {
             ps.inline_breakable_of(BreakableDelims::for_binary_op(), |ps| {
                 let exceptions_count = exceptions.len();


### PR DESCRIPTION
Attempt at closing #911