### PR TITLE
[fix] Emit `at_offset` for anonymous block args

### DIFF
--- a/fixtures/small/anonymous_blockarg_actual.rb
+++ b/fixtures/small/anonymous_blockarg_actual.rb
@@ -1,3 +1,25 @@
 def foo(a, b, &)
   bar a, b, &
 end
+
+def foo(
+  a,
+  &
+)
+  bar(
+    a,
+  &)
+end
+
+def foo(
+  a,
+  *b,
+  &
+)
+bar(
+    a,
+    b,
+    &
+  )
+end
+

--- a/fixtures/small/anonymous_blockarg_expected.rb
+++ b/fixtures/small/anonymous_blockarg_expected.rb
@@ -1,3 +1,25 @@
 def foo(a, b, &)
   bar(a, b, &)
 end
+
+def foo(
+  a,
+  &
+)
+  bar(
+    a,
+    &
+  )
+end
+
+def foo(
+  a,
+  *b,
+  &
+)
+  bar(
+    a,
+    b,
+    &
+  )
+end

--- a/librubyfmt/src/format_prism.rs
+++ b/librubyfmt/src/format_prism.rs
@@ -1639,6 +1639,8 @@ fn format_block_parameter_node<'src>(
             let ident_str = ident.as_slice();
             ps.bind_variable(ident_str);
             handle_string_at_offset(ps, ident_str, block_arg.name_loc().unwrap().end_offset());
+        } else {
+            ps.at_offset(block_arg.location().start_offset());
         }
     });
 }


### PR DESCRIPTION
Closes #942 

On the tin -- for anonymous block args, we need to ensure we wind forward the line number correctly. We do this properly for named args, but we need to also update the line number when `block_arg.name()` is None.