### PR TITLE
respect .rubyfmtignore with multiple roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,9 +433,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
 ctrlc = { version = "3.2", features = ["termination"] }
-ignore = "0.4.18"
+ignore = "0.4.26"
 rubyfmt = { path = "./librubyfmt" }
 similar = { version = "2.7.0", features = ["bytes"] }
 

--- a/tests/cli_interface_test.rs
+++ b/tests/cli_interface_test.rs
@@ -729,6 +729,34 @@ fn test_respects_rubyfmtignore() {
 }
 
 #[test]
+fn test_respects_rubyfmtignore_with_multiple_directory_arguments() {
+    for arguments in [["app", "db"], ["db", "app"]] {
+        let dir = tempdir().unwrap();
+        create_dir(dir.path().join("app")).unwrap();
+        create_dir(dir.path().join("db")).unwrap();
+
+        let app_file = dir.path().join("app/application.rb");
+        let schema_file = dir.path().join("db/schema.rb");
+        fs::write(&app_file, "a 1, 2, 3\n").unwrap();
+        fs::write(&schema_file, "a 4, 5, 6\n").unwrap();
+        fs::write(dir.path().join(".rubyfmtignore"), "db/schema.rb\n").unwrap();
+
+        Command::cargo_bin("rubyfmt-main")
+            .unwrap()
+            .current_dir(dir.path())
+            .arg("-i")
+            .args(arguments)
+            .assert()
+            .stdout("")
+            .code(0)
+            .success();
+
+        assert_eq!("a(1, 2, 3)\n", read_to_string(app_file).unwrap());
+        assert_eq!("a 4, 5, 6\n", read_to_string(schema_file).unwrap());
+    }
+}
+
+#[test]
 fn test_respects_gitignore() {
     let dir = tempdir().unwrap();
     // Fake a git repo


### PR DESCRIPTION
* Resolves existing multi-root walk bug in `ignore` crate by bumping to patched version
  * **Issue:** https://github.com/BurntSushi/ripgrep/issues/3419
  * **Merged PR (fixed in 0.4.26):** https://github.com/BurntSushi/ripgrep/pull/3420
* Adds regression test for `rubyfmt` multi-root behavior