### PR TITLE
chore: improve rubyfmt maintenance path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -456,3 +456,72 @@ fn main() {
         }),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::parse_magic_comment;
+
+    #[test]
+    fn parse_magic_comment_true() {
+        assert_eq!(parse_magic_comment("# rubyfmt: true"), Some("true"));
+    }
+
+    #[test]
+    fn parse_magic_comment_false() {
+        assert_eq!(parse_magic_comment("# rubyfmt: false"), Some("false"));
+    }
+
+    #[test]
+    fn parse_magic_comment_no_spaces() {
+        assert_eq!(parse_magic_comment("#rubyfmt:true"), Some("true"));
+        assert_eq!(parse_magic_comment("#rubyfmt:false"), Some("false"));
+    }
+
+    #[test]
+    fn parse_magic_comment_extra_whitespace() {
+        assert_eq!(parse_magic_comment("#   rubyfmt:   true  "), Some("true"));
+        assert_eq!(parse_magic_comment("# \t rubyfmt: \t false \t"), Some("false"));
+    }
+
+    #[test]
+    fn parse_magic_comment_ignores_invalid_value() {
+        assert_eq!(parse_magic_comment("# rubyfmt: maybe"), None);
+        assert_eq!(parse_magic_comment("# rubyfmt: 1"), None);
+    }
+
+    #[test]
+    fn parse_magic_comment_ignores_non_comment_lines() {
+        assert_eq!(parse_magic_comment("a 1,2,3\n# rubyfmt: true"), Some("true"));
+    }
+
+    #[test]
+    fn parse_magic_comment_returns_first_match() {
+        assert_eq!(
+            parse_magic_comment("# rubyfmt: true\n# rubyfmt: false"),
+            Some("true")
+        );
+        assert_eq!(
+            parse_magic_comment("# rubyfmt: false\n# rubyfmt: true"),
+            Some("false")
+        );
+    }
+
+    #[test]
+    fn parse_magic_comment_ignores_double_hash() {
+        assert_eq!(parse_magic_comment("## rubyfmt: true"), None);
+    }
+
+    #[test]
+    fn parse_magic_comment_requires_exact_value() {
+        assert_eq!(parse_magic_comment("# rubyfmt: truefalse"), None);
+        assert_eq!(parse_magic_comment("# rubyfmt: truely"), None);
+        assert_eq!(parse_magic_comment("# rubyfmt: falsehood"), None);
+    }
+
+    #[test]
+    fn parse_magic_comment_empty_and_no_header() {
+        assert_eq!(parse_magic_comment(""), None);
+        assert_eq!(parse_magic_comment("a 1,2,3"), None);
+        assert_eq!(parse_magic_comment("# some other comment"), None);
+    }
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -13,6 +13,7 @@ macro_rules! fixture {
 }
 
 pub fn test_fixture(name: &str) {
+    assert!(!name.is_empty(), "fixture name must not be empty");
     let expected = read_to_string(format!("fixtures/{}_expected.rb", name)).unwrap();
 
     // Test if the formatting works as expected


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in src/main.rs, tests/common.rs related to runtime safety, error handling, performance, tests; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.